### PR TITLE
fix: add default value for the local chunk check

### DIFF
--- a/packages/repack/src/webpack/plugins/OutputPlugin.ts
+++ b/packages/repack/src/webpack/plugins/OutputPlugin.ts
@@ -98,14 +98,13 @@ export class OutputPlugin implements WebpackPlugin {
       remoteChunksOutput,
     });
 
-    const isLocalChunk = (chunkId: string): boolean => {
-      return webpack.ModuleFilenameHelpers.matchObject(
+    const isLocalChunk = (chunkId: string): boolean =>
+      webpack.ModuleFilenameHelpers.matchObject(
         {
           include: this.config.localChunks ?? [],
         },
         chunkId
       );
-    };
 
     let entryGroup: webpack.Compilation['chunkGroups'][0] | undefined;
     const localChunks: webpack.Chunk[] = [];


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary
Adds default value for the local chunk check because `undefined` value results with all chunks being handled as local ones.

Related to #122
