### PR TITLE
refactor(webpack/Compiler): remove duplicated assets in assetCache

### DIFF
--- a/.changeset/ten-tigers-kiss.md
+++ b/.changeset/ten-tigers-kiss.md
@@ -1,0 +1,5 @@
+---
+"@callstack/repack": minor
+---
+
+Fix: assetsCache not available on Windows platform due to problem with path encoding

--- a/packages/repack/src/webpack/Compiler.ts
+++ b/packages/repack/src/webpack/Compiler.ts
@@ -8,6 +8,7 @@ import { SendProgress } from '@callstack/repack-dev-server';
 import type { CliOptions, StartArguments } from '../types';
 import type { LogType, Reporter } from '../logging';
 import { VERBOSE_ENV_KEY, WORKER_ENV_KEY } from '../env';
+import { adaptFilenameToPlatform } from './utils';
 
 export interface Asset {
   data: string | Buffer;
@@ -118,8 +119,7 @@ export class Compiler extends EventEmitter {
               };
               return {
                 ...acc,
-                [filename]: asset,
-                [filename.replace(/\\/g, '/')]: asset,
+                [adaptFilenameToPlatform(filename)]: asset,
               };
             },
             {}

--- a/packages/repack/src/webpack/utils/adaptFilenameToPlatform.ts
+++ b/packages/repack/src/webpack/utils/adaptFilenameToPlatform.ts
@@ -1,0 +1,10 @@
+import os from 'os';
+
+const isWindows = os.platform() === 'win32';
+
+export const adaptFilenameToPlatform = (filename: string) => {
+  if (isWindows) {
+    return filename.replace(/\\/g, '/');
+  }
+  return filename;
+};

--- a/packages/repack/src/webpack/utils/index.ts
+++ b/packages/repack/src/webpack/utils/index.ts
@@ -4,3 +4,4 @@ export * from './getPublicPath';
 export * from './assetExtensions';
 export * from './getWebpackEnvOptions';
 export * from './getDirname';
+export * from './adaptFilenameToPlatform';


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

This PR slightly refactors what was already implemented by @meypod in #256 – instead of duplicating each asset under a key which is valid pathname for Windows I'm modifying (or not) the filename based on the platform in context of which `Complier` is run. This should be safe as it will not affect production builds because the `Compiler` in only used with devServer.

### Test plan

Unfortunately I don't have access to a machine running Windows – @meypod would you be able to test that change and let me know if it's working properly on your end?
