### PR TITLE
fix: use per-platform directories in OutputPlugin and improve error messages for chunk loading 

### DIFF
--- a/packages/TesterApp/webpack.config.js
+++ b/packages/TesterApp/webpack.config.js
@@ -200,6 +200,7 @@ module.exports = {
      * In development mode (when development server is running), this plugin is a no-op.
      */
     new ReactNative.OutputPlugin({
+      platform,
       devServerEnabled: devServer.enabled,
       localChunks: [/Async/],
       remoteChunksOutput: path.join(__dirname, 'build', platform, 'remote'),

--- a/packages/repack/src/client/chunks-api/ChunkManager.ts
+++ b/packages/repack/src/client/chunks-api/ChunkManager.ts
@@ -2,6 +2,7 @@
 
 // @ts-ignore
 import { NativeModules } from 'react-native';
+import { LoadEvent } from '../shared/LoadEvent';
 
 const CACHE_KEY = `Repack.ChunkManager.Cache.${__DEV__ ? 'debug' : 'release'}`;
 
@@ -94,8 +95,17 @@ class ChunkManager {
   }
 
   async loadChunk(chunkId: string) {
+    let url;
+    let fetch;
     try {
-      const { url, fetch } = await this.resolveChunk(chunkId);
+      const resolved = await this.resolveChunk(chunkId);
+      url = resolved.url;
+      fetch = resolved.fetch;
+    } catch (error) {
+      throw new LoadEvent('resolution', chunkId, error);
+    }
+
+    try {
       await NativeModules.ChunkManager.loadChunk(chunkId, url, fetch);
     } catch (error) {
       console.error(
@@ -103,13 +113,22 @@ class ChunkManager {
         error.message,
         error.code ? `[${error.code}]` : ''
       );
-      throw error;
+      throw new LoadEvent('load', url, error);
     }
   }
 
   async preloadChunk(chunkId: string) {
+    let url;
+    let fetch;
     try {
-      const { url, fetch } = await this.resolveChunk(chunkId);
+      const resolved = await this.resolveChunk(chunkId);
+      url = resolved.url;
+      fetch = resolved.fetch;
+    } catch (error) {
+      throw new LoadEvent('resolution', chunkId, error);
+    }
+
+    try {
       await NativeModules.ChunkManager.preloadChunk(chunkId, url, fetch);
     } catch (error) {
       console.error(
@@ -117,7 +136,7 @@ class ChunkManager {
         error.message,
         error.code ? `[${error.code}]` : ''
       );
-      throw error;
+      throw new LoadEvent('load', url, error);
     }
   }
 

--- a/packages/repack/src/client/runtime/setupChunkLoader.ts
+++ b/packages/repack/src/client/runtime/setupChunkLoader.ts
@@ -2,15 +2,8 @@
 /* globals __webpack_require__ __DEV__ */
 
 import { ChunkManager } from '../chunks-api';
+import { LoadEvent } from '../shared/LoadEvent';
 import { getDevServerLocation } from './getDevServerLocation';
-
-class LoadEvent {
-  target: { src: string };
-
-  constructor(public type: string, src: string) {
-    this.target = { src };
-  }
-}
 
 type LoadCallback = (event?: LoadEvent) => void;
 
@@ -33,7 +26,7 @@ async function loadHmrUpdate(url: string, cb: LoadCallback) {
       cb();
     } catch (error) {
       console.error('Loading HMR update chunk failed:', error);
-      cb(new LoadEvent('exec', url));
+      cb(new LoadEvent('exec', url, error));
     }
   }
 }
@@ -46,7 +39,7 @@ async function loadAsyncChunk(
   try {
     await ChunkManager.loadChunk(chunkId.toString());
   } catch (error) {
-    cb(new LoadEvent('load', url));
+    cb(error);
   }
 }
 

--- a/packages/repack/src/client/shared/LoadEvent.ts
+++ b/packages/repack/src/client/shared/LoadEvent.ts
@@ -1,0 +1,7 @@
+export class LoadEvent {
+  target: { src: string };
+
+  constructor(public type: string, src: string, public error?: Error | any) {
+    this.target = { src };
+  }
+}

--- a/packages/repack/src/webpack/plugins/OutputPlugin.ts
+++ b/packages/repack/src/webpack/plugins/OutputPlugin.ts
@@ -8,6 +8,8 @@ import { AssetsCopyProcessor } from './utils/AssetsCopyProcessor';
  * {@link OutputPlugin} configuration options.
  */
 export interface OutputPluginConfig {
+  /** Target application platform. */
+  platform: string;
   /** Whether the development server is enabled and running. */
   devServerEnabled?: boolean;
   /**
@@ -36,7 +38,11 @@ export class OutputPlugin implements WebpackPlugin {
    *
    * @param config Plugin configuration options.
    */
-  constructor(private config: OutputPluginConfig) {}
+  constructor(private config: OutputPluginConfig) {
+    if (!this.config.platform) {
+      throw new Error('Missing `platform` option in `OutputPlugin`');
+    }
+  }
 
   /**
    * Apply the plugin.
@@ -174,6 +180,7 @@ export class OutputPlugin implements WebpackPlugin {
       }
 
       const localAssetsCopyProcessor = new AssetsCopyProcessor({
+        platform: this.config.platform,
         compilation,
         outputPath,
         bundleOutput,
@@ -183,6 +190,7 @@ export class OutputPlugin implements WebpackPlugin {
         logger,
       });
       const remoteAssetsCopyProcessor = new AssetsCopyProcessor({
+        platform: this.config.platform,
         compilation,
         outputPath,
         bundleOutput: '',

--- a/packages/repack/src/webpack/plugins/OutputPlugin.ts
+++ b/packages/repack/src/webpack/plugins/OutputPlugin.ts
@@ -1,8 +1,8 @@
 import path from 'path';
-import fs from 'fs-extra';
 import webpack from 'webpack';
 import { CLI_OPTIONS_ENV_KEY } from '../../env';
-import { CliOptions, Rule, WebpackLogger, WebpackPlugin } from '../../types';
+import { CliOptions, Rule, WebpackPlugin } from '../../types';
+import { AssetsCopyProcessor } from './utils/AssetsCopyProcessor';
 
 /**
  * {@link OutputPlugin} configuration options.
@@ -64,6 +64,7 @@ export class OutputPlugin implements WebpackPlugin {
     if (!path.isAbsolute(bundleOutput)) {
       bundleOutput = path.join(cliOptions.config.root, bundleOutput);
     }
+    const bundleOutputDir = path.dirname(bundleOutput);
 
     if (!sourcemapOutput) {
       sourcemapOutput = `${bundleOutput}.map`;
@@ -73,7 +74,7 @@ export class OutputPlugin implements WebpackPlugin {
     }
 
     if (!assetsDest) {
-      assetsDest = path.dirname(bundleOutput);
+      assetsDest = bundleOutputDir;
     }
 
     let remoteChunksOutput = this.config.remoteChunksOutput;
@@ -172,156 +173,42 @@ export class OutputPlugin implements WebpackPlugin {
         throw new Error('Cannot infer output path from compilation');
       }
 
-      const promises: Promise<void>[] = [];
+      const localAssetsCopyProcessor = new AssetsCopyProcessor({
+        compilation,
+        outputPath,
+        bundleOutput,
+        bundleOutputDir,
+        sourcemapOutput,
+        assetsDest,
+        logger,
+      });
+      const remoteAssetsCopyProcessor = new AssetsCopyProcessor({
+        compilation,
+        outputPath,
+        bundleOutput: '',
+        bundleOutputDir: remoteChunksOutput ?? '',
+        sourcemapOutput: '',
+        assetsDest: remoteChunksOutput ?? '',
+        logger,
+      });
 
       for (const chunk of localChunks) {
         // Process entry chunk
-        if (entryGroup?.chunks[0] === chunk) {
-          promises.push(
-            ...this.processEntryChunkFiles(
-              compilation,
-              chunk,
-              outputPath,
-              bundleOutput,
-              sourcemapOutput,
-              logger
-            )
-          );
-        } else {
-          promises.push(
-            ...this.processChunkFiles(
-              compilation,
-              chunk,
-              outputPath,
-              assetsDest,
-              logger
-            )
-          );
-        }
-
-        promises.push(
-          ...this.processChunkAuxiliaryFiles(
-            chunk,
-            outputPath,
-            assetsDest,
-            logger
-          )
-        );
+        localAssetsCopyProcessor.enqueueChunk(chunk, {
+          isEntry: entryGroup?.chunks[0] === chunk,
+        });
       }
 
       if (remoteChunksOutput) {
         for (const chunk of remoteChunks) {
-          promises.push(
-            ...this.processChunkFiles(
-              compilation,
-              chunk,
-              outputPath,
-              remoteChunksOutput,
-              logger
-            )
-          );
-
-          promises.push(
-            ...this.processChunkAuxiliaryFiles(
-              chunk,
-              outputPath,
-              remoteChunksOutput,
-              logger
-            )
-          );
+          remoteAssetsCopyProcessor.enqueueChunk(chunk, { isEntry: false });
         }
       }
 
-      await Promise.all(promises);
+      await Promise.all([
+        ...localAssetsCopyProcessor.execute(),
+        ...remoteAssetsCopyProcessor.execute(),
+      ]);
     });
-  }
-
-  private async copyAsset(from: string, to: string, logger: WebpackLogger) {
-    logger.debug('Copying asset:', from, 'to:', to);
-    await fs.ensureDir(path.dirname(to));
-    await fs.copyFile(from, to);
-  }
-
-  private processEntryChunkFiles(
-    compilation: webpack.Compilation,
-    chunk: webpack.Chunk,
-    outputPath: string,
-    bundleOutput: string,
-    sourcemapOutput: string,
-    logger: WebpackLogger
-  ) {
-    const promises = [];
-    const [bundleFile] = [...chunk.files];
-    const relatedSourceMap =
-      compilation.assetsInfo.get(bundleFile)?.related?.sourceMap;
-    const sourceMapFile = Array.isArray(relatedSourceMap)
-      ? relatedSourceMap[0]
-      : relatedSourceMap;
-    promises.push(
-      this.copyAsset(path.join(outputPath, bundleFile), bundleOutput, logger)
-    );
-    if (sourceMapFile) {
-      promises.push(
-        this.copyAsset(
-          path.join(outputPath, sourceMapFile),
-          sourcemapOutput,
-          logger
-        )
-      );
-    }
-
-    return promises;
-  }
-
-  private processChunkFiles(
-    compilation: webpack.Compilation,
-    chunk: webpack.Chunk,
-    outputPath: string,
-    assetsDest: string,
-    logger: WebpackLogger
-  ) {
-    const promises = [];
-    const [chunkFile] = [...chunk.files];
-    const relatedSourceMap =
-      compilation.assetsInfo.get(chunkFile)?.related?.sourceMap;
-    const sourceMapFile = Array.isArray(relatedSourceMap)
-      ? relatedSourceMap[0]
-      : relatedSourceMap;
-    promises.push(
-      this.copyAsset(
-        path.join(outputPath, chunkFile),
-        path.join(assetsDest, chunkFile),
-        logger
-      )
-    );
-    if (sourceMapFile) {
-      promises.push(
-        this.copyAsset(
-          path.join(outputPath, sourceMapFile),
-          path.join(assetsDest, sourceMapFile),
-          logger
-        )
-      );
-    }
-
-    return promises;
-  }
-
-  private processChunkAuxiliaryFiles(
-    chunk: webpack.Chunk,
-    outputPath: string,
-    assetsDest: string,
-    logger: WebpackLogger
-  ) {
-    const assets = [...chunk.auxiliaryFiles].filter(
-      (file) => !/\.map$/.test(file)
-    );
-    return assets.map((asset) =>
-      this.copyAsset(
-        path.join(outputPath, asset),
-        path.join(assetsDest, asset),
-        logger
-      )
-    );
   }
 }

--- a/packages/repack/src/webpack/plugins/utils/AssetsCopyProcessor.ts
+++ b/packages/repack/src/webpack/plugins/utils/AssetsCopyProcessor.ts
@@ -8,6 +8,7 @@ export class AssetsCopyProcessor {
 
   constructor(
     public readonly config: {
+      platform: string;
       compilation: webpack.Compilation;
       outputPath: string;
       bundleOutput: string;
@@ -33,6 +34,7 @@ export class AssetsCopyProcessor {
       sourcemapOutput,
       bundleOutputDir,
       assetsDest,
+      platform,
     } = this.config;
     const sourcemapOutputDir = path.dirname(sourcemapOutput);
 
@@ -46,7 +48,12 @@ export class AssetsCopyProcessor {
     this.queue.push(() =>
       this.copyAsset(
         path.join(outputPath, chunkFile),
-        isEntry ? bundleOutput : path.join(bundleOutputDir, chunkFile)
+        isEntry
+          ? bundleOutput
+          : path.join(
+              platform === 'ios' ? assetsDest : bundleOutputDir,
+              chunkFile
+            )
       )
     );
 
@@ -56,7 +63,10 @@ export class AssetsCopyProcessor {
           path.join(outputPath, sourceMapFile),
           isEntry
             ? sourcemapOutput
-            : path.join(sourcemapOutputDir, sourceMapFile)
+            : path.join(
+                platform === 'ios' ? assetsDest : sourcemapOutputDir,
+                sourceMapFile
+              )
         )
       );
     }
@@ -82,7 +92,7 @@ export class AssetsCopyProcessor {
         (asset) => () =>
           this.copyAsset(
             path.join(outputPath, asset),
-            path.join(bundleOutputDir, asset)
+            path.join(platform === 'ios' ? assetsDest : bundleOutputDir, asset)
           )
       )
     );

--- a/packages/repack/src/webpack/plugins/utils/AssetsCopyProcessor.ts
+++ b/packages/repack/src/webpack/plugins/utils/AssetsCopyProcessor.ts
@@ -1,0 +1,96 @@
+import path from 'path';
+import fs from 'fs-extra';
+import webpack from 'webpack';
+import { WebpackLogger } from '../../../types';
+
+export class AssetsCopyProcessor {
+  queue: Array<() => Promise<void>> = [];
+
+  constructor(
+    public readonly config: {
+      compilation: webpack.Compilation;
+      outputPath: string;
+      bundleOutput: string;
+      bundleOutputDir: string;
+      sourcemapOutput: string;
+      assetsDest: string;
+      logger: WebpackLogger;
+    },
+    private filesystem: Pick<typeof fs, 'ensureDir' | 'copyFile'> = fs
+  ) {}
+
+  private async copyAsset(from: string, to: string) {
+    this.config.logger.debug('Copying asset:', from, 'to:', to);
+    await this.filesystem.ensureDir(path.dirname(to));
+    await this.filesystem.copyFile(from, to);
+  }
+
+  enqueueChunk(chunk: webpack.Chunk, { isEntry }: { isEntry: boolean }) {
+    const {
+      compilation,
+      outputPath,
+      bundleOutput,
+      sourcemapOutput,
+      bundleOutputDir,
+      assetsDest,
+    } = this.config;
+    const sourcemapOutputDir = path.dirname(sourcemapOutput);
+
+    const [chunkFile] = [...chunk.files];
+    const relatedSourceMap =
+      compilation.assetsInfo.get(chunkFile)?.related?.sourceMap;
+    const sourceMapFile = Array.isArray(relatedSourceMap)
+      ? relatedSourceMap[0]
+      : relatedSourceMap;
+
+    this.queue.push(() =>
+      this.copyAsset(
+        path.join(outputPath, chunkFile),
+        isEntry ? bundleOutput : path.join(bundleOutputDir, chunkFile)
+      )
+    );
+
+    if (sourceMapFile) {
+      this.queue.push(() =>
+        this.copyAsset(
+          path.join(outputPath, sourceMapFile),
+          isEntry
+            ? sourcemapOutput
+            : path.join(sourcemapOutputDir, sourceMapFile)
+        )
+      );
+    }
+
+    const mediaAssets = [...chunk.auxiliaryFiles].filter(
+      (file) => !/\.(map|bundle\.json)$/.test(file)
+    );
+    this.queue.push(
+      ...mediaAssets.map(
+        (asset) => () =>
+          this.copyAsset(
+            path.join(outputPath, asset),
+            path.join(assetsDest, asset)
+          )
+      )
+    );
+
+    const manifests = [...chunk.auxiliaryFiles].filter((file) =>
+      /\.bundle\.json$/.test(file)
+    );
+    this.queue.push(
+      ...manifests.map(
+        (asset) => () =>
+          this.copyAsset(
+            path.join(outputPath, asset),
+            path.join(bundleOutputDir, asset)
+          )
+      )
+    );
+  }
+
+  execute() {
+    const queue = this.queue;
+    this.queue = [];
+    return queue.map((work) => work());
+  }
+}

--- a/packages/repack/src/webpack/plugins/utils/__tests__/AssetsCopyProcessor.test.ts
+++ b/packages/repack/src/webpack/plugins/utils/__tests__/AssetsCopyProcessor.test.ts
@@ -1,0 +1,124 @@
+import webpack from 'webpack';
+import { WebpackLogger } from '../../../../types';
+import { AssetsCopyProcessor } from '../AssetsCopyProcessor';
+
+class FsMock {
+  ensuredDirs: string[] = [];
+  copiedFiles: Array<[string, string]> = [];
+
+  async ensureDir(dir: string) {
+    if (!this.ensuredDirs.includes(dir)) {
+      this.ensuredDirs.push(dir);
+    }
+  }
+
+  async copyFile(from: string, to: string) {
+    this.copiedFiles.push([from, to]);
+  }
+}
+
+describe('AssetsCopyProcessor', () => {
+  describe('for android', () => {
+    const acpConfigStub = {
+      compilation: {
+        assetsInfo: new Map([
+          [
+            'index.bundle',
+            {
+              related: {
+                sourceMap: 'index.bundle.map',
+              },
+            },
+          ],
+          [
+            'src_Async_js.chunk.bundle',
+            {
+              related: {
+                sourceMap: 'src_Async_js.chunk.bundle.map',
+              },
+            },
+          ],
+        ]),
+      } as unknown as webpack.Compilation,
+      outputPath: '/dist',
+      bundleOutput:
+        '/target/generated/assets/react/release/index.android.bundle',
+      bundleOutputDir: '/target/generated/assets/react/release',
+      sourcemapOutput:
+        '/target/generated/sourcemaps/react/release/index.android.bundle.map',
+      assetsDest: '/target/generated/res/react/release',
+      logger: { debug: jest.fn() } as unknown as WebpackLogger,
+    };
+
+    it("should copy entry chunk's files into correct directories", async () => {
+      const fs = new FsMock();
+      const acp = new AssetsCopyProcessor(acpConfigStub, fs);
+      acp.enqueueChunk(
+        {
+          files: ['index.bundle'],
+          auxiliaryFiles: [
+            'drawable-mdpi/node_modules_reactnative_libraries_newappscreen_components_logo.png',
+            'index.bundle.map',
+          ],
+        } as unknown as webpack.Chunk,
+        { isEntry: true }
+      );
+      await Promise.all(acp.execute());
+
+      expect(fs.ensuredDirs).toEqual([
+        '/target/generated/assets/react/release',
+        '/target/generated/sourcemaps/react/release',
+        '/target/generated/res/react/release/drawable-mdpi',
+      ]);
+      expect(fs.copiedFiles).toEqual([
+        [
+          '/dist/index.bundle',
+          '/target/generated/assets/react/release/index.android.bundle',
+        ],
+        [
+          '/dist/index.bundle.map',
+          '/target/generated/sourcemaps/react/release/index.android.bundle.map',
+        ],
+        [
+          '/dist/drawable-mdpi/node_modules_reactnative_libraries_newappscreen_components_logo.png',
+          '/target/generated/res/react/release/drawable-mdpi/node_modules_reactnative_libraries_newappscreen_components_logo.png',
+        ],
+      ]);
+    });
+
+    it("should copy regular chunk's files into correct directories", async () => {
+      const fs = new FsMock();
+      const acp = new AssetsCopyProcessor(acpConfigStub, fs);
+      acp.enqueueChunk(
+        {
+          files: ['src_Async_js.chunk.bundle'],
+          auxiliaryFiles: [
+            'src_Async_js.chunk.bundle.map',
+            'src_Async_js.chunk.bundle.json',
+          ],
+        } as unknown as webpack.Chunk,
+        { isEntry: false }
+      );
+      await Promise.all(acp.execute());
+
+      expect(fs.ensuredDirs).toEqual([
+        '/target/generated/assets/react/release',
+        '/target/generated/sourcemaps/react/release',
+      ]);
+      expect(fs.copiedFiles).toEqual([
+        [
+          '/dist/src_Async_js.chunk.bundle',
+          '/target/generated/assets/react/release/src_Async_js.chunk.bundle',
+        ],
+        [
+          '/dist/src_Async_js.chunk.bundle.map',
+          '/target/generated/sourcemaps/react/release/src_Async_js.chunk.bundle.map',
+        ],
+        [
+          '/dist/src_Async_js.chunk.bundle.json',
+          '/target/generated/assets/react/release/src_Async_js.chunk.bundle.json',
+        ],
+      ]);
+    });
+  });
+});

--- a/templates/webpack.config.js
+++ b/templates/webpack.config.js
@@ -199,6 +199,7 @@ module.exports = {
      * In development mode (when development server is running), this plugin is a no-op.
      */
     new ReactNative.OutputPlugin({
+      platform,
       devServerEnabled: devServer.enabled,
     }),
 


### PR DESCRIPTION
### Summary

Fixes #55 

### Test plan

1. Build TesterApp in release mode on iOS and Android
2. The app should load Async chunk and display it without any errors. 
