### PR TITLE
fix(repack): disable CJS tranform for client's code

### DIFF
--- a/packages/repack/babel.config.js
+++ b/packages/repack/babel.config.js
@@ -7,7 +7,7 @@ module.exports = {
       comments: false,
     },
     {
-      exclude: ['./src/**/runtime/implementation'],
+      exclude: ['./src/**/runtime/implementation', './src/modules'],
       presets: [
         [
           '@babel/preset-env',

--- a/packages/repack/babel.config.js
+++ b/packages/repack/babel.config.js
@@ -1,3 +1,21 @@
+const defaultConfig = {
+  presets: [
+    [
+      '@babel/preset-env',
+      {
+        targets: {
+          node: 14,
+        },
+        // Disable CJS transform and add it manually.
+        // Otherwise it will replace `import(...)` with `require(...)`, which
+        // is not what we want.
+        modules: false,
+      },
+    ],
+  ],
+  plugins: ['@babel/plugin-transform-modules-commonjs'],
+};
+
 module.exports = {
   presets: ['@babel/preset-typescript'],
   plugins: ['@babel/plugin-proposal-export-namespace-from'],
@@ -8,21 +26,11 @@ module.exports = {
     },
     {
       exclude: ['./src/**/runtime/implementation', './src/modules'],
-      presets: [
-        [
-          '@babel/preset-env',
-          {
-            targets: {
-              node: 14,
-            },
-            // Disable CJS transform and add it manually.
-            // Otherwise it will replace `import(...)` with `require(...)`, which
-            // is not what we want.
-            modules: false,
-          },
-        ],
-      ],
-      plugins: ['@babel/plugin-transform-modules-commonjs'],
+      ...defaultConfig,
     },
   ],
+  env: {
+    // Transform everything in `test` environment, so unit test can pass.
+    test: defaultConfig,
+  },
 };


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

`@callstack/repack/client`'s code should not be transformed more that it's necessary and it it should retain ESM import and exports - this is necessary so that Webpack can do tree shaking and esbuild-loader/swc-loader can properly transpile the code.

This is an implementation detail and should not affect users in any way - no changeset is necessary.