### PR TITLE
fix: prevent importModule from crashing

### DIFF
--- a/.changeset/strange-shirts-guess.md
+++ b/.changeset/strange-shirts-guess.md
@@ -4,4 +4,4 @@
 
 ### Fix `importModule` crashing the app
 
-Prevent `importModul`e from crashing with _cannot read property __isInitialized of undefined_.
+Prevent `importModule` from crashing with _cannot read property __isInitialized of undefined_.

--- a/.changeset/strange-shirts-guess.md
+++ b/.changeset/strange-shirts-guess.md
@@ -1,0 +1,7 @@
+---
+"@callstack/repack": patch
+---
+
+### Fix `importModule` crashing the app
+
+Prevent `importModul`e from crashing with _cannot read property __isInitialized of undefined_.

--- a/packages/repack/src/modules/ScriptManager/federated.ts
+++ b/packages/repack/src/modules/ScriptManager/federated.ts
@@ -264,12 +264,15 @@ export namespace Federated {
       __webpack_share_scopes__[scope].__isInitialized = true;
     }
 
-    const container = self[containerName];
-
-    if (!container) {
+    // Do not use `const container = self[containerName];` here. Once container is loaded
+    // `container` reference is not updated, so `container.__isInitialized`
+    // will crash the application, because of reading property from `undefined`.
+    if (!self[containerName]) {
       // Download and execute container
       await ScriptManager.shared.loadScript(containerName);
     }
+
+    const container = self[containerName];
 
     if (!container.__isInitialized) {
       container.__isInitialized = true;


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

Prevent `importModule` from crashing with `cannot read property __isInitialized of undefined`.


<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
