### PR TITLE
fix: add missing remoteChunksOutput option to the template

### DIFF
--- a/templates/webpack.config.js
+++ b/templates/webpack.config.js
@@ -1,7 +1,7 @@
-const path = require("path");
-const webpack = require("webpack");
-const TerserPlugin = require("terser-webpack-plugin");
-const ReactNative = require("@callstack/repack");
+const path = require('path');
+const webpack = require('webpack');
+const TerserPlugin = require('terser-webpack-plugin');
+const ReactNative = require('@callstack/repack');
 
 /**
  * More documentation, installation, usage, motivation and differences with Metro is available at:
@@ -31,8 +31,8 @@ const ReactNative = require("@callstack/repack");
  * to specify your values, if the defaults don't suit your project.
  */
 
-const mode = ReactNative.getMode({ fallback: "development" });
-const dev = mode === "development";
+const mode = ReactNative.getMode({ fallback: 'development' });
+const dev = mode === 'development';
 const context = ReactNative.getContext();
 const entry = ReactNative.getEntry();
 const platform = ReactNative.getPlatform({ fallback: process.env.PLATFORM });
@@ -99,9 +99,9 @@ module.exports = {
    */
   output: {
     clean: true,
-    path: path.join(__dirname, "build", platform),
-    filename: "index.bundle",
-    chunkFilename: "[name].chunk.bundle",
+    path: path.join(__dirname, 'build', platform),
+    filename: 'index.bundle',
+    chunkFilename: '[name].chunk.bundle',
     publicPath: ReactNative.getPublicPath(devServer),
   },
   /**
@@ -146,7 +146,7 @@ module.exports = {
           /node_modules(.*[/\\])+abort-controller/,
           /node_modules(.*[/\\])+@callstack[/\\]repack/,
         ],
-        use: "babel-loader",
+        use: 'babel-loader',
       },
       /**
        * Here you can adjust loader that will process your files.
@@ -158,10 +158,10 @@ module.exports = {
         test: /\.[jt]sx?$/,
         exclude: /node_modules/,
         use: {
-          loader: "babel-loader",
+          loader: 'babel-loader',
           options: {
             /** Add React Refresh transform only when HMR is enabled. */
-            plugins: devServer.hmr ? ["module:react-refresh/babel"] : undefined,
+            plugins: devServer.hmr ? ['module:react-refresh/babel'] : undefined,
           },
         },
       },
@@ -180,7 +180,7 @@ module.exports = {
           ReactNative.ASSET_EXTENSIONS
         ),
         use: {
-          loader: "@callstack/repack/assets-loader",
+          loader: '@callstack/repack/assets-loader',
           options: {
             platform,
             devServerEnabled: devServer.enabled,
@@ -224,13 +224,13 @@ module.exports = {
      * but in order to for the React Native application to include those files (or a subset of those)
      * they need to be copied over to correct output directories supplied from React Native CLI
      * when bundling the code (with `webpack-bundle` command).
-     * All remote chunks will be emitted into `remoteChunksOutput (eg: `<root>/build/ios/remote`)
+     * All remote chunks will be placed under `remoteChunksOutput` directory (eg: `<root>/build/<platform>/remote` by default).
      * In development mode (when development server is running), this plugin is a no-op.
      */
     new ReactNative.OutputPlugin({
       platform,
       devServerEnabled: devServer.enabled,
-      remoteChunksOutput: path.join(__dirname, "build", platform, "remote"),
+      remoteChunksOutput: path.join(__dirname, 'build', platform, 'remote'),
     }),
 
     /**
@@ -252,7 +252,7 @@ module.exports = {
     new webpack.SourceMapDevToolPlugin({
       test: /\.(js)?bundle$/,
       exclude: /\.chunk\.(js)?bundle$/,
-      filename: "[file].map",
+      filename: '[file].map',
       append: `//# sourceMappingURL=[url]?platform=${platform}`,
       /**
        * Uncomment for faster builds but less accurate Source Maps
@@ -269,7 +269,7 @@ module.exports = {
     new webpack.SourceMapDevToolPlugin({
       test: /\.(js)?bundle$/,
       include: /\.chunk\.(js)?bundle$/,
-      filename: "[file].map",
+      filename: '[file].map',
       append: `//# sourceMappingURL=[url]?platform=${platform}`,
       /**
        * Uncomment for faster builds but less accurate Source Maps


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary
This PR adds missing `remoteChunksOutput` option to the template
