### PR TITLE
fix: typo in dirname in templates/webpack.config.cjs fix

### DIFF
--- a/templates/webpack.config.cjs
+++ b/templates/webpack.config.cjs
@@ -104,7 +104,7 @@ module.exports = (env) => {
      */
     output: {
       clean: true,
-      path: path.join(dirname, 'build/generated', platform),
+      path: path.join(__dirname, 'build/generated', platform),
       filename: 'index.bundle',
       chunkFilename: '[name].chunk.bundle',
       publicPath: Repack.getPublicPath({ platform, devServer }),


### PR DESCRIPTION
This fixes a typo in `templates/webpack.config.cjs` which causes webpack to not work/crash.  It changes `dirname` to `__dirname`.