### PR TITLE
fix: Use fastify-reply-from plugin to ensure headers are not lost when proxying

### DIFF
--- a/packages/repack/package.json
+++ b/packages/repack/package.json
@@ -63,6 +63,7 @@
     "fastify": "^3.12.0",
     "fastify-express": "^0.3.2",
     "fastify-graceful-shutdown": "^3.1.0",
+    "fastify-reply-from": "^6.0.1",
     "fastify-static": "^4.0.1",
     "fs-extra": "^10.0.0",
     "get-port": "^5.1.1",


### PR DESCRIPTION
### Summary

**Background:** I encountered issues while trying to incorporate an imported mp4 into my react-native application using `react-native-video`. After investigation, I found that the video was unable to play due to missing headers (specifically, range headers). I found that the headers are correctly set by webpack-dev-server, but are then lost when proxying through repack.

**Description:** This pull request makes updates to the repack DevServerProxy module, choosing to use `fastify-reply-from` as a more robust mechanism to forward requests to the underlying webpack-dev-server.

**Alternatives:** The proxying logic could have been added inline rather than pulling in a 3rd party module, but using a more robust implementation seemed like a smaller burden in both upfront cost and continued maintenance.

### Test plan

I did not have a clear/easy path for testing this change directly within `repack` due to the current state of testing infra.
* I would have been happy to add a unit/integration test had there been a bit more scaffolding in place.
* Introducing a dependency like react-native-video into the e2e test seemed heavy-handed.

In a world where I had more time, I would have probably tried to add a light integration/unit test within repack that confirmed headers weren't dropped.

So the current state of testing is that I have confirmed this fixes my issue by manually copying the build output into the repack install within my project's node_modules.

I'd prefer not to spend too much more time on this issue, but happy to iterate if you see low-hanging fruit for increasing test coverage and/or building confidence in the PR.