### PR TITLE
feat(repack): upgrade React Refresh Webpack Plugin

### DIFF
--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -11,6 +11,7 @@
   },
   "changesets": [
     "gold-ears-switch",
+    "red-garlics-perform",
     "selfish-rings-do",
     "tame-bats-shake"
   ]

--- a/.changeset/red-garlics-perform.md
+++ b/.changeset/red-garlics-perform.md
@@ -1,0 +1,8 @@
+---
+"@callstack/repack": patch
+---
+
+### HMR
+
+- Upgraded `@pmmmwh/react-refresh-webpack-plugin` to `0.5.7` and added `react-refresh@^0.14.0` as a `@callstack/repack` dependency.
+- `RepackTargetPlugin` now requires to pass `hmr?: boolean` property to a constructor - only relevant, if you're __not__ using `RepackPlugin`. 

--- a/packages/TesterApp/package.json
+++ b/packages/TesterApp/package.json
@@ -14,7 +14,7 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "@callstack/repack": "3.0.0-next.0",
+    "@callstack/repack": "3.0.0-next.1",
     "@react-native-async-storage/async-storage": "^1.15.4",
     "lodash.throttle": "^4.1.1",
     "react": "17.0.2",

--- a/packages/repack/CHANGELOG.md
+++ b/packages/repack/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @callstack/repack
 
+## 3.0.0-next.1
+
+### Patch Changes
+
+- ### HMR
+
+  - Upgraded `@pmmmwh/react-refresh-webpack-plugin` to `0.5.7` and added `react-refresh@^0.14.0` as a `@callstack/repack` dependency.
+  - `RepackTargetPlugin` now requires to pass `hmr?: boolean` property to a constructor - only relevant, if you're **not** using `RepackPlugin`.
+
 ## 3.0.0-next.0
 
 ### Major Changes

--- a/packages/repack/package.json
+++ b/packages/repack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@callstack/repack",
-  "version": "3.0.0-next.0",
+  "version": "3.0.0-next.1",
   "description": "A Webpack-based toolkit to build your React Native application with full support of Webpack ecosystem.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -57,7 +57,7 @@
   },
   "dependencies": {
     "@callstack/repack-dev-server": "^1.0.0-next.0",
-    "@pmmmwh/react-refresh-webpack-plugin": "^0.4.3",
+    "@pmmmwh/react-refresh-webpack-plugin": "^0.5.7",
     "colorette": "^1.2.2",
     "dedent": "^0.7.0",
     "escape-string-regexp": "^4.0.0",
@@ -72,6 +72,7 @@
     "memfs": "^3.4.4",
     "mime-types": "^2.1.35",
     "pretty-format": "^26.6.2",
+    "react-refresh": "^0.14.0",
     "schema-utils": "^3.0.0",
     "shallowequal": "^1.1.0",
     "string.prototype.replaceall": "^1.0.6",

--- a/packages/repack/src/webpack/plugins/RepackPlugin.ts
+++ b/packages/repack/src/webpack/plugins/RepackPlugin.ts
@@ -138,7 +138,9 @@ export class RepackPlugin implements WebpackPlugin {
       devServer: this.config.devServer,
     }).apply(compiler);
 
