### PR TITLE
feat: Allow storing compilation stats in file

### DIFF
--- a/.changeset/loud-seas-drum.md
+++ b/.changeset/loud-seas-drum.md
@@ -1,0 +1,8 @@
+---
+"@callstack/repack": minor
+---
+
+Allow storing compilation stats.
+
+You can now run `webpack-bundle` with `--json <file> --stats <preset>` (like with `webpack-cli`) to store compilation stats in the specified file.
+Compilation stats can be used to analyze the bundle (e.g. with [`webpack-bundle-analyzer`](https://github.com/webpack-contrib/webpack-bundle-analyzer) or https://statoscope.tech/).

--- a/packages/repack/commands.js
+++ b/packages/repack/commands.js
@@ -75,7 +75,6 @@ module.exports = [
         name: '--stats <preset>',
         description:
           'It instructs Webpack on how to treat the stats e.g. normal',
-        default: 'none',
       }
     ),
     func: require('./dist/commands/bundle').bundle,

--- a/packages/repack/commands.js
+++ b/packages/repack/commands.js
@@ -65,7 +65,18 @@ module.exports = [
         name: '--verbose',
         description: 'Enables verbose logging',
       },
-      webpackConfigOption
+      webpackConfigOption,
+      {
+        name: '--json <statsFile>',
+        description: 'Stores stats in a file.',
+        parse: (val) => path.resolve(val),
+      },
+      {
+        name: '--stats <preset>',
+        description:
+          'It instructs Webpack on how to treat the stats e.g. normal',
+        default: 'none',
+      }
     ),
     func: require('./dist/commands/bundle').bundle,
   },

