### PR TITLE
feat(assetLoader): support remote assets

### DIFF
--- a/packages/repack/src/loader-utils.d.ts
+++ b/packages/repack/src/loader-utils.d.ts
@@ -20,6 +20,7 @@ declare module 'loader-utils' {
   export interface LoaderContext {
     rootContext: string;
     resourcePath: string;
+    resourceQuery: string;
     fs: webpack.Compiler['inputFileSystem'];
     cacheable(flag?: boolean): void;
     async(): LoaderCallback | undefined;


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

Hi! I'm working for a project that is near to use this modification of the asset loader and wanted to contribute this back (so we avoid deviating from repack and using a custom loader). Keep in mind that while this work for us, some parts could be improved, so I wanted to open this early to get some feedback.

### Summary

<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->
Support the ability for a react-native app to load some assets (like png, jpgs) from a remote location (like a CDN) and reduce the bundle size of the app.


### Test plan

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
- [ ] Will update TesterApp to have a example of this feature
- [ ] Add example of the Image customSourceResolver & webpack config
