### PR TITLE
fix: ensure file lists in manifests are sorted

### DIFF
--- a/packages/repack/src/webpack/plugins/ManifestPlugin.ts
+++ b/packages/repack/src/webpack/plugins/ManifestPlugin.ts
@@ -17,8 +17,8 @@ export class ManifestPlugin implements WebpackPlugin {
           const manifest = {
             id: chunk.id,
             name: chunk.name,
-            files: [...chunk.files],
-            auxiliaryFiles: [...chunk.auxiliaryFiles],
+            files: [...chunk.files].sort(),
+            auxiliaryFiles: [...chunk.auxiliaryFiles].sort(),
           };
 
           if (manifest.files.length) {


### PR DESCRIPTION
### Summary

After building an app, the manifest (`{chunk}.json`) files contain file lists in the `files` and `auxiliaryFiles` fields. These file lists are not sorted, causing the total "output" of a build to change, even if the source did not change.

This PR adds sorting to fix this. 


