### PR TITLE
fix: pass watch options to the compiler worker

### DIFF
--- a/packages/repack/src/server/compilerWorker.ts
+++ b/packages/repack/src/server/compilerWorker.ts
@@ -1,13 +1,15 @@
 import webpack from 'webpack';
 
 const webpackConfigPath = process.argv[2];
-const compiler = webpack(require(webpackConfigPath));
+const webpackConfig = require(webpackConfigPath) as webpack.Configuration;
+const watchOptions = webpackConfig.watchOptions ?? {};
+const compiler = webpack(webpackConfig);
 
 compiler.hooks.watchRun.tap('compilerWorker', () => {
   process.send?.({ event: 'watchRun' });
 });
 
-compiler.watch({}, (error) => {
+compiler.watch(watchOptions, (error) => {
   if (error) {
     console.error(error);
     process.exit(2);


### PR DESCRIPTION
### Summary
In this PR we provide support for `watchOptions`
https://webpack.js.org/configuration/watch/#watchoptions
It closes #137.


### Test plan
1. Add watchOptions to the webpack's config file
2. Specify which file webpack's should ignore
3. Changes in the specified file should be ignored by the webpack's compiler