-    new RepackTargetPlugin().apply(compiler);
+    new RepackTargetPlugin({
+      hmr: this.config.devServer?.hmr,
+    }).apply(compiler);
 
     if (this.config.sourceMaps) {
       new webpack.SourceMapDevToolPlugin({

--- a/packages/repack/src/webpack/plugins/RepackTargetPlugin/RepackTargetPlugin.ts
+++ b/packages/repack/src/webpack/plugins/RepackTargetPlugin/RepackTargetPlugin.ts
@@ -1,8 +1,14 @@
 import path from 'path';
 import webpack from 'webpack';
-import type { WebpackPlugin } from '../../../types';
+import type { DevServerOptions, WebpackPlugin } from '../../../types';
 import { RepackInitRuntimeModule } from './runtime/RepackInitRuntimeModule';
 import { RepackLoadScriptRuntimeModule } from './runtime/RepackLoadScriptRuntimeModule';
+
+/**
+ * {@link RepackTargetPlugin} configuration options.
+ */
+export interface RepackTargetPluginConfig
+  extends Pick<DevServerOptions, 'hmr'> {}
 
 /**
  * Plugin for tweaking the JavaScript runtime code to account for React Native environment.
@@ -13,6 +19,13 @@ import { RepackLoadScriptRuntimeModule } from './runtime/RepackLoadScriptRuntime
  * @category Webpack Plugin
  */
 export class RepackTargetPlugin implements WebpackPlugin {
+  /**
+   * Constructs new `RepackTargetPlugin`.
+   *
+   * @param config Plugin configuration options.
+   */
+  constructor(private config?: RepackTargetPluginConfig) {}
+
   /**
    * Apply the plugin.
    *
@@ -57,11 +70,13 @@ export class RepackTargetPlugin implements WebpackPlugin {
           // Add code initialize Re.Pack's runtime logic.
           compilation.addRuntimeModule(
             chunk,
-            new RepackInitRuntimeModule(
-              chunk.id ?? undefined,
+            new RepackInitRuntimeModule({
+              chunkId: chunk.id ?? undefined,
               globalObject,
-              compiler.options.output.chunkLoadingGlobal!
-            )
+              chunkLoadingGlobal: compiler.options.output.chunkLoadingGlobal!,
+              hmrEnabled:
+                compilation.options.mode === 'development' && this.config?.hmr,
+            })
           );
         }
       );

--- a/packages/repack/src/webpack/plugins/RepackTargetPlugin/runtime/RepackInitRuntimeModule.ts
+++ b/packages/repack/src/webpack/plugins/RepackTargetPlugin/runtime/RepackInitRuntimeModule.ts
@@ -1,11 +1,14 @@
 import webpack from 'webpack';
 
+interface RepackInitRuntimeModuleConfig {
+  chunkId: string | number | undefined;
+  globalObject: string;
+  chunkLoadingGlobal: string;
+  hmrEnabled?: boolean;
+}
+
 export class RepackInitRuntimeModule extends webpack.RuntimeModule {
-  constructor(
-    private chunkId: string | number | undefined,
-    private globalObject: string,
-    private chunkLoadingGlobal: string
-  ) {
+  constructor(private config: RepackInitRuntimeModuleConfig) {
     super('repack/init', webpack.RuntimeModule.STAGE_BASIC);
   }
 
@@ -13,9 +16,13 @@ export class RepackInitRuntimeModule extends webpack.RuntimeModule {
     return webpack.Template.asString([
       '// Repack runtime initialization logic',
       webpack.Template.getFunctionContent(require('./implementation/init'))
-        .replaceAll('$chunkId$', `"${this.chunkId ?? 'unknown'}"`)
-        .replaceAll('$chunkLoadingGlobal$', `"${this.chunkLoadingGlobal}"`)
-        .replaceAll('$globalObject$', this.globalObject),
+        .replaceAll('$hmrEnabled$', `${this.config.hmrEnabled ?? false}`)
+        .replaceAll('$chunkId$', `"${this.config.chunkId ?? 'unknown'}"`)
+        .replaceAll(
+          '$chunkLoadingGlobal$',
+          `"${this.config.chunkLoadingGlobal}"`
+        )
+        .replaceAll('$globalObject$', this.config.globalObject),
     ]);
   }
 }

--- a/packages/repack/src/webpack/plugins/RepackTargetPlugin/runtime/implementation/init.ts
+++ b/packages/repack/src/webpack/plugins/RepackTargetPlugin/runtime/implementation/init.ts
@@ -1,11 +1,13 @@
+/* eslint-disable no-restricted-globals */
 /* eslint-disable promise/prefer-await-to-then */
 /* eslint-disable promise/no-callback-in-promise */
 /* eslint-env browser */
-/* global LoadScriptEvent RepackRuntime __DEV__ __webpack_require__ */
+/* global LoadScriptEvent RepackRuntime __webpack_require__ */
 
-let $chunkId$ = '';
-let $chunkLoadingGlobal$ = '';
-let $globalObject$ = {} as Record<string, any>;
+const $chunkId$ = '';
+const $chunkLoadingGlobal$ = '';
+const $globalObject$ = {} as Record<string, any>;
+const $hmrEnabled$ = false;
 
 module.exports = function () {
   var loadScriptCallback: string[] = [];
@@ -83,7 +85,7 @@ module.exports = function () {
   }
 
   function loadHotUpdate(url: string, done: (event?: LoadScriptEvent) => void) {
-    if (!__DEV__ || !module.hot) {
+    if (!$hmrEnabled$) {
       console.error('[RepackRuntime] Loading HMR update chunks is disabled');
       done({ type: 'disabled', target: { src: url } });
       return;
@@ -106,14 +108,14 @@ module.exports = function () {
       .then(function (script?: string) {
         if (script) {
           // @ts-ignore
-          const globalEvalWithSourceUrl = global.globalEvalWithSourceUrl;
+          const globalEvalWithSourceUrl = self.globalEvalWithSourceUrl;
           (function () {
             if (globalEvalWithSourceUrl) {
               globalEvalWithSourceUrl(script, null);
             } else {
               eval(script);
             }
-          }.call(global));
+          }.call(self));
           done();
         }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3684,7 +3684,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@callstack/repack@3.0.0-next.0, @callstack/repack@workspace:packages/repack":
+"@callstack/repack@3.0.0-next.1, @callstack/repack@workspace:packages/repack":
   version: 0.0.0-use.local
   resolution: "@callstack/repack@workspace:packages/repack"
   dependencies:
@@ -29507,7 +29507,7 @@ __metadata:
     "@babel/core": ^7.12.9
     "@babel/runtime": ^7.12.5
     "@callstack/eslint-config": ^12.0.2
-    "@callstack/repack": 3.0.0-next.0
+    "@callstack/repack": 3.0.0-next.1
     "@react-native-async-storage/async-storage": ^1.15.4
     "@svgr/webpack": ^6.2.1
     "@types/get-port": ^4.2.0

--- a/yarn.lock
+++ b/yarn.lock
@@ -3695,7 +3695,7 @@ __metadata:
     "@babel/preset-typescript": ^7.17.12
     "@callstack/eslint-config": ^11.0.0
     "@callstack/repack-dev-server": ^1.0.0-next.0
-    "@pmmmwh/react-refresh-webpack-plugin": ^0.4.3
+    "@pmmmwh/react-refresh-webpack-plugin": ^0.5.7
     "@react-native-community/cli": 5.0.1-alpha.1
     "@react-native-community/cli-types": 5.0.1-alpha.1
     "@release-it/conventional-changelog": ^3.0.1
@@ -3728,6 +3728,7 @@ __metadata:
     mime-types: ^2.1.35
     pretty-format: ^26.6.2
     react-native: ^0.64.1
+    react-refresh: ^0.14.0
     release-it: ^14.10.0
     schema-utils: ^3.0.0
     shallowequal: ^1.1.0
@@ -6246,23 +6247,26 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@pmmmwh/react-refresh-webpack-plugin@npm:^0.4.3":
-  version: 0.4.3
-  resolution: "@pmmmwh/react-refresh-webpack-plugin@npm:0.4.3"
+"@pmmmwh/react-refresh-webpack-plugin@npm:^0.5.7":
+  version: 0.5.7
+  resolution: "@pmmmwh/react-refresh-webpack-plugin@npm:0.5.7"
   dependencies:
-    ansi-html: ^0.0.7
+    ansi-html-community: ^0.0.8
+    common-path-prefix: ^3.0.0
+    core-js-pure: ^3.8.1
     error-stack-parser: ^2.0.6
-    html-entities: ^1.2.1
-    native-url: ^0.2.6
-    schema-utils: ^2.6.5
+    find-up: ^5.0.0
+    html-entities: ^2.1.0
+    loader-utils: ^2.0.0
+    schema-utils: ^3.0.0
     source-map: ^0.7.3
   peerDependencies:
-    "@types/webpack": 4.x
-    react-refresh: ">=0.8.3 <0.10.0"
+    "@types/webpack": 4.x || 5.x
+    react-refresh: ">=0.10.0 <1.0.0"
     sockjs-client: ^1.4.0
-    type-fest: ^0.13.1
+    type-fest: ">=0.17.0 <3.0.0"
     webpack: ">=4.43.0 <6.0.0"
-    webpack-dev-server: 3.x
+    webpack-dev-server: 3.x || 4.x
     webpack-hot-middleware: 2.x
     webpack-plugin-serve: 0.x || 1.x
   peerDependenciesMeta:
@@ -6278,7 +6282,7 @@ __metadata:
       optional: true
     webpack-plugin-serve:
       optional: true
-  checksum: 36a7b0c63f0aabde856a2b43f3f3bfa7919920afa67b4fbcf7d4980b286c7c11e34ada13654d81bf30c3d3e2c12a5b9eef6c15e21a200003b8030809d3ddd6c6
+  checksum: 3490649181878cc8808fb91f3870ef095e5a1fb9647b3ac83740df07379c9d1cf540f24bf2b09d5f26a3a8c805b2c6b9c5be7192bdb9317d0ffffa67426e9f66
   languageName: node
   linkType: hard
 
@@ -8849,15 +8853,6 @@ __metadata:
   bin:
     ansi-html: bin/ansi-html
   checksum: 04c568e8348a636963f915e48eaa3e01218322e1169acafdd79c384f22e5558c003f79bbc480c1563865497482817c7eed025f0653ebc17642fededa5cb42089
-  languageName: node
-  linkType: hard
-
-"ansi-html@npm:^0.0.7":
-  version: 0.0.7
-  resolution: "ansi-html@npm:0.0.7"
-  bin:
-    ansi-html: ./bin/ansi-html
-  checksum: 9b839ce99650b4c2d83621d67d68622d27e7948b54f7a4386f2218a3997ee4e684e5a6e8d290880c3f3260e8d90c2613c59c7028f04992ad5c8d99d3a0fcc02c
   languageName: node
   linkType: hard
 
@@ -11985,6 +11980,13 @@ __metadata:
   version: 3.23.1
   resolution: "core-js-pure@npm:3.23.1"
   checksum: a31d934f9ef7a0907e7c767c1eeba7aae6a9c5b01b8a8cd2dccd01e7ca1bf72bdfddc43ebb69855c5390ceae8dc1a51da739bb67c0d72d904b81e28b2b1d7ce8
+  languageName: node
+  linkType: hard
+
+"core-js-pure@npm:^3.8.1":
+  version: 3.23.3
+  resolution: "core-js-pure@npm:3.23.3"
+  checksum: 09a477a56963ca4409ca383d36429ea3b51b658ff85e94331a510543c77c4d1b44cb6b305b0f185d729eb059c71f1289c62fdec6371ff46ce838a16988cdcb2e
   languageName: node
   linkType: hard
 
@@ -17479,10 +17481,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"html-entities@npm:^1.2.1":
-  version: 1.4.0
-  resolution: "html-entities@npm:1.4.0"
-  checksum: 4b73ffb9eead200f99146e4fbe70acb0af2fea136901a131fc3a782e9ef876a7cbb07dec303ca1f8804232b812249dbf3643a270c9c524852065d9224a8dcdd0
+"html-entities@npm:^2.1.0":
+  version: 2.3.3
+  resolution: "html-entities@npm:2.3.3"
+  checksum: 92521501da8aa5f66fee27f0f022d6e9ceae62667dae93aa6a2f636afa71ad530b7fb24a18d4d6c124c9885970cac5f8a52dbf1731741161002816ae43f98196
   languageName: node
   linkType: hard
 
@@ -22591,15 +22593,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"native-url@npm:^0.2.6":
-  version: 0.2.6
-  resolution: "native-url@npm:0.2.6"
-  dependencies:
-    querystring: ^0.2.0
-  checksum: d56a67b32e635c4944985f551a9976dfe609a3947810791c50f5c37cff1d9dd5fe040184989d104be8752582b79dc4e726f2a9c075d691ecce86b31ae9387f1b
-  languageName: node
-  linkType: hard
-
 "natural-compare@npm:^1.4.0":
   version: 1.4.0
   resolution: "natural-compare@npm:1.4.0"
@@ -25717,13 +25710,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"querystring@npm:^0.2.0":
-  version: 0.2.1
-  resolution: "querystring@npm:0.2.1"
-  checksum: 7b83b45d641e75fd39cd6625ddfd44e7618e741c61e95281b57bbae8fde0afcc12cf851924559e5cc1ef9baa3b1e06e22b164ea1397d65dd94b801f678d9c8ce
-  languageName: node
-  linkType: hard
-
 "queue-microtask@npm:^1.1.2, queue-microtask@npm:^1.2.2":
   version: 1.2.3
   resolution: "queue-microtask@npm:1.2.3"
@@ -26151,6 +26137,13 @@ __metadata:
   bin:
     react-native: cli.js
   checksum: a4b3edf605ac958afd8bac99fbf01d815d8e452b807905ba505562ff4025cbc3576dc181e3a1b0ed22bc7c36814c57877a95ebc731a3ef17cb1f670b60933fc8
+  languageName: node
+  linkType: hard
+
+"react-refresh@npm:^0.14.0":
+  version: 0.14.0
+  resolution: "react-refresh@npm:0.14.0"
+  checksum: dc69fa8c993df512f42dd0f1b604978ae89bd747c0ed5ec595c0cc50d535fb2696619ccd98ae28775cc01d0a7c146a532f0f7fb81dc22e1977c242a4912312f4
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

Upgrades `@pmmmwh/react-refresh-webpack-plugin` and adds `react-refresh@^0.14.0` as a `@callstack/repack` dependency.

### Test plan

- HMR/FR works in TesterApp
