### PR TITLE
fix(dev-server): prevent logger from sending to non-existent API WS server

### DIFF
--- a/.changeset/wet-tigers-deliver.md
+++ b/.changeset/wet-tigers-deliver.md
@@ -1,0 +1,5 @@
+---
+"@callstack/repack-dev-server": patch
+---
+
+Prevent server logger from emitting log to API WS server before WS servers are created.

--- a/packages/dev-server/src/createServer.ts
+++ b/packages/dev-server/src/createServer.ts
@@ -28,7 +28,7 @@ export async function createServer(config: Server.Config) {
         write: (chunk, _encoding, callback) => {
           const log = JSON.parse(chunk.toString());
           delegate?.logger.onMessage(log);
-          instance.wss.apiServer.send(log);
+          instance.wss?.apiServer.send(log);
           callback();
         },
       }),


### PR DESCRIPTION


<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

Prevent server logger from emitting log to API WS server before WS servers are created.

### Test plan

Run dev server - it should not crash.
