### PR TITLE
fix: windows support fix in HMR

### DIFF
--- a/packages/repack/src/types.ts
+++ b/packages/repack/src/types.ts
@@ -82,7 +82,7 @@ export interface StartArguments extends CommonArguments {
 export interface DevServerOptions {
   /** Whether to start development server. */
   enabled?: boolean;
-  /** Hostname under which to run the development server. Defaults to `localhost`. */
+  /** Hostname under which to run the development server. */
   host?: string;
   /** Port under which to run the development server. See: {@link DEFAULT_PORT}. */
   port: number;

--- a/packages/repack/src/types.ts
+++ b/packages/repack/src/types.ts
@@ -82,7 +82,10 @@ export interface StartArguments extends CommonArguments {
 export interface DevServerOptions {
   /** Whether to start development server. */
   enabled?: boolean;
-  /** Hostname under which to run the development server. */
+  /**
+   * Hostname or IP address under which to run the development server.
+   * When left unspecified, it will listen on all available network interfaces, similarly to listening on '0.0.0.0'.
+   */
   host?: string;
   /** Port under which to run the development server. See: {@link DEFAULT_PORT}. */
   port: number;

--- a/packages/repack/src/webpack/plugins/TargetPlugin.ts
+++ b/packages/repack/src/webpack/plugins/TargetPlugin.ts
@@ -24,7 +24,7 @@ export class TargetPlugin implements WebpackPlugin {
     compiler.options.output.chunkLoadingGlobal = 'rnwtLoadChunk';
 
     new webpack.NormalModuleReplacementPlugin(
-      /react-native\/Libraries\/Utilities\/HMRClient\.js$/,
+      /react-native([/\\]+)Libraries([/\\]+)Utilities([/\\]+)HMRClient\.js$/,
       function (resource) {
         const request = require.resolve('../../client/runtime/DevServerClient');
         const context = path.dirname(request);

--- a/packages/repack/src/webpack/utils/env/__tests__/getDevServerOptions.test.ts
+++ b/packages/repack/src/webpack/utils/env/__tests__/getDevServerOptions.test.ts
@@ -36,7 +36,6 @@ describe('getDevServerOptions', () => {
       enabled: true,
       hmr: true,
       port: DEFAULT_PORT,
-      host: 'localhost',
     });
 
     process.env[CLI_OPTIONS_ENV_KEY] = JSON.stringify({

--- a/packages/repack/src/webpack/utils/env/getDevServerOptions.ts
+++ b/packages/repack/src/webpack/utils/env/getDevServerOptions.ts
@@ -35,7 +35,7 @@ export function getDevServerOptions(
     return {
       enabled: true,
       hmr: getFallbackFromOptions(options).hmr ?? true,
-      host: host || getFallbackFromOptions(options).host || 'localhost',
+      host: host || getFallbackFromOptions(options).host,
       port: port ?? getFallbackFromOptions(options).port ?? DEFAULT_PORT,
       https,
       cert,


### PR DESCRIPTION
fix: windows support fix in TargetPlugin for HMRClient && remove default 'localhost' in getDevServerOptions for windows

<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

HMR is not working on windows due to the incorrect regexp in `webpack.NormalModuleReplacementPlugin`.
Besides, the fallback value for `host` in `getDevServerOptions` should be removed to allow access for DevServer by IP in LAN.
