### PR TITLE
docs: update old TesterApp urls for code splitting

### DIFF
--- a/website/docs/code-splitting/usage.md
+++ b/website/docs/code-splitting/usage.md
@@ -149,7 +149,7 @@ To learn more or use async chunks in your project, check out our [dedicated Asyn
 :::tip
 
 To see `import(...)`, `React.lazy` and `React.Suspense` in action, check out
-[Re.Pack's `TesterApp`](https://github.com/callstack/repack/blob/main/packages/TesterApp/src/AsyncContainer.js).
+[Re.Pack's `TesterApp`](https://github.com/callstack/repack/blob/main/packages/TesterApp/src/asyncChunks/AsyncContainer.tsx).
 
 :::
 

--- a/website/versioned_docs/version-2x/code-splitting/usage.md
+++ b/website/versioned_docs/version-2x/code-splitting/usage.md
@@ -159,7 +159,7 @@ To learn more or use async chunks in your project, check out our [dedicated Asyn
 :::tip
 
 To see `import(...)`, `React.lazy` and `React.Suspense` in action, check out
-[Re.Pack's `TesterApp`](https://github.com/callstack/repack/blob/main/packages/TesterApp/src/AsyncContainer.js).
+[Re.Pack's `TesterApp`](https://github.com/callstack/repack/blob/2.x/packages/TesterApp/src/AsyncContainer.js).
 
 :::
 


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

Updated TesterApp urls in Code Splitting  v3 and v2 docs - old urls threw 404

### Test plan

n/a
