### PR TITLE
feat(dev-server): silence json endpoint logging

### DIFF
--- a/packages/dev-server/src/plugins/wss/servers/HermesInspectorProxy.ts
+++ b/packages/dev-server/src/plugins/wss/servers/HermesInspectorProxy.ts
@@ -1,7 +1,12 @@
 import type { IncomingMessage } from 'http';
 import { URL } from 'url';
 import WebSocket from 'ws';
-import type { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
+import type {
+  FastifyInstance,
+  FastifyReply,
+  FastifyRequest,
+  LogLevel,
+} from 'fastify';
 import { WebSocketServer } from '../WebSocketServer';
 import { Server } from '../../../types';
 // @ts-ignore
@@ -77,7 +82,11 @@ export class HermesInspectorProxy extends WebSocketServer {
     };
 
     this.fastify.get('/json/list', { onSend }, pageListHandler);
-    this.fastify.get('/json', { onSend }, pageListHandler);
+    this.fastify.get(
+      '/json',
+      { onSend, logLevel: 'silent' as LogLevel },
+      pageListHandler
+    );
   }
 
   private buildPageDescription(deviceId: number, page: Page) {


### PR DESCRIPTION
Silence `/json` endpoint logging to avoid cluttering console output when debugging with Hermes.