### PR TITLE
fix: asset resolver failure due to missing scales

### DIFF
--- a/packages/repack/src/webpack/plugins/AssetsResolverPlugin/AssetResolver.ts
+++ b/packages/repack/src/webpack/plugins/AssetsResolverPlugin/AssetResolver.ts
@@ -61,7 +61,9 @@ export class AssetResolver {
       ? new RegExp(
           `^${escapeStringRegexp(
             name
-          )}(@\\d+(\\.\\d+)?x)?(\\.(${platform}|native))?\\.${type}$`
+          )}(@\\d+(\\.\\d+)?x)?(\\.(${platform}|native))?${escapeStringRegexp(
+            type
+          )}$`
         )
       : new RegExp(
           `^${escapeStringRegexp(name)}(\\.(${platform}|native))?\\.${type}$`
@@ -129,7 +131,7 @@ export class AssetResolver {
 
             const basename = path.basename(requestPath);
             const name = basename.replace(/\.[^.]+$/, '');
-            const type = path.extname(requestPath).substring(1);
+            const type = path.extname(requestPath);
             const files = ((results as Array<string | Buffer>)?.filter(
               (result) => typeof result === 'string'
             ) ?? []) as string[];


### PR DESCRIPTION
### Summary

Fixes #97 

Fix `AssetResolver` to use correct regex for matching scales. Otherwise it will fail if there are missing scales - e.g. only `3x`.

### Test plan

1. Rename image to `@3x` scale.
2. Run development server in TesterApp.
3. Request the bundle.
