### PR TITLE
fix: pointer to bool conversion in chunk config on iOS

### DIFF
--- a/packages/repack/ios/ChunkConfig.m
+++ b/packages/repack/ios/ChunkConfig.m
@@ -36,12 +36,15 @@
     NSURLComponents *urlComponents = [NSURLComponents componentsWithString:urlString];
     urlComponents.query = query;
     
+    BOOL fetch = [config[@"fetch"] boolValue];
+    BOOL absolute = [config[@"absolute"] boolValue];
+    
     return [[ChunkConfig alloc] initWithChunk:chunkId
                                       withURL:urlComponents.URL
                                    withMethod:method
                                     withQuery:query
-                                    withFetch:config[@"fetch"]
-                                 withAbsolute:config[@"absolute"]
+                                    withFetch:fetch
+                                 withAbsolute:absolute
                                   withHeaders:config[@"headers"]
                                      withBody:[config[@"body"] dataUsingEncoding:NSUTF8StringEncoding]
                                   withTimeout:config[@"timeout"]];


### PR DESCRIPTION
### Summary

On iOS loading async chunks in release mode would always fail due to the chunk config always saying it is an absolute URL. This PR fixes the `fromConfigDictionary` method to correctly handle type conversion.  

### Test plan

Build a release build of the iOS TesterApp and see it never loading the async chunk before this change, but that the thing works fine with my change. Make sure you are not loading main bundle from network!