### PR TITLE
feat(repack): add ModuleFederationPlugin with @ support

### DIFF
--- a/.changeset/sweet-pets-scream.md
+++ b/.changeset/sweet-pets-scream.md
@@ -1,0 +1,51 @@
+---
+"@callstack/repack": minor
+---
+
+__Custom Module Federation plugin - `Repack.plugins.ModuleFederationPlugin`__
+
+Add custom `ModuleFederationPlugin` plugin with defaults for React Native, automatic `remotes`
+conversion to `promise new Promise` (via `Federated.createRemote`) and support for `remote@location` syntax.
+
+For example, instead of using `webpack.container.ModuleFederationPlugin`, you can now use:
+```js
+import * as Repack from '@callstack/repack';
+
+new Repack.plugins.ModuleFederationPlugin({
+  name: 'host',
+});
+
+new Repack.plugins.ModuleFederationPlugin({
+  name: 'app1',
+  remotes: {
+    module1: 'module1@https://example.com/module1.container.bundle',
+  },
+});
+
+new Repack.plugins.ModuleFederationPlugin({
+  name: 'app2',
+  remotes: {
+    module1: 'module1@https://example.com/module1.container.bundle',
+    module2: 'module1@dynamic',
+  },
+});
+```
+
+__Priority for resolvers in `ScriptManager`__
+
+To support `remote@location` in `Repack.plugins.ModuleFederationPlugin`/`Federated.createRemote`, when adding
+a resolver using `ScriptManager.shared.addResolver` you can optionally specify priority of that resolver.
+By default all resolvers have priority of `2`.
+
+When using `remote@location` syntax with valid URL as `location` (eg `module1@https://example.com/module1.container.bundle`), a default resolver for the container and it's chunks will be added with priority `0`.
+If you want to overwrite it, add new resolver with higher priority.
+
+To specify custom priority use 2nd options argument:
+```js
+import { ScriptManager } from '@callstack/repack/client';
+
+ScriptManager.shared.addResolver(async (scriptId, caller) => {
+  // ...
+}, { priority: 1 }); // Default priority is `2`.
+```
+

