### PR TITLE
fix: use parse float for scale keys instead of parse int

### DIFF
--- a/packages/repack/src/webpack/loaders/assetsLoader.ts
+++ b/packages/repack/src/webpack/loaders/assetsLoader.ts
@@ -108,8 +108,8 @@ export default async function reactNativeAssetsLoader(this: LoaderContext) {
 
     const scaleKeys = Object.keys(scales).sort(
       (a, b) =>
-        parseInt(a.replace(/[^\d.]/g, ''), 10) -
-        parseInt(b.replace(/[^\d.]/g, ''), 10)
+        parseFloat(a.replace(/[^\d.]/g, '')) -
+        parseFloat(b.replace(/[^\d.]/g, ''))
     );
 
     const scaleNumbers = scaleKeys.map((scale) =>


### PR DESCRIPTION
### Summary
We use `parseFloat` instead of `parseInt` for scale keys as well as for scale numbers.
It fixes #157.

### Test plan
1. Add images with suffixes that contain same number before decimal point with different decimal places.
2. Image with the most suitable scale for the screen should be used
