### PR TITLE
fix: webpack.config.js LoggerPlugin file path

### DIFF
--- a/templates/webpack.config.js
+++ b/templates/webpack.config.js
@@ -260,7 +260,7 @@ module.exports = {
          * Uncomment for having logs stored in a file to this specific compilation.
          * Compilation for each platform gets it's own log file.
          */
-        // file: path.join(__dirname, '${build}.${platform}.log`),
+        // file: path.join(__dirname, `${mode}.${platform}.log`),
       },
     }),
   ],


### PR DESCRIPTION
### Summary

there was a syntax error beside I think mode is what I was searching for. outputs will be like `production.ios.log` and `development.ios.log`