--- a/packages/repack/src/webpack/federated.ts
+++ b/packages/repack/src/webpack/federated.ts
@@ -6,9 +6,83 @@ import dedent from 'dedent';
  */
 export namespace Federated {
   /**
+   * Predefined options for shared `react` dependency.
+   *
+   * @example Basic example.
+   * ```js
+   * import * as React from '@callstack/repack';
+   *
+   * new Repack.plugins.ModuleFederationPlugin({
+   *   // ...
+   *   shared: {
+   *     react: Repack.Federated.SHARED_REACT,
+   *   }
+   * });
+   * ```
+   *
+   * @example Example with spread and additional options.
+   * ```js
+   * import * as React from '@callstack/repack';
+   *
+   * new Repack.plugins.ModuleFederationPlugin({
+   *   // ...
+   *   shared: {
+   *     react: {
+   *       ...Repack.Federated.SHARED_REACT,
+   *       // additional options
+   *     }
+   *   }
+   * });
+   * ```
+   */
+  export const SHARED_REACT = {
+    singleton: true,
+    eager: true,
+  };
+
+  /**
+   * Predefined options for shared `react-native` dependency.
+   *
+   * @example Basic example.
+   * ```js
+   * import * as React from 'repack';
+   *
+   * new Repack.plugins.ModuleFederationPlugin({
+   *   // ...
+   *   shared: {
+   *     'react-native': Repack.Federated.SHARED_REACT,
+   *   }
+   * });
+   * ```
+   *
+   * @example Example with spread and additional options.
+   * ```js
+   * import * as React from 'repack';
+   *
+   * new Repack.plugins.ModuleFederationPlugin({
+   *   // ...
+   *   shared: {
+   *     'react-native': {
+   *       ...Repack.Federated.SHARED_REACT_NATIVE,
+   *       // additional options
+   *     }
+   *   }
+   * });
+   * ```
+   */
+  export const SHARED_REACT_NATIVE = {
+    singleton: true,
+    eager: true,
+  };
+
+  /**
    * Creates JavaScript loading code for the given Module Federation remote
    * allowing to import that remote without creating an async boundary, but with
    * simple import statement, eg: `import MyComponent from 'my-remote/MyComponent';`.
+   *
+   * `Federated.createRemote` adds a default resolver for container and it's chunks
+   * with priority `0`, if you provide URL after the `@`.
+   * If `dynamic` (eg `module1@dynamic`) is provided, no default resolver will be added.
    *
    * __This function should be used only when using `webpack.container.ModuleFederationPlugin`.__
    * For `Repack.plugins.ModuleFederationPlugin`, `Federated.createRemote` is used under the hood.

--- a/packages/repack/src/webpack/federated.ts
+++ b/packages/repack/src/webpack/federated.ts
@@ -173,7 +173,6 @@ export namespace Federated {
       if (self.${remoteName}) {
         return resolveRemote();
       }
-      
       var scriptManager = __webpack_require__.repack.shared.scriptManager;
 
       ${defaultResolver}

--- a/packages/repack/src/webpack/plugins/ManifestPlugin.ts
+++ b/packages/repack/src/webpack/plugins/ManifestPlugin.ts
@@ -1,6 +1,9 @@
 import webpack from 'webpack';
 import type { WebpackPlugin } from '../../types';
 
+/**
+ * @category Webpack Plugin
+ */
 export class ManifestPlugin implements WebpackPlugin {
   /**
    * Apply the plugin.

--- a/packages/repack/src/webpack/plugins/ModuleFederationPlugin.ts
+++ b/packages/repack/src/webpack/plugins/ModuleFederationPlugin.ts
@@ -1,0 +1,98 @@
+import { Compiler, container } from 'webpack';
+import type { WebpackPlugin } from '../../types';
+import { Federated } from '../federated';
+
+type ModuleFederationPluginOptions =
+  typeof container.ModuleFederationPlugin extends {
+    new (options: infer O): InstanceType<
+      typeof container.ModuleFederationPlugin
+    >;
+  }
+    ? O
+    : never;
+
+type ExtractRemotesObject<T> = T extends {}
+  ? T extends Array<any>
+    ? never
+    : T
+  : never;
+
+type RemotesObject = ExtractRemotesObject<
+  ModuleFederationPluginOptions['remotes']
+>;
+
+export interface ModuleFederationPluginConfig
+  extends ModuleFederationPluginOptions {}
+
+export const SHARED_REACT = {
+  react: {
+    singleton: true,
+    eager: true,
+  },
+};
+
+export const SHARED_REACT_NATIVE = {
+  'react-native': {
+    singleton: true,
+    eager: true,
+  },
+};
+
+export class ModuleFederationPlugin implements WebpackPlugin {
+  constructor(private config: ModuleFederationPluginConfig) {}
+
+  private replaceRemotes<T extends string | string[] | RemotesObject>(
+    remote: T
+  ): T {
+    if (typeof remote === 'string') {
+      return remote.startsWith('promise new Promise')
+        ? remote
+        : (Federated.createRemote(remote) as T);
+    }
+
+    if (Array.isArray(remote)) {
+      return remote.map((remoteItem) => this.replaceRemotes(remoteItem)) as T;
+    }
+
+    const replaced = {} as RemotesObject;
+    for (const key in remote as RemotesObject) {
+      const value = remote[key];
+      if (typeof value === 'string' || Array.isArray(value)) {
+        replaced[key] = this.replaceRemotes(value);
+      } else {
+        replaced[key] = {
+          ...value,
+          external: this.replaceRemotes(value.external),
+        };
+      }
+    }
+
+    return replaced as T;
+  }
+
+  apply(compiler: Compiler) {
+    const remotes = Array.isArray(this.config.remotes)
+      ? this.config.remotes.map((remote) => this.replaceRemotes(remote))
+      : this.replaceRemotes(this.config.remotes ?? {});
+
+    new container.ModuleFederationPlugin({
+      ...this.config,
+      filename:
+        this.config.filename ?? this.config.exposes
+          ? `${this.config.name}.container.bundle`
+          : undefined,
+      library: this.config.exposes
+        ? {
+            name: this.config.name,
+            type: 'self',
+            ...this.config.library,
+          }
+        : undefined,
+      shared: this.config.shared ?? {
+        ...SHARED_REACT,
+        ...SHARED_REACT_NATIVE,
+      },
+      remotes,
+    }).apply(compiler);
+  }
+}

--- a/packages/repack/src/webpack/plugins/__tests__/ModuleFederationPlugin.test.ts
+++ b/packages/repack/src/webpack/plugins/__tests__/ModuleFederationPlugin.test.ts
@@ -1,0 +1,100 @@
+import { container } from 'webpack';
+import { ModuleFederationPlugin } from '../ModuleFederationPlugin';
+
+jest.mock('webpack', () => ({
+  container: {
+    ModuleFederationPlugin: jest.fn().mockReturnValue({
+      apply: jest.fn(),
+    }),
+  },
+}));
+
+describe('ModuleFederationPlugin', () => {
+  it('should replace RemotesObject remotes', () => {
+    new ModuleFederationPlugin({
+      remotes: {
+        external: 'external1@dynamic',
+      },
+    }).apply(jest.fn() as any);
+
+    let config = (container.ModuleFederationPlugin as jest.Mock).mock
+      .calls[0][0];
+    expect(config.remotes.external).toMatch('promise new Promise');
+    (container.ModuleFederationPlugin as jest.Mock).mockClear();
+
+    new ModuleFederationPlugin({
+      remotes: {
+        external: ['external1@dynamic', 'external2@dynamic'],
+      },
+    }).apply(jest.fn() as any);
+
+    config = (container.ModuleFederationPlugin as jest.Mock).mock.calls[0][0];
+    expect(config.remotes.external[0]).toMatch('promise new Promise');
+    expect(config.remotes.external[1]).toMatch('promise new Promise');
+    (container.ModuleFederationPlugin as jest.Mock).mockClear();
+  });
+
+  it('should replace string[] remotes', () => {
+    new ModuleFederationPlugin({
+      remotes: ['remote1@dynamic', 'remote2@dynamic'],
+    }).apply(jest.fn() as any);
+
+    const config = (container.ModuleFederationPlugin as jest.Mock).mock
+      .calls[0][0];
+    expect(config.remotes[0]).toMatch('promise new Promise');
+    expect(config.remotes[1]).toMatch('promise new Promise');
+    (container.ModuleFederationPlugin as jest.Mock).mockClear();
+  });
+
+  it('should replace RemotesObject[] remotes', () => {
+    new ModuleFederationPlugin({
+      remotes: [
+        {
+          external: 'external1@dynamic',
+        },
+        {
+          external: ['external2@dynamic', 'external3@dynamic'],
+        },
+      ],
+    }).apply(jest.fn() as any);
+
+    const config = (container.ModuleFederationPlugin as jest.Mock).mock
+      .calls[0][0];
+    expect(config.remotes[0].external).toMatch('promise new Promise');
+    expect(config.remotes[1].external[0]).toMatch('promise new Promise');
+    expect(config.remotes[1].external[1]).toMatch('promise new Promise');
+    (container.ModuleFederationPlugin as jest.Mock).mockClear();
+  });
+
+  it('should not add default resolver for remote', () => {
+    new ModuleFederationPlugin({
+      remotes: {
+        app1: 'app1@dynamic',
+      },
+    }).apply(jest.fn() as any);
+    const config = (container.ModuleFederationPlugin as jest.Mock).mock
+      .calls[0][0];
+    expect(config.remotes.app1).toMatch('promise new Promise');
+    expect(config.remotes.app1).not.toMatch('scriptManager.addResolver');
+    (container.ModuleFederationPlugin as jest.Mock).mockClear();
+  });
+
+  it('should add default resolver for remote', () => {
+    new ModuleFederationPlugin({
+      remotes: {
+        app1: 'app1@http://localhost:6789/static/app1.container.bundle',
+      },
+    }).apply(jest.fn() as any);
+    const config = (container.ModuleFederationPlugin as jest.Mock).mock
+      .calls[0][0];
+    expect(config.remotes.app1).toMatch('promise new Promise');
+    expect(config.remotes.app1).toMatch('scriptManager.addResolver');
+    expect(config.remotes.app1).toMatch(
+      'http://localhost:6789/static/app1.container.bundle'
+    );
+    expect(config.remotes.app1).toMatch(
+      'http://localhost:6789/static/[name][ext]'
+    );
+    (container.ModuleFederationPlugin as jest.Mock).mockClear();
+  });
+});

--- a/packages/repack/src/webpack/plugins/index.ts
+++ b/packages/repack/src/webpack/plugins/index.ts
@@ -6,3 +6,4 @@ export * from './ManifestPlugin';
 export * from './OutputPlugin';
 export * from './ReactRefreshPlugin';
 export * from './RepackTargetPlugin';
+export * from './ModuleFederationPlugin';


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

Adds custom `ModuleFederationPlugin` to abstract platform (React Native) differences.

Related #199 

### Todo

- [x] Implementation
- [x] API comment docs
- [x] Module Federation guide update
- [x] Add changesets

### Test plan

- `module-federation` example should work: https://github.com/callstack/repack-examples/tree/repack-module-federation-plugin
