### PR TITLE
Fix a bug in loading local chunks

### DIFF
--- a/packages/repack/src/webpack/plugins/OutputPlugin.ts
+++ b/packages/repack/src/webpack/plugins/OutputPlugin.ts
@@ -176,7 +176,7 @@ export class OutputPlugin implements WebpackPlugin {
               new webpack.sources.ConcatSource(
                 `var __CHUNKS__=${JSON.stringify({
                   local: localChunks.map(
-                    (localChunk) => localChunk.name ?? localChunk.id
+                    (localChunk) => localChunk.name ?? localChunk.id?.toString()
                   ),
                 })};`,
                 '\n',


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary
In `ChunkManagerBackend`,  params `chunkId`  is a string.
But chunkId in `__CHUNKS__` is a number.
<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->

### Test plan

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
