### PR TITLE
fix: stop caching chunks in dev environment

### DIFF
--- a/packages/TesterApp/index.js
+++ b/packages/TesterApp/index.js
@@ -1,9 +1,11 @@
 import { AppRegistry } from 'react-native';
 import { ChunkManager } from '@callstack/repack/client';
+import AsyncStorage from '@react-native-async-storage/async-storage';
 import App from './src/App';
 import { name as appName } from './app.json';
 
 ChunkManager.configure({
+  storage: AsyncStorage,
   resolveRemoteChunk: async (chunkId) => {
     return {
       url: `http://localhost:5000/${chunkId}`,

--- a/packages/repack/src/client/chunks-api/ChunkManager.ts
+++ b/packages/repack/src/client/chunks-api/ChunkManager.ts
@@ -115,6 +115,7 @@ class ChunkManagerBackend {
 
     if (__DEV__ && !this.forceRemoteChunkResolution) {
       url = Chunk.fromDevServer(chunkId);
+      fetch = true;
     } else if (
       global.__CHUNKS__?.['local']?.includes(chunkId) &&
       !this.forceRemoteChunkResolution


### PR DESCRIPTION

### Summary

Caching chunks in development environment was causing issues related to not refreshed chunk content after app reload. This PR resolves it by refetching chunks every time in dev env. 

