### PR TITLE
fix: replace process.env.__PUBLIC_PORT__ by __PUBLIC_PORT__

### DIFF
--- a/packages/TesterApp/ios/Podfile.lock
+++ b/packages/TesterApp/ios/Podfile.lock
@@ -1,6 +1,6 @@
 PODS:
   - boost-for-react-native (1.63.0)
-  - callstack-repack (2.4.2):
+  - callstack-repack (2.5.1):
     - React-Core
   - CocoaAsyncSocket (7.6.5)
   - DoubleConversion (1.1.6)
@@ -461,11 +461,11 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   boost-for-react-native: 39c7adb57c4e60d6c5479dd8623128eb5b3f0f2c
-  callstack-repack: 69bed058b305cea0b105f8b2aac49a78dcbec4b4
+  callstack-repack: 6ad4ee385be3feab2095af1e5031d8b292c641b6
   CocoaAsyncSocket: 065fd1e645c7abab64f7a6a2007a48038fdc6a99
   DoubleConversion: cf9b38bf0b2d048436d9a82ad2abe1404f11e7de
   FBLazyVector: e686045572151edef46010a6f819ade377dfeb4b
-  FBReactNativeSpec: 63e99f3442c4ac39bf9cf8e29cf605b54cba9f22
+  FBReactNativeSpec: fcd45dbbdb21f2f5d8c80eeeb3e2b8a708b0ffa7
   Flipper: d3da1aa199aad94455ae725e9f3aa43f3ec17021
   Flipper-DoubleConversion: 38631e41ef4f9b12861c67d17cb5518d06badc41
   Flipper-Folly: 755929a4f851b2fb2c347d533a23f191b008554c

--- a/packages/repack/src/client/setup/modules/WebpackHMRClient.ts
+++ b/packages/repack/src/client/setup/modules/WebpackHMRClient.ts
@@ -1,5 +1,5 @@
 /* eslint-env browser */
-/* globals __webpack_hash__ __DEV__ */
+/* globals __webpack_hash__ __DEV__, __PUBLIC_PORT__ */
 
 import type { HMRMessage, HMRMessageBody } from '../../../types';
 import { getDevServerLocation } from '../utils/getDevServerLocation';
@@ -19,9 +19,9 @@ class HMRClient {
       };
     }
   ) {
-    this.url = `ws://${getDevServerLocation().hostname}:${
-      process.env.__PUBLIC_PORT__
-    }/__hmr`;
+    this.url = `ws://${
+      getDevServerLocation().hostname
+    }:${__PUBLIC_PORT__}/__hmr`;
     this.socket = new WebSocket(this.url);
 
     console.log('[HMRClient] Connecting...', {

--- a/packages/repack/src/runtime-globals.d.ts
+++ b/packages/repack/src/runtime-globals.d.ts
@@ -1,6 +1,7 @@
 /// <reference lib="DOM" />
 
 declare var __DEV__: boolean;
+declare var __PUBLIC_PORT__: number;
 declare var __CHUNKS__: { local?: Array<string | number | null> } | undefined;
 declare var __webpack_public_path__: string;
 declare var __webpack_get_script_filename__: (script: string) => string;

--- a/packages/repack/src/webpack/plugins/DevServerPlugin/DevServerPlugin.ts
+++ b/packages/repack/src/webpack/plugins/DevServerPlugin/DevServerPlugin.ts
@@ -55,7 +55,7 @@ export class DevServerPlugin implements WebpackPlugin {
     }
 
     new webpack.DefinePlugin({
-      'process.env.__PUBLIC_PORT__': JSON.stringify(this.config.port),
+      __PUBLIC_PORT__: JSON.stringify(this.config.port),
     }).apply(compiler);
 
     if (this.config?.hmr) {


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

In some cases, value returned by process.env.__PUBLIC_PORT__ was undefined because of which hot reload wasn't working.
Fixes https://github.com/callstack/repack/issues/141

### Test plan

Make sure that hot reload is working as expected.
