### PR TITLE
fix: absolute flag and promise resolving inside the file system chunk loader

### DIFF
--- a/packages/repack/android/src/main/java/com/callstack/repack/FileSystemChunkLoader.kt
+++ b/packages/repack/android/src/main/java/com/callstack/repack/FileSystemChunkLoader.kt
@@ -16,7 +16,7 @@ class FileSystemChunkLoader(private val reactContext: ReactContext) {
                 val assetName = "assets://$filename"
                 reactContext.catalystInstance.loadScriptFromAssets(reactContext.assets, assetName, false)
             }
-
+            promise.resolve(null);
         } catch (error: Exception) {
             promise.reject(
                     ChunkLoadingError.FileSystemEvalFailure.code,

--- a/packages/repack/src/client/api/ChunkManagerBackend.ts
+++ b/packages/repack/src/client/api/ChunkManagerBackend.ts
@@ -90,6 +90,7 @@ export class ChunkManagerBackend {
       }
 
       const config = await this.resolveRemoteChunk(chunkId, parentChunkId);
+      absolute = config.absolute ?? absolute;
       timeout = config.timeout ?? timeout;
       method = config.method ?? method;
       url = Chunk.fromRemote(config.url, {

--- a/packages/repack/src/client/api/__tests__/ChunkManagerBackend.spec.ts
+++ b/packages/repack/src/client/api/__tests__/ChunkManagerBackend.spec.ts
@@ -241,6 +241,7 @@ describe('ChunkManager', () => {
       timeout: DEFAULT_TIMEOUT,
     });
   });
+
   it('should resolve with absolute path', async () => {
     const manager = new ChunkManagerBackend({});
     const cache = new FakeCache();

--- a/packages/repack/src/client/api/__tests__/ChunkManagerBackend.spec.ts
+++ b/packages/repack/src/client/api/__tests__/ChunkManagerBackend.spec.ts
@@ -241,4 +241,31 @@ describe('ChunkManager', () => {
       timeout: DEFAULT_TIMEOUT,
     });
   });
+  it('should resolve with absolute path', async () => {
+    const manager = new ChunkManagerBackend({});
+    const cache = new FakeCache();
+
+    manager.configure({
+      storage: cache,
+      resolveRemoteChunk: async (chunkId, parentChunkId) => {
+        expect(parentChunkId).toEqual('main');
+
+        return {
+          fetch: true,
+          url: `file://absolute/directory/${chunkId}`,
+          method: 'POST',
+          absolute: true,
+        };
+      },
+    });
+
+    const config = await manager.resolveChunk('src_App_js', 'main');
+    expect(config).toEqual({
+      url: 'file://absolute/directory/src_App_js.chunk.bundle',
+      fetch: true,
+      absolute: true,
+      method: 'POST',
+      timeout: DEFAULT_TIMEOUT,
+    });
+  });
 });


### PR DESCRIPTION
### Summary
Fix setting absolute flag and resolving promise inside the file system chunk loader

### Test plan
Add tests for absolute equals`true`.