### PR TITLE
fix: prevent removing envs

### DIFF
--- a/.changeset/gentle-jeans-film.md
+++ b/.changeset/gentle-jeans-film.md
@@ -1,0 +1,5 @@
+---
+"@callstack/repack": patch
+---
+
+Pass `SHARE_ENV` to Worker to keep process envs from parent process

--- a/packages/repack/src/webpack/Compiler.ts
+++ b/packages/repack/src/webpack/Compiler.ts
@@ -1,4 +1,4 @@
-import { Worker } from 'worker_threads';
+import { Worker, SHARE_ENV } from 'worker_threads';
 import path from 'path';
 import fs from 'fs';
 import EventEmitter from 'events';
@@ -45,13 +45,13 @@ export class Compiler extends EventEmitter {
       },
     };
 
+    process.env[WORKER_ENV_KEY] = '1';
+    process.env[VERBOSE_ENV_KEY] = this.isVerbose ? '1' : undefined;
+
     const worker = new Worker(path.join(__dirname, './webpackWorker.js'), {
       stdout: true,
       stderr: true,
-      env: {
-        [WORKER_ENV_KEY]: '1',
-        [VERBOSE_ENV_KEY]: this.isVerbose ? '1' : undefined,
-      },
+      env: SHARE_ENV,
       workerData,
     });
 


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->
Those changes will allow `Worker` to access process envs from parent (by passing `SHARE_ENV` symbol). This way passing `STANDALONE=1 yarn start` will expose STANDALONE process env and it will be accessible in `webpack.config` at project level

### Test plan

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
