### PR TITLE
fix: use parse float instead of parse int for scale

### DIFF
--- a/packages/repack/src/webpack/loaders/assetsLoader.ts
+++ b/packages/repack/src/webpack/loaders/assetsLoader.ts
@@ -113,7 +113,7 @@ export default async function reactNativeAssetsLoader(this: LoaderContext) {
     );
 
     const scaleNumbers = scaleKeys.map((scale) =>
-      parseInt(scale.replace(/[^\d.]/g, ''), 10)
+      parseFloat(scale.replace(/[^\d.]/g, ''))
     );
     const assets = await Promise.all(
       scaleKeys.map(


### PR DESCRIPTION
### Summary
It fixes parsing scale because when scale was i.e `3.5` then asset was not properly resolved.
Thanks for the really good catch  👍 https://github.com/callstack/repack/pull/153#discussion_r798273941

### Test plan
1. Add 2 images and name one of them with i.e: @3.5x suffix
2. Image that has the most suitable scale should be used 
(i.e screen's `PixelRatio` is equal to 4 and we've added two images with `@2x` and `@3.5x`. Image that scale is equal to `3.5` will be used)
