### PR TITLE
fix: source map output for remote chunks

### DIFF
--- a/packages/repack/src/webpack/plugins/utils/AssetsCopyProcessor.ts
+++ b/packages/repack/src/webpack/plugins/utils/AssetsCopyProcessor.ts
@@ -39,7 +39,9 @@ export class AssetsCopyProcessor {
       assetsDest,
       platform,
     } = this.config;
-    const sourcemapOutputDir = path.dirname(sourcemapOutput);
+    const sourcemapOutputDir = sourcemapOutput
+      ? path.dirname(sourcemapOutput)
+      : bundleOutputDir;
 
     // Chunk bundle e.g: `index.bundle`, `src_App_js.chunk.bundle`
     const [chunkFile] = [...chunk.files];


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

Fixes issue when source maps for remote chunks gets output into CWD instead of the directory specified by `remoteChunksOutput` in `OutputPlugin`.

### Test plan

1. Bundle TesterApp
2. Source maps for `remote` and `miniapp` chunks should be in `build/android/remote`
