### PR TITLE
fix: expose port reverse argument

### DIFF
--- a/.changeset/brown-jokes-remain.md
+++ b/.changeset/brown-jokes-remain.md
@@ -1,0 +1,5 @@
+---
+"@callstack/repack": minor
+---
+
+Expose `--reverse-port` argument in start command to fix dev server on Android

--- a/packages/repack/commands.js
+++ b/packages/repack/commands.js
@@ -85,6 +85,10 @@ module.exports = [
         description: 'Log all messages to the console/stdout in JSON format',
       },
       {
+        name: '--reverse-port',
+        description: 'ADB reverse port on starting devServers only for Android',
+      },
+      {
         name: '--log-file <string>',
         description: 'Enables file logging to specified file',
       },

--- a/packages/repack/src/commands/start.ts
+++ b/packages/repack/src/commands/start.ts
@@ -33,6 +33,7 @@ export async function start(_: string[], config: Config, args: StartArguments) {
     config.root,
     args.webpackConfig
   );
+  const { reversePort: reversePortArg, ...restArgs } = args;
   const cliOptions: CliOptions = {
     config: {
       root: config.root,
@@ -42,9 +43,11 @@ export async function start(_: string[], config: Config, args: StartArguments) {
     command: 'start',
     arguments: {
       // `platform` is empty, since it will be filled in later by `DevServerProxy`
-      start: { ...args, platform: '' },
+      start: { ...restArgs, platform: '' },
     },
   };
+
+  const reversePort = reversePortArg ?? process.argv.includes('--reverse-port');
   const isSilent = args.silent;
   const isVerbose = isSilent
     ? false
@@ -76,6 +79,10 @@ export async function start(_: string[], config: Config, args: StartArguments) {
     delegate: (ctx): Server.Delegate => {
       if (args.interactive) {
         bindKeypressInput(ctx);
+      }
+
+      if (reversePort && args.port) {
+        runAdbReverse(ctx, args.port);
       }
 
       let lastStats: webpack.StatsCompilation | undefined;

--- a/packages/repack/src/types.ts
+++ b/packages/repack/src/types.ts
@@ -75,6 +75,7 @@ export interface StartArguments extends CommonArguments {
   silent?: boolean;
   verbose?: boolean;
   json?: boolean;
+  reversePort?: boolean;
   logFile?: string;
 }
 


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->
When working with `repack-examples` on Android there the error `[ScriptManager] Failed to load script: [NetworkFailure] ...` occured when an attempt to load scripts from remote dev servers runs on different port that host app. It's because those remote ports are not reversed when ScriptManager tries to resolve from `localhost`. Logic to reverse ports is implemented on `watchRun` which seems to be 'too' late to prevent mentioned crash.

This PR expose `--reverse-port` flag which allow to reverse port upfront when starting dev server.

### Test plan

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->

- [x] run Module Federation example on Android device or Emulator and not facing `[ScriptManager] Failed to load script: [NetworkFailure] ...`
