### PR TITLE
fix: prevent crash when using custom Webpack path

### DIFF
--- a/packages/repack/commands.js
+++ b/packages/repack/commands.js
@@ -47,7 +47,12 @@ const webpackConfigOption = {
     const {
       getWebpackConfigPath,
     } = require('./dist/commands/utils/getWebpackConfigPath');
-    return getWebpackConfigPath(config.root);
+
+    try {
+      return getWebpackConfigPath(config.root);
+    } catch {
+      return '';
+    }
   },
 };
 


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

- Fixes #105 

### Test plan

1. Run Re.Pack's start/bundle in TesterApp (it should not crash)
1. Change `webpack.config.js` to `webpack2.config.js`
1. Run Re.Pack's start/bundle in TesterApp (it should crash)
1. Run Re.Pack's start/bundle in TesterApp with `--webpackConfig ./webpack2.config.js` (it should not crash)