--- a/packages/repack/package.json
+++ b/packages/repack/package.json
@@ -59,6 +59,7 @@
   },
   "dependencies": {
     "@callstack/repack-dev-server": "^1.0.0",
+    "@discoveryjs/json-ext": "^0.5.7",
     "@pmmmwh/react-refresh-webpack-plugin": "^0.5.7",
     "colorette": "^1.2.2",
     "dedent": "^0.7.0",

--- a/packages/repack/src/commands/bundle.ts
+++ b/packages/repack/src/commands/bundle.ts
@@ -51,7 +51,6 @@ export async function bundle(
     webpackEnvOptions
   );
   const compiler = webpack(webpackConfig);
-  console.log(compiler.options.stats);
 
   return new Promise<void>((resolve, reject) => {
     compiler.run((error, stats) => {

--- a/packages/repack/src/commands/bundle.ts
+++ b/packages/repack/src/commands/bundle.ts
@@ -51,6 +51,7 @@ export async function bundle(
     webpackEnvOptions
   );
   const compiler = webpack(webpackConfig);
+  console.log(compiler.options.stats);
 
   return new Promise<void>((resolve, reject) => {
     compiler.run((error, stats) => {
@@ -65,8 +66,20 @@ export async function bundle(
         }
 
         if (args.json && stats !== undefined) {
-          console.log(`Writing '${args.stats}' compiler stats`);
-          const statsJson = stats.toJson(args.stats);
+          console.log(`Writing compiler stats`);
+
+          let statOptions: Parameters<typeof stats.toJson>[0];
+          if (args.stats !== undefined) {
+            statOptions = { preset: args.stats };
+          } else if (typeof compiler.options.stats === 'boolean') {
+            statOptions = compiler.options.stats
+              ? { preset: 'normal' }
+              : { preset: 'none' };
+          } else {
+            statOptions = compiler.options.stats;
+          }
+
+          const statsJson = stats.toJson(statOptions);
           // Stats can be fairly big at which point their JSON no longer fits into a single string.
           // Approach was copied from `webpack-cli`: https://github.com/webpack/webpack-cli/blob/c03fb03d0aa73d21f16bd9263fd3109efaf0cd28/packages/webpack-cli/src/webpack-cli.ts#L2471-L2482
           const outputStream = fs.createWriteStream(args.json);

--- a/packages/repack/src/types.ts
+++ b/packages/repack/src/types.ts
@@ -51,6 +51,7 @@ export interface CommonArguments {
 export interface BundleArguments extends CommonArguments {
   assetsDest?: string;
   entryFile: string;
+  json?: string;
   minify?: boolean;
   dev: boolean;
   bundleOutput: string;
@@ -58,6 +59,7 @@ export interface BundleArguments extends CommonArguments {
   sourcemapOutput?: string;
   // sourcemapSourcesRoot?: string;
   // sourcemapUseAbsolutePath: boolean;
+  stats?: string;
 }
 
 /**

--- a/packages/repack/src/webpack/plugins/LoggerPlugin.ts
+++ b/packages/repack/src/webpack/plugins/LoggerPlugin.ts
@@ -125,7 +125,9 @@ export class LoggerPlugin implements WebpackPlugin {
    */
   apply(compiler: webpack.Compiler) {
     // Make sure webpack-cli doesn't print stats by default.
-    compiler.options.stats = 'none';
+    if (compiler.options.stats === undefined) {
+      compiler.options.stats = 'none';
+    }
 
     if (this.config.devServerEnabled) {
       new webpack.ProgressPlugin((percentage, message, text) => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3696,6 +3696,7 @@ __metadata:
     "@babel/preset-typescript": ^7.17.12
     "@callstack/eslint-config": ^11.0.0
     "@callstack/repack-dev-server": ^1.0.0
+    "@discoveryjs/json-ext": ^0.5.7
     "@pmmmwh/react-refresh-webpack-plugin": ^0.5.7
     "@react-native-community/cli": 5.0.1-alpha.1
     "@react-native-community/cli-types": 5.0.1-alpha.1
@@ -4046,6 +4047,13 @@ __metadata:
   version: 0.5.3
   resolution: "@discoveryjs/json-ext@npm:0.5.3"
   checksum: fea319569f9894391ff1ddb5f59f9dfebe611ac202e7e97d9719ff9f7a726388e6a0a7e5ae8e54cf009ae1748269760d5842bfda5b9cbf834ceda28711baf89d
+  languageName: node
+  linkType: hard
+
+"@discoveryjs/json-ext@npm:^0.5.7":
+  version: 0.5.7
+  resolution: "@discoveryjs/json-ext@npm:0.5.7"
+  checksum: 2176d301cc258ea5c2324402997cf8134ebb212469c0d397591636cea8d3c02f2b3cf9fd58dcb748c7a0dade77ebdc1b10284fa63e608c033a1db52fddc69918
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

Allows creating JSON files of compilation stats that can be analyzed with https://statoscope.tech/
Command-line argumes take precedence over options in `webpack.config.js`

Copied behavior from webpack-cli: https://github.com/webpack/webpack-cli/blob/26ba6a82e7bc596e7fe48db9028f79e65e8131bc/packages/webpack-cli/src/webpack-cli.ts#L2291-L2299 

<details>
<summary>Based on this local patch</summary>

```diff
diff --git a/node_modules/@klapp/native/node_modules/@callstack/repack/commands.js b/node_modules/@klapp/native/node_modules/@callstack/repack/commands.js
index 8342509..b045590 100644
--- a/node_modules/@klapp/native/node_modules/@callstack/repack/commands.js
+++ b/node_modules/@klapp/native/node_modules/@callstack/repack/commands.js
@@ -65,7 +65,16 @@ module.exports = [
         name: '--verbose',
         description: 'Enables verbose logging',
       },
-      webpackConfigOption
+      webpackConfigOption,
+      {
+        name: '--json <statsFile>',
+        description: "TODO webpack json",
+        parse: (val) => path.resolve(val),
+      },
+      {
+        name: '--stats <preset>',
+        description: "TODO webpack json",
+      }
     ),
     func: require('./dist/commands/bundle').bundle,
   },
diff --git a/node_modules/@klapp/native/node_modules/@callstack/repack/dist/commands/bundle.js b/node_modules/@klapp/native/node_modules/@callstack/repack/dist/commands/bundle.js
index 276ca72..5a6e4d0 100644
--- a/node_modules/@klapp/native/node_modules/@callstack/repack/dist/commands/bundle.js
+++ b/node_modules/@klapp/native/node_modules/@callstack/repack/dist/commands/bundle.js
@@ -10,6 +10,8 @@ var _webpack = _interopRequireDefault(require("webpack"));
 var _env = require("../env");

 var _getWebpackConfigPath = require("./utils/getWebpackConfigPath");
+const fs = require('fs')
+const {stringifyStream} = require('@discoveryjs/json-ext')

 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }

@@ -45,11 +47,31 @@ function bundle(_, config, args) {
   }

   const compiler = (0, _webpack.default)(require(webpackConfigPath));
-  compiler.run(error => {
+  compiler.run((error, stats) => {
     if (error) {
       console.error(error);
       process.exit(2);
     }
+
+    if (args.json) {
+      console.log('Writing compiler stats', args.stats)
+      const statsJson = stats.toJson(args.stats)
+      const outputStream = fs.createWriteStream(args.json)
+
+      stringifyStream(statsJson).on(
+        'error', (error) => {
+          console.error(error);
+          process.exit(2);
+        }
+      ).pipe(outputStream).on(
+        'error', (error) => {
+          console.error(error);
+          process.exit(2);
+        }
+      ).on("close", () => {
+        console.log(`Wrote compiler stats to ${args.json}`)
+      })
+    }
   });
 }
 //# sourceMappingURL=bundle.js.map
```
</details>


### Test plan

- [x] Tested patch in Klarna mobile app
- [x] in `packages/TesterApp`: `yarn bundle --stats normal --json stats.json`:
     ```bash
     $ yarn bundle --stats normal --json stats.json
     ....
     webpack 5.50.0 compiled successfully in 24543 ms 
     Writing compiler stats
     Wrote compiler stats to /Users/sebastian.silbermann/repack/packages/TesterApp/stats.json
     ```
- [x] in `packages/TesterApp`: `yarn bundle --json stats.json` with `stats: { preset: 'normal' }` in `webpack.config.mjs`
- [x] CI (needs maintainer approval)
