### PR TITLE
fix: ReactRefreshPluginConfig shoud specified port

### DIFF
--- a/packages/repack/src/webpack/plugins/ReactRefreshPlugin.ts
+++ b/packages/repack/src/webpack/plugins/ReactRefreshPlugin.ts
@@ -16,6 +16,7 @@ type EntryStaticNormalized =
  */
 export interface ReactRefreshPluginConfig extends DevServerOptions {
   platform: string;
+  port: number;
 }
 
 /**


### PR DESCRIPTION
```js
new Repack.plugins.ReactRefreshPlugin({platform}),
```

If not set port will cause invalid URL port:
```sh
⚠ [09:13:21.864Z][LoggerPlugin] Warning in "undefined": DefinePlugin
Conflicting values for '__PUBLIC_PORT__' 
```


