### PR TITLE
fix: force the webpack.config.js cache invalidation

### DIFF
--- a/packages/repack/src/commands/bundle.ts
+++ b/packages/repack/src/commands/bundle.ts
@@ -38,6 +38,10 @@ export function bundle(_: string[], config: Config, args: BundleArguments) {
     process.env[VERBOSE_ENV_KEY] = '1';
   }
 
+  /**
+   * force nodejs to invalidate the webpack config to ensure the bundling works as expected.
+   */
+  delete require.cache[require.resolve(webpackConfigPath)];
   const compiler = webpack(require(webpackConfigPath));
 
   compiler.run((error) => {
@@ -45,5 +49,9 @@ export function bundle(_: string[], config: Config, args: BundleArguments) {
       console.error(error);
       process.exit(2);
     }
+
+    compiler.close((closeErr) => {
+      typeof args.done === 'function' && args.done(closeErr);
+    });
   });
 }

--- a/packages/repack/src/types.ts
+++ b/packages/repack/src/types.ts
@@ -49,6 +49,7 @@ export interface CommonArguments {
  * @internal
  */
 export interface BundleArguments extends CommonArguments {
+  done?: (err?: Error) => void;
   assetsDest?: string;
   entryFile: string;
   minify?: boolean;


### PR DESCRIPTION
 force the cache of webpack.config.js in bundle.ts to invalidate to allow multiple bundles for different platforms

<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

android & ios needs bundling separately and we call the `commands/bundle.ts` as below:

```javascript
  /**
  * platformOptions contain options for android & ios platforms
  */
  for (const opt of platformOptions) {
    bundle(/** bundle related args */)
  }
```

Bundles for each platform are expected but what we got is a duplicate of ios bundle for android platform, which does not work on android devices.

And the reason is that nodejs caches every module required throughout the program. I wonder if it is better to move all the webpack resolving logic to some function like getWebpackConfig?

Besides, I'd like to be noticed when the bundling is done. So I append a done callback to the bundle params. And `compiler.close` is supposed to called for webpack5 to allow for the low-priority work.
