### PR TITLE
Force chunkIds to strings in __CHUNKS__

### DIFF
--- a/packages/repack/src/webpack/plugins/OutputPlugin.ts
+++ b/packages/repack/src/webpack/plugins/OutputPlugin.ts
@@ -165,7 +165,7 @@ export class OutputPlugin implements WebpackPlugin {
         assets[mainBundleAssetName] = new webpack.sources.ConcatSource(
           `var __CHUNKS__=${JSON.stringify({
             local: localChunks.map(
-              (localChunk) => localChunk.name ?? localChunk.id
+              (localChunk) => localChunk.name ?? localChunk.id.toString()
             ),
           })};\n`,
           mainBundleSource


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

In our project we use: 
```js
optimization: {
  moduleIds: 'size',
  chunkIds: 'size',
}
```

This causes the chunks to be named `0.chunk.bundle` etc. When the chunk manager tries to load a chunk the type of the `chunkId` is always forced to a string, but since the `__CHUNKS__` variable retains the chunk id number as a fallback it will not find the chunk id and will try to load it remotely which fails. 

This PR forces the `chunkId` values to be strings in both places so that a chunk is correctly labeled as local. 

### Test plan

Use config above and build the app in release mode. 