### PR TITLE
fix(debugger-app): fixes #219

### DIFF
--- a/packages/debugger-app/index.js
+++ b/packages/debugger-app/index.js
@@ -1,3 +1,3 @@
-import { URL } from 'url';
+import { URL, fileURLToPath } from 'url';
 
-export default new URL('./dist', import.meta.url).pathname;
+export default fileURLToPath(new URL('./dist', import.meta.url));


### PR DESCRIPTION
use `fileURLToPath` function to get path of URL instead of `.pathname` (added in [v10.12.0](https://nodejs.org/dist/latest-v10.x/docs/api/url.html#url_url_fileurltopath_url))

fixes #219 