### PR TITLE
feat(repack): unify output paths in Webpack configs and add local chunks docs

### DIFF
--- a/packages/TesterApp/webpack.config.mjs
+++ b/packages/TesterApp/webpack.config.mjs
@@ -231,10 +231,17 @@ export default (env) => {
           sourceMapFilename,
           assetsPath,
         },
-        extraChunks: [{
-          include: ['src_Async_js'],
-          type: 'local'
-        }]
+        extraChunks: [
+          {
+            include: ['src_Async_js'],
+            type: 'local',
+          },
+          {
+            exclude: ['src_Async_js'],
+            type: 'remote',
+            outputPath: path.join('build/output', platform, 'remote'),
+          },
+        ],
       }),
     ],
   };

--- a/templates/webpack.config.cjs
+++ b/templates/webpack.config.cjs
@@ -91,7 +91,7 @@ module.exports = (env) => {
      */
     output: {
       clean: true,
-      path: path.join(dirname, 'build', platform),
+      path: path.join(dirname, 'build/generated', platform),
       filename: 'index.bundle',
       chunkFilename: '[name].chunk.bundle',
       publicPath: Repack.getPublicPath({ platform, devServer }),

--- a/templates/webpack.config.mjs
+++ b/templates/webpack.config.mjs
@@ -93,7 +93,7 @@ export default (env) => {
      */
     output: {
       clean: true,
-      path: path.join(dirname, 'build', platform),
+      path: path.join(dirname, 'build/generated', platform),
       filename: 'index.bundle',
       chunkFilename: '[name].chunk.bundle',
       publicPath: Repack.getPublicPath({ platform, devServer }),

--- a/website/docs/code-splitting/code-push.md
+++ b/website/docs/code-splitting/code-push.md
@@ -26,3 +26,9 @@ which will cause cache invalidation and new script will be downloaded.
 Re.Pack is not an alternative for CodePush, and both projects aim to accomplish different use cases.
 
 :::
+
+:::warning
+
+Code Push works only on the main bundle, meaning all local chunks will not be updated by Code Push. 
+
+:::

--- a/website/docs/code-splitting/glossary.md
+++ b/website/docs/code-splitting/glossary.md
@@ -32,9 +32,13 @@ In plural form: Async chunks refer to a [Code Splitting approach](./usage#async-
 
 A [Chunk](#chunk) stored locally on a filesystem (of a mobile device), contrary to a [Remote chunk](#remote-chunk).
 
+You can learn more about local chunks in the dedicated [Local vs remote chunks guide](./local-vs-remote-chunks).
+
 ## Remote chunk
 
 A [Chunk](#chunk) stored remotely on the server, CDN or any other network location, contrary to a [Local chunk](#local-chunk).
+
+You can learn more about remote chunks in the dedicated [Local vs remote chunks guide](./local-vs-remote-chunks).
 
 ## Script
 

--- a/website/docs/code-splitting/guide-async-chunks.md
+++ b/website/docs/code-splitting/guide-async-chunks.md
@@ -111,8 +111,8 @@ module.exports = {
 At this point all the code used by `StudentSide.js` will be put into `student.chunk.bundle` and
 `TeacherSide.js` into `teacher.chunk.bundle`.
 
-Before we can actually render out application, we need to configure [`ScriptManager`](../api/repack/client/classes/ScriptManager)
-so it can resolve out chunks:
+Before we can actually render out application, we need to instantiate [`ScriptManager`](../api/repack/client/classes/ScriptManager),
+so it can resolve the chunks:
 
 ```js
 // index.js
@@ -148,61 +148,15 @@ This code will allow Re.Pack's [`ScriptManager`](../api/repack/client/classes/Sc
 actually locate your chunks for the student and the teacher, and download them.
 
 When bundling for production/release, all remote chunks, including `student.chunk.bundle` and
-`teacher.chunk.bundle` will be copied to `<projectRoot>/build/<platform>/remote` by default.
+`teacher.chunk.bundle` will be copied to `<projectRoot>/build/output/<platform>/remote` by default,
+for example: `<projectRoot>/build/output/ios/student.chunk.bundle`.
+
 You should upload files from this directory to a remote server or a CDN from where `ScriptManager`
 will download them.
 
-You can change this directory using
-[`remoteChunksOutput`](../api/repack/interfaces/plugins.OutputPluginConfig#remotechunksoutput)
-in [`RepackPlugin`](../api/repack/classes/RepackPlugin) or [`OutputPlugin`](../api/repack/classes/plugins.OutputPlugin) configuration.
+:::tip
 
-## Local vs remote chunks
-
-By default all async chunks are remote chunks, meaning they are hosted on a remote server (e.g: CDN)
-and downloaded on demand.
-
-Local chunks, however, are always stored on a filesystem and bundled together with main bundle into
-the final `.ipa` or `.apk` file, meaning they increase initial download size the user has to
-download when installing your application.
-
-Local chunks should only be used if you know that the majority of users will need them or if you
-want to have *pre-built* features/modules.
-
-:::info
-
-Local chunks will not be copied into `<projectRoot>/build/<platform>/remote` (or directory specified
-in [`remoteChunksOutput`](../api/repack/interfaces/plugins.OutputPluginConfig#remotechunksoutput)).
-They will be stored next to the main bundle.
+You can change this directory and/or mark chunks as local. Refer to dedicated [Local vs Remote chunks guide](./local-vs-remote-chunks)
+for more information.
 
 :::
-
-To mark a chunk as a local chunk, you need to add it's name or a RegExp matching the chunk's name to
-[`localChunks`](../api/repack/interfaces/plugins.OutputPluginConfig#localchunks) in
-your Webpack config.
-
-For example, if we know they majority of the users will be students, it would make sense to make 
-`student` chunk a local chunk. To mark the `student` chunk as a local one, apply this diff to your
-Webpack configuration:
-
-If you're using [`RepackPlugin`](../api/repack/classes/RepackPlugin):
-
-```diff
-      new Repack.RepackPlugin({
-        mode,
-        platform,
-        devServer,
-+       output: {
-+         localChunks: ['student'],
-+       },
-      }),
-```
-
-If you're using [`OutputPlugin`](../api/repack/classes/plugins.OutputPlugin):
-
-```diff
-      new ReactNative.OutputPlugin({
-        platform,
-        devServerEnabled: devServer.enabled,
-+       localChunks: ['student'],
-      }),
-```

--- a/website/docs/code-splitting/local-vs-remote-chunks.md
+++ b/website/docs/code-splitting/local-vs-remote-chunks.md
@@ -1,0 +1,1 @@
+# Local vs Remote chunks

--- a/website/docs/code-splitting/local-vs-remote-chunks.md
+++ b/website/docs/code-splitting/local-vs-remote-chunks.md
@@ -48,7 +48,7 @@ force Webpack to always use the human-readable form for the name of the chunks.
 
 :::info
 
-In newer versions of Re.Pack's templates for Webpack config, `chunkIds` is set to `named` by default.
+In version `3.x`, Re.Pack's templates for Webpack config have `chunkIds` is set to `named` by default.
 
 :::
 

--- a/website/docs/code-splitting/local-vs-remote-chunks.md
+++ b/website/docs/code-splitting/local-vs-remote-chunks.md
@@ -201,6 +201,45 @@ Specifying `extraChunks` will override any defaults - you must configure `remote
 
 :::
 
+Once you have some chunks as local, you need to alter `resolve` function in [`ScriptManager`](../api/repack/client/classes/ScriptManager#constructor):
+
+```js
+import { ScriptManager, Script } from '@callstack/repack/client';
+
+new ScriptManager({
+  resolve: async (scriptId) => {
+    // In development, get all the chunks from dev server.
+    if (__DEV__) {
+      return {
+        url: Script.getDevServerURL(scriptId),
+        cache: false,
+      };
+    }
+
+    // In production, get chunks matching the regex from filesystem.
+    if (/^.+\.local$/.test(scriptId)) {
+      return {
+        url: Script.getFileSystemURL(scriptId),
+      };
+    } else {
+      return {
+        url: Script.getRemoteURL(`https://my-domain.dev/${scriptId}`),
+      };
+    }
+
+    throw new Error(`Script ${scriptId} could not be resolved`);
+  },
+});
+```
+
+:::tip
+
+To avoid having to repeat the RegExp, you can create a new `.js` or `.json` file, export the RegExp and use the file both in the source code as well as in the Webpack config.
+
+Check out the [`local-chunks` example](https://github.com/callstack/repack-examples) for concrete implementation.
+
+:::
+
 ## Advanced example
 
 You can mix multiple `type: 'local'` and `type: 'remote'` specs using `test`, `include` and `exclude` to match different chunks:

--- a/website/docs/code-splitting/local-vs-remote-chunks.md
+++ b/website/docs/code-splitting/local-vs-remote-chunks.md
@@ -102,7 +102,7 @@ By default all chunks are remote chunks, meaning they are not bundled into the a
 This helps with reducing the initial application size, especially if you have logic or features that only a subset of users will use - it doesn't make sense for everyone else
 to always have to download the code (together with the application) they won't need.
 
-All remote chunks are stored under `<projectRoot>/build/output/<platform>/remotes` by default, for example if `button.chunk.bundle` is a remote chunk, it will be stored under:
+All remote chunks are stored under `<projectRoot>/build/output/<platform>/remotes` by default. For example if `button.chunk.bundle` is a remote chunk, it will be stored under:
 `<projectRoot>/build/output/ios/remotes/button.chunk.bundle` for iOS.
 
 You can customize this by providing [`extraChunks`](../api/repack/interfaces/plugins.OutputPluginConfig#extrachunks) to [`RepackPlugin`](../api/repack/classes/RepackPlugin) or [`OutputPlugin`](../api/repack/classes/plugins.OutputPlugin) (if you're not using `RepackPlugin`):

--- a/website/docs/code-splitting/local-vs-remote-chunks.md
+++ b/website/docs/code-splitting/local-vs-remote-chunks.md
@@ -1,1 +1,268 @@
 # Local vs Remote chunks
+
+Each chunk created by using dynamic `import(...)` function can be either remote or a local chunk.
+
+__By default all chunks are remote.__
+
+## Chunk naming
+
+Regardless of the chunk's type, it's important to understand how chunks are named.
+
+:::info
+
+Chunk naming is handled solely by Webpack. Re.Pack does not alter or customize chunk names in any way.
+
+:::
+
+By default, chunk name is inferred by Webpack based on the source filename. For example if you have a file
+`./src/Button.js`, the inferred name would be `src_Button_js`. This human-readable chunk name will only be used
+in development though. By default, Webpack in production, minimizes chunk names to numbers to save space,
+meaning `src_Button_js` chunk in production might look like `137`.
+
+This behavior is fine for Web, but in React Native with `ScriptManager`, it's not ideal, because we don't know what
+this number will be in production.
+
+There are 2 options to address this problem:
+
+1. Set [`optimization.chunkIds`](https://webpack.js.org/configuration/optimization/#optimizationchunkids) option to `named` in Webpack config.
+1. Use `/* webpackChunkName: "<name>" */` magic comment in `import(...)`.
+
+:::tip
+
+You can use both `optimization.chunkIds` and `webpackChunkName` comment at the same time. They are not mutually exclusive.
+
+:::
+
+:::tip
+
+Chunk extension can be configured in [`output.chunkFilename`](https://webpack.js.org/configuration/output/#outputchunkfilename), which is set to `.chunk.bundle` by default.
+It's usually __not__ necessary to modify it.
+
+:::
+
+
+### Named `chunkIds` config option
+
+Setting [`optimization.chunkIds`](https://webpack.js.org/configuration/optimization/#optimizationchunkids) option to `named` in your Webpack config will
+force Webpack to always use the human-readable form for the name of the chunks.
+
+:::info
+
+In newer versions of Re.Pack's templates for Webpack config, `chunkIds` is set to `named` by default.
+
+:::
+
+```js
+/* ... */
+
+export default (env) => {
+  /* ... */
+
+  return {
+    /* ... */
+
+    optimization: {
+      /* ... */
+
+      chunkIds: 'named',
+    },
+
+    /* ... */
+  };
+}
+```
+
+:::tip
+
+Keep in mind that, `webpackChunkName` magic comment will always take precedence, so even if you have `chunkIds: 'named'`, Webpack will use name in `webpackChunkName`
+comment for that chunk instead of the inferred one.
+
+:::
+
+### `webpackChunkName` magic comment
+
+`webpackChunkName` magic comment allows you to provide your own custom name that should be used for the chunk when calling `import(...)` function:
+
+```js
+import(/* webpackChunkName: "button" */ './Button');
+```
+
+This example will result in chunk being named `button`, so the filename with extension will be `button.chunk.bundle`.
+
+:::tip
+
+You can use `webpackChunkName` magic comment to provide your custom name, regardless of the `optimization.chunkIds` option.
+`webpackChunkName` will always take precedence.
+
+:::
+
+## Remote chunks
+
+By default all chunks are remote chunks, meaning they are not bundled into the application and will be downloaded from the remote location (usually the Internet) on demand.
+This helps with reducing the initial application size, especially if you have logic or features that only a subset of users will use - it doesn't make sense for everyone else
+to always have to download the code (together with the application) they won't need.
+
+All remote chunks are stored under `<projectRoot>/build/output/<platform>/remotes` by default, for example if `button.chunk.bundle` is a remote chunk, it will be stored under:
+`<projectRoot>/build/output/ios/remotes/button.chunk.bundle` for iOS.
+
+You can customize this by providing [`extraChunks`](../api/repack/interfaces/plugins.OutputPluginConfig#extrachunks) to [`RepackPlugin`](../api/repack/classes/RepackPlugin) or [`OutputPlugin`](../api/repack/classes/plugins.OutputPlugin) (if you're not using `RepackPlugin`):
+
+```js
+/* ... */
+
+export default (env) => {
+  /* ... */
+
+  return {
+    /* ... */
+
+    plugins: [
+      new Repack.RepackPlugin({
+        /* ... */
+
+        extraChunks: [
+          {
+            test: /.*/,
+            type: 'remote',
+            outputPath: path.join('my/custom/path'),
+          },
+        ],
+      }),
+    ],
+  };
+};
+```
+
+This example, will mark all chunks as remote ones and store them under `<projectRoot>/my/custom/path`.
+
+If `outputPath` in `extraChunks` is a relative path, it will be joined with the value of `context` property, which is set to root directory of your project by default.
+You can also provide an absolute path, in which case, it won't be modified in any way and used as is.
+
+:::tip
+
+You can provide multiple `type: 'remote'` specs - see [Advanced example](#advanced-example) for more info.
+
+:::
+
+## Local chunks
+
+In some situations, having chunks as remote ones is not ideal. For example, if you know that majority of the users will need a specific chunk you can mark it as local.
+
+Local chunks will always be included in the final application (`.ipa` or `.apk`) file alongside main bundle. This can save mobile data usage and make your application feel
+faster (in cases where network connection is degraded), but you will still benefit from improved startup, because the JavaScript engine will defer parsing and evaluation of
+local chunks until they are actually needed.
+
+:::tip
+
+If you're using Hermes and you compile your code into bytecode bundles, it's better __not__ to use local chunks and instead make the code a part of the main bundle.
+
+Using __local__ chunks with Hermes and bytecode bundles, will likely result __in worse performance__.
+
+:::
+
+You can customize which chunk should be local by providing [`extraChunks`](../api/repack/interfaces/plugins.OutputPluginConfig#extrachunks) option in [`RepackPlugin`](../api/repack/classes/RepackPlugin) or [`OutputPlugin`](../api/repack/classes/plugins.OutputPlugin) (if you're not using `RepackPlugin`) configuration:
+
+```js
+/* ... */
+
+export default (env) => {
+  /* ... */
+
+  return {
+    /* ... */
+
+    plugins: [
+      new Repack.RepackPlugin({
+        /* ... */
+
+        extraChunks: [
+          {
+            include: /^.+\.local$/,
+            type: 'local',
+          },
+          {
+            // IMPORTANT!
+            exclude: /^.+\.local$/,
+            type: 'remote',
+            outputPath: path.join('build/output', platform, 'remote'), // Default path
+          },
+        ],
+      }),
+    ],
+  };
+};
+```
+
+The example above will make all chunks matching the RegExp `/^.+\.local$/` a local chunks, for example `student.local` (`student.local.chunk.bundle`) will be a local chunk, whereas everything else will become a remote.
+
+:::warning
+
+Specifying `extraChunks` will override any defaults - you must configure `remote` chunks yourself as well, otherwise they won't be stored anywhere!
+
+:::
+
+## Advanced example
+
+You can mix multiple `type: 'local'` and `type: 'remote'` specs using `test`, `include` and `exclude` to match different chunks:
+
+```js
+/* ... */
+
+export default (env) => {
+  /* ... */
+
+  return {
+    /* ... */
+
+    plugins: [
+      new Repack.RepackPlugin({
+        /* ... */
+
+        extraChunks: [
+          {
+            // Make all student related chunks local.
+            include: ['student', /^student-.+$/],
+            type: 'local',
+          },
+          {
+            // Anything not student related should be remote and stored under
+            // `<projectRoot>/build/output/<platform>/remotes/core`.
+            exclude: /^student-.+$/,
+            type: 'remote',
+            outputPath: path.join('build/output', platform, 'remotes/core'),
+          },
+          {
+            // All teacher related chunks should be remote and stored under
+            // `<projectRoot>/build/output/<platform>/remotes/teacher`.
+            test: /^teacher.*$/,
+            type: 'remote',
+            outputPath: path.join('build/output', platform, 'remotes/teacher'),
+          },
+        ],
+      }),
+    ],
+  };
+};
+```
+
+Use the table below for examples, how the config above would treat different chunks:
+
+| Name                   | `type`   | `outputPath`                                            |
+|------------------------|----------|---------------------------------------------------------|
+| `student`              | `local`  | -                                                       |
+| `student-extensions`   | `local`  | -                                                       |
+| `components`           | `remote` | `<projectRoot>/build/output/<platform>/remotes/core`    |
+| `utils`                | `remote` | `<projectRoot>/build/output/<platform>/remotes/core`    |
+| `teacher`              | `remote` | `<projectRoot>/build/output/<platform>/remotes/teacher` |
+| `teacher-affiliations` | `remote` | `<projectRoot>/build/output/<platform>/remotes/teacher` |
+
+:::tip
+
+`test`, `include` and `exclude` properties behave in the same way as those in [Webpack's loader rules](https://webpack.js.org/configuration/module/#rule-conditions):
+
+- `test: string | RegExp | Array<string | RegExp>` must match if specified
+- `include: string | RegExp | Array<string | RegExp>` must match if specified
+- `exclude: string | RegExp | Array<string | RegExp>` must __not__ match if specified
+
+:::
+

--- a/website/docs/code-splitting/usage.md
+++ b/website/docs/code-splitting/usage.md
@@ -137,7 +137,7 @@ function App() {
 ```
 
 For each file in the dynamic `import(...)` function a new chunk will be created - those chunks will
-be a remote chunks by default.
+be remote chunks by default.
 
 :::tip
 

--- a/website/docs/code-splitting/usage.md
+++ b/website/docs/code-splitting/usage.md
@@ -137,12 +137,13 @@ function App() {
 ```
 
 For each file in the dynamic `import(...)` function a new chunk will be created - those chunks will
-be a remote chunks by default and they will be copied to `<projectRoot>/build/<platform>/remote` by
-default. All chunks in this directory should be uploaded to the remote server or a CDN.
+be a remote chunks by default.
 
-You can change this directory using
-[`remoteChunksOutput`](../api/repack/interfaces/plugins.OutputPluginConfig#remotechunksoutput)
-in [`RepackPlugin`](../api/repack/classes/RepackPlugin) or [`OutputPlugin`](../api/repack/classes/plugins.OutputPlugin) configuration.
+:::tip
+
+You can learn more about local and remote chunks in the dedicated [Local vs Remote chunks guide](./local-vs-remote-chunks).
+
+:::
 
 :::tip
 

--- a/website/package.json
+++ b/website/package.json
@@ -10,7 +10,7 @@
     "start": "yarn copy-api-docs && docusaurus start",
     "export": "yarn copy-api-docs && docusaurus build",
     "diff:v1-v2": "git diff origin/nativepack:templates/webpack.config.js origin/2.x:templates/webpack.config.js > static/diffs/repack_v1-v2.diff",
-    "diff:v2-v3": "git diff origin/2.x:templates/webpack.config.js origin/v3:templates/webpack.config.js > static/diffs/repack_v2-v3.diff"
+    "diff:v2-v3": "git diff origin/2.x:templates/webpack.config.js origin/v3:templates/webpack.config.cjs > static/diffs/repack_v2-v3.diff"
   },
   "dependencies": {
     "@docusaurus/core": "^2.0.0-beta.21",

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -36,6 +36,7 @@ module.exports = {
             'code-splitting/usage',
             'code-splitting/glossary',
             'code-splitting/guide-async-chunks',
+            'code-splitting/local-vs-remote-chunks',
             'code-splitting/caching-versioning',
             'code-splitting/react-navigation',
             'code-splitting/code-push',

--- a/website/static/diffs/repack_v2-v3.diff
+++ b/website/static/diffs/repack_v2-v3.diff
@@ -1,8 +1,17 @@
-diff --git a/templates/webpack.config.js b/templates/webpack.config.js
-index 6ff525d..c5dba19 100644
+diff --git a/templates/webpack.config.js b/templates/webpack.config.cjs
+index 6ff525d..9957a93 100644
 --- a/templates/webpack.config.js
-+++ b/templates/webpack.config.js
-@@ -12,292 +12,288 @@ const ReactNative = require('@callstack/repack');
++++ b/templates/webpack.config.cjs
+@@ -1,7 +1,6 @@
+ const path = require('path');
+-const webpack = require('webpack');
+ const TerserPlugin = require('terser-webpack-plugin');
+-const ReactNative = require('@callstack/repack');
++const Repack = require('@callstack/repack');
+ 
+ /**
+  * More documentation, installation, usage, motivation and differences with Metro is available at:
+@@ -12,292 +11,224 @@ const ReactNative = require('@callstack/repack');
   */
  
  /**
@@ -36,6 +45,9 @@ index 6ff525d..c5dba19 100644
 +    platform,
 +    minimize = mode === 'production',
 +    devServer = undefined,
++    bundleFilename = undefined,
++    sourceMapFilename = undefined,
++    assetsPath = undefined,
 +    reactNativePath = require.resolve('react-native'),
 +  } = env;
  
@@ -47,10 +59,7 @@ index 6ff525d..c5dba19 100644
 -const minimize = ReactNative.isMinimizeEnabled({ fallback: !dev });
 -const devServer = ReactNative.getDevServerOptions();
 -const reactNativePath = ReactNative.getReactNativePath();
-+  if (!platform) {
-+    throw new Error('Missing platform');
-+  }
- 
+-
 -/**
 - * Depending on your Babel configuration you might want to keep it.
 - * If you don't use `env` in your Babel config, you can remove it.
@@ -60,7 +69,10 @@ index 6ff525d..c5dba19 100644
 - * in development mode by Babel.
 - */
 -process.env.BABEL_ENV = mode;
--
++  if (!platform) {
++    throw new Error('Missing platform');
++  }
+ 
 -/**
 - * Webpack configuration.
 - */
@@ -154,7 +166,7 @@ index 6ff525d..c5dba19 100644
 -          },
 -        },
 +    entry: [
-+      ...ReactNative.getInitializationEntries(reactNativePath, {
++      ...Repack.getInitializationEntries(reactNativePath, {
 +        hmr: devServer && devServer.hmr,
        }),
 +      entry,
@@ -168,7 +180,7 @@ index 6ff525d..c5dba19 100644
 +       * convention and some 3rd-party libraries that specify `react-native` field
 +       * in their `package.json` might not work correctly.
 +       */
-+      ...ReactNative.getResolveOptions(platform),
++      ...Repack.getResolveOptions(platform),
 +
 +      /**
 +       * Uncomment this to ensure all `react-native*` imports will resolve to the same React Native
@@ -184,16 +196,14 @@ index 6ff525d..c5dba19 100644
 +     * It's recommended to leave it as it is unless you know what you're doing.
 +     * By default Webpack will emit files into the directory specified under `path`. In order for the
 +     * React Native app use them when bundling the `.ipa`/`.apk`, they need to be copied over with
-+     * `ReactNative.OutputPlugin`, which is configured by default.
++     * `Repack.OutputPlugin`, which is configured by default inside `Repack.RepackPlugin`.
 +     */
 +    output: {
 +      clean: true,
-+      path: path.join(__dirname, 'build', platform),
++      path: path.join(dirname, 'build/generated', platform),
 +      filename: 'index.bundle',
 +      chunkFilename: '[name].chunk.bundle',
-+      publicPath: ReactNative.getPublicPath(devServer),
-+      hotUpdateChunkFilename: `[id].[fullhash].hot-update.${platform}.js`,
-+      hotUpdateMainFilename: `[runtime].[fullhash].hot-update.${platform}.json`,
++      publicPath: Repack.getPublicPath({ platform, devServer }),
 +    },
      /**
 -     * This rule will process all React Native related dependencies with Babel.
@@ -297,16 +307,65 @@ index 6ff525d..c5dba19 100644
            },
          },
 -      },
--      /**
++        /**
++         * This loader handles all static assets (images, video, audio and others), so that you can
++         * use (reference) them inside your application.
++         *
++         * If you wan to handle specific asset type manually, filter out the extension
++         * from `ASSET_EXTENSIONS`, for example:
++         * ```
++         * Repack.ASSET_EXTENSIONS.filter((ext) => ext !== 'svg')
++         * ```
++         */
++        {
++          test: Repack.getAssetExtensionsRegExp(
++            Repack.ASSET_EXTENSIONS.filter((ext) => ext !== 'svg')
++          ),
++          use: {
++            loader: '@callstack/repack/assets-loader',
++            options: {
++              platform,
++              devServerEnabled: Boolean(devServer),
++              /**
++               * Defines which assets are scalable - which assets can have
++               * scale suffixes: `@1x`, `@2x` and so on.
++               * By default all images are scalable.
++               */
++              scalableAssetExtensions: Repack.SCALABLE_ASSETS,
++            },
++          },
++        },
++        {
++          test: /\.svg$/,
++          use: [
++            {
++              loader: '@svgr/webpack',
++              options: {
++                native: true,
++                dimensions: false,
++              },
++            },
++          ],
++        },
++      ],
++    },
++    plugins: [
+       /**
 -       * This loader handles all static assets (images, video, audio and others), so that you can
 -       * use (reference) them inside your application.
--       *
++       * Configure other required and additional plugins to make the bundle
++       * work in React Native and provide good development experience with
++       * sensible defaults.
+        *
 -       * If you wan to handle specific asset type manually, filter out the extension
 -       * from `ASSET_EXTENSIONS`, for example:
 -       * ```
 -       * ReactNative.ASSET_EXTENSIONS.filter((ext) => ext !== 'svg')
 -       * ```
--       */
++       * `Repack.RepackPlugin` provides some degree of customization, but if you
++       * need more control, you can replace `Repack.RepackPlugin` with plugins
++       * from `Repack.plugins`.
+        */
 -      {
 -        test: ReactNative.getAssetExtensionsRegExp(
 -          ReactNative.ASSET_EXTENSIONS
@@ -322,36 +381,20 @@ index 6ff525d..c5dba19 100644
 -             * By default all images are scalable.
 -             */
 -            scalableAssetExtensions: ReactNative.SCALABLE_ASSETS,
-+        /**
-+         * This loader handles all static assets (images, video, audio and others), so that you can
-+         * use (reference) them inside your application.
-+         *
-+         * If you wan to handle specific asset type manually, filter out the extension
-+         * from `ASSET_EXTENSIONS`, for example:
-+         * ```
-+         * ReactNative.ASSET_EXTENSIONS.filter((ext) => ext !== 'svg')
-+         * ```
-+         */
-+        {
-+          test: ReactNative.getAssetExtensionsRegExp(
-+            ReactNative.ASSET_EXTENSIONS.filter((ext) => ext !== 'svg')
-+          ),
-+          use: {
-+            loader: '@callstack/repack/assets-loader',
-+            options: {
-+              platform,
-+              devServerEnabled: Boolean(devServer),
-+              /**
-+               * Defines which assets are scalable - which assets can have
-+               * scale suffixes: `@1x`, `@2x` and so on.
-+               * By default all images are scalable.
-+               */
-+              scalableAssetExtensions: ReactNative.SCALABLE_ASSETS,
-+            },
-           },
+-          },
++      new Repack.RepackPlugin({
++        context,
++        mode,
++        platform,
++        devServer,
++        output: {
++          bundleFilename,
++          sourceMapFilename,
++          assetsPath,
          },
 -      },
--    ],
++      }),
+     ],
 -  },
 -  plugins: [
 -    /**
@@ -369,31 +412,14 @@ index 6ff525d..c5dba19 100644
 -    new ReactNative.AssetsResolverPlugin({
 -      platform,
 -    }),
-+      ],
-+    },
-+    plugins: [
-+      /**
-+       * Various libraries like React and React rely on `process.env.NODE_ENV` / `__DEV__`
-+       * to distinguish between production and development
-+       */
-+      new webpack.DefinePlugin({
-+        __DEV__: JSON.stringify(mode === 'development'),
-+      }),
- 
+-
 -    /**
 -     * React Native environment (globals and APIs that are available inside JS) differ greatly
 -     * from Web or Node.js. This plugin ensures everything is setup correctly so that features
 -     * like Hot Module Replacement will work correctly.
 -     */
 -    new ReactNative.TargetPlugin(),
-+      /**
-+       * This plugin makes sure the resolution for assets like images works with scales,
-+       * for example: `image@1x.png`, `image@2x.png`.
-+       */
-+      new ReactNative.AssetsResolverPlugin({
-+        platform,
-+      }),
- 
+-
 -    /**
 -     * By default Webpack will emit files into `output.path` directory (eg: `<root>/build/ios`),
 -     * but in order to for the React Native application to include those files (or a subset of those)
@@ -407,13 +433,68 @@ index 6ff525d..c5dba19 100644
 -      devServerEnabled: devServer.enabled,
 -      remoteChunksOutput: path.join(__dirname, 'build', platform, 'remote'),
 -    }),
-+      /**
-+       * React Native environment (globals and APIs that are available inside JS) differ greatly
-+       * from Web or Node.js. This plugin ensures everything is setup correctly so that features
-+       * like Hot Module Replacement will work correctly.
-+       */
-+      new ReactNative.TargetPlugin(),
- 
+-
 -    /**
 -     * Runs development server when running with React Native CLI start command or if `devServer`
--     * was provided 
+-     * was provided as s `fallback`.
+-     */
+-    new ReactNative.DevServerPlugin({
+-      platform,
+-      ...devServer,
+-    }),
+-
+-    /**
+-     * Configures Source Maps for the main bundle based on CLI options received from
+-     * React Native CLI or fallback value..
+-     * It's recommended to leave the default values, unless you know what you're doing.
+-     * Wrong options might cause symbolication of stack trace inside React Native app
+-     * to fail - the app will still work, but you might not get Source Map support.
+-     */
+-    new webpack.SourceMapDevToolPlugin({
+-      test: /\.(js)?bundle$/,
+-      exclude: /\.chunk\.(js)?bundle$/,
+-      filename: '[file].map',
+-      append: `//# sourceMappingURL=[url]?platform=${platform}`,
+-      /**
+-       * Uncomment for faster builds but less accurate Source Maps
+-       */
+-      // columns: false,
+-    }),
+-
+-    /**
+-     * Configures Source Maps for any additional chunks.
+-     * It's recommended to leave the default values, unless you know what you're doing.
+-     * Wrong options might cause symbolication of stack trace inside React Native app
+-     * to fail - the app will still work, but you might not get Source Map support.
+-     */
+-    new webpack.SourceMapDevToolPlugin({
+-      test: /\.(js)?bundle$/,
+-      include: /\.chunk\.(js)?bundle$/,
+-      filename: '[file].map',
+-      append: `//# sourceMappingURL=[url]?platform=${platform}`,
+-      /**
+-       * Uncomment for faster builds but less accurate Source Maps
+-       */
+-      // columns: false,
+-    }),
+-
+-    /**
+-     * Logs messages and progress.
+-     * It's recommended to always have this plugin, otherwise it might be difficult
+-     * to figure out what's going on when bundling or running development server.
+-     */
+-    new ReactNative.LoggerPlugin({
+-      platform,
+-      devServerEnabled: devServer.enabled,
+-      output: {
+-        console: true,
+-        /**
+-         * Uncomment for having logs stored in a file to this specific compilation.
+-         * Compilation for each platform gets it's own log file.
+-         */
+-        // file: path.join(__dirname, `${mode}.${platform}.log`),
+-      },
+-    }),
+-  ],
++  };
+ };


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

- Unify output paths in Webpack config
- Add Local vs Remote chunks guide

No changeset is necessary.