### PR TITLE
fix: Exit with non-zero exit code if compilation has errors

### DIFF
--- a/.changeset/chilled-oranges-leave.md
+++ b/.changeset/chilled-oranges-leave.md
@@ -1,0 +1,5 @@
+---
+"@callstack/repack": patch
+---
+
+Exit with non-zero exit code if compilation has errors

--- a/packages/repack/src/commands/bundle.ts
+++ b/packages/repack/src/commands/bundle.ts
@@ -51,13 +51,18 @@ export async function bundle(
   const compiler = webpack(webpackConfig);
 
   return new Promise<void>((resolve, reject) => {
-    compiler.run((error) => {
+    compiler.run((error, stats) => {
       if (error) {
         reject();
         console.error(error);
         process.exit(2);
       } else {
-        resolve();
+        if (stats?.hasErrors()) {
+          reject();
+          process.exit(2);
+        } else {
+          resolve();
+        }
       }
     });
   });


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

Exit with non-zero exit code if compilation has errors

### Test plan

-  [x] CI
- [x] Tested in a local patch with the Klarna app
