### PR TITLE
feat: Raise error on missing native module

### DIFF
--- a/.changeset/tricky-papayas-perform.md
+++ b/.changeset/tricky-papayas-perform.md
@@ -1,0 +1,5 @@
+---
+"@callstack/repack": patch
+---
+
+raise error on missing native module

--- a/packages/repack/src/modules/ScriptManager/ScriptManager.ts
+++ b/packages/repack/src/modules/ScriptManager/ScriptManager.ts
@@ -105,6 +105,13 @@ export class ScriptManager extends EventEmitter {
   ) {
     super();
 
+    if (!nativeScriptManager) {
+      throw new Error(
+        'repack react-native module was not found.' +
+          (__DEV__ ? ' Did you forget to update native dependencies?' : '')
+      );
+    }
+
     if (__webpack_require__.repack.shared.scriptManager) {
       throw new Error(
         'ScriptManager was already instantiated. Use ScriptManager.shared instead.'

--- a/packages/repack/src/modules/ScriptManager/__tests__/ScriptManager.test.ts
+++ b/packages/repack/src/modules/ScriptManager/__tests__/ScriptManager.test.ts
@@ -1,8 +1,9 @@
 /* globals globalThis */
+import * as ReactNative from 'react-native';
 import { Script } from '../Script';
 import { ScriptManager } from '../ScriptManager';
 
-jest.mock('react-native', () => ({ NativeModules: {} }));
+jest.mock('react-native', () => ({ NativeModules: { ScriptManager: {} } }));
 
 // @ts-ignore
 globalThis.__webpack_require__ = {
@@ -28,6 +29,8 @@ class FakeCache {
 }
 
 beforeEach(() => {
+  ReactNative.NativeModules.ScriptManager = {};
+
   try {
     ScriptManager.shared.__destroy();
   } catch {
@@ -36,6 +39,12 @@ beforeEach(() => {
 });
 
 describe('ScriptManagerAPI', () => {
+  it('throw error if ScriptManager NativeModule was not found', async () => {
+    ReactNative.NativeModules.ScriptManager = undefined;
+
+    await expect(() => ScriptManager.shared).toThrow(/module was not found/);
+  });
+
   it('throw error if there are no resolvers', async () => {
     await expect(
       ScriptManager.shared.resolveScript('src_App_js', 'main')


### PR DESCRIPTION
This fix detects missing React Native module (e.g. due to missing `pod install` after installation) and raises error if true.

### Summary

This change improves developer experience. Should not affect any other areas.

Done a simple test on TesterApp and seems that nothing is broken by this change.

### Test plan

 1. Setup a RN application
 2. Install `repack` without updating native dependencies
 3. Setup Module Federation in app and use it
 4. New error `repack react-native module was not found` should appear instead of instead of `[ScriptManager] Failed to load script`