### PR TITLE
fix: wrong error position on JSC engine

### DIFF
--- a/packages/TesterApp/src/App.js
+++ b/packages/TesterApp/src/App.js
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React from 'react';
 import {
   SafeAreaView,
   ScrollView,

--- a/packages/TesterApp/src/App.js
+++ b/packages/TesterApp/src/App.js
@@ -19,7 +19,6 @@ const App = () => {
   const backgroundStyle = {
     backgroundColor: isDarkMode ? Colors.darker : Colors.lighter,
   };
-
   return (
     <SafeAreaView style={backgroundStyle}>
       <StatusBar barStyle={isDarkMode ? 'light-content' : 'dark-content'} />

--- a/packages/TesterApp/src/App.js
+++ b/packages/TesterApp/src/App.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import {
   SafeAreaView,
   ScrollView,
@@ -19,6 +19,7 @@ const App = () => {
   const backgroundStyle = {
     backgroundColor: isDarkMode ? Colors.darker : Colors.lighter,
   };
+
   return (
     <SafeAreaView style={backgroundStyle}>
       <StatusBar barStyle={isDarkMode ? 'light-content' : 'dark-content'} />

--- a/packages/TesterApp/webpack.config.js
+++ b/packages/TesterApp/webpack.config.js
@@ -36,7 +36,7 @@ const dev = mode === 'development';
 const context = ReactNative.getContext();
 const entry = ReactNative.getEntry();
 const platform = ReactNative.getPlatform({ fallback: process.env.PLATFORM });
-const minimize = ReactNative.isMinimizeEnabled({ fallback: !dev });
+const minimize = true;
 const devServer = ReactNative.getDevServerOptions();
 const reactNativePath = ReactNative.getReactNativePath();
 
@@ -121,6 +121,11 @@ module.exports = {
          * differently.
          */
         extractComments: false,
+        terserOptions: {
+          format: {
+            comments: false,
+          },
+        },
       }),
     ],
     chunkIds: 'named',

--- a/packages/TesterApp/webpack.config.js
+++ b/packages/TesterApp/webpack.config.js
@@ -36,7 +36,7 @@ const dev = mode === 'development';
 const context = ReactNative.getContext();
 const entry = ReactNative.getEntry();
 const platform = ReactNative.getPlatform({ fallback: process.env.PLATFORM });
-const minimize = true;
+const minimize = ReactNative.isMinimizeEnabled({ fallback: !dev });
 const devServer = ReactNative.getDevServerOptions();
 const reactNativePath = ReactNative.getReactNativePath();
 

--- a/templates/webpack.config.js
+++ b/templates/webpack.config.js
@@ -120,6 +120,11 @@ module.exports = {
          * differently.
          */
         extractComments: false,
+        terserOptions: {
+          format: {
+            comments: false,
+          },
+        },
       }),
     ],
   },


### PR DESCRIPTION
### Summary
In this PR including any comments to the minified bundle has been disabled.
It fixes #128


### Test plan
JSC engine should return correct column number when we've thrown error.
