### PR TITLE
fix: images with higher resolution not used when possible

### DIFF
--- a/packages/repack/src/webpack/loaders/assetsLoader.ts
+++ b/packages/repack/src/webpack/loaders/assetsLoader.ts
@@ -112,6 +112,9 @@ export default async function reactNativeAssetsLoader(this: LoaderContext) {
         parseInt(b.replace(/[^\d.]/g, ''), 10)
     );
 
+    const scaleNumbers = scaleKeys.map((scale) =>
+      parseInt(scale.replace(/[^\d.]/g, ''), 10)
+    );
     const assets = await Promise.all(
       scaleKeys.map(
         (
@@ -271,7 +274,7 @@ export default async function reactNativeAssetsLoader(this: LoaderContext) {
       var AssetRegistry = require('react-native/Libraries/Image/AssetRegistry');
       module.exports = AssetRegistry.registerAsset({
         __packager_asset: true,
-        scales: ${JSON.stringify(scales)},
+        scales: ${JSON.stringify(scaleNumbers)},
         name: ${JSON.stringify(filename)},
         type: ${JSON.stringify(type)},
         hash: ${JSON.stringify(hashes.join())},


### PR DESCRIPTION


<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary
It fixes #148 .

### Test plan
Add two images and name it same way but one of them should have `@2x` suffix. On an iOS simulator image with mentioned suffix should be displayed.