### PR TITLE
feat: populate library in compiler options output

### DIFF
--- a/packages/repack/src/webpack/plugins/ModuleFederationPlugin.ts
+++ b/packages/repack/src/webpack/plugins/ModuleFederationPlugin.ts
@@ -156,13 +156,13 @@ export class ModuleFederationPlugin implements WebpackPlugin {
         'react-native': Federated.SHARED_REACT_NATIVE,
       },
       remotes,
-    }
+    };
 
     if (config.library) {
       compiler.options.output.library = {
         ...compiler.options.output.library,
         ...config.library,
-      }
+      };
     }
 
     new container.ModuleFederationPlugin(config).apply(compiler);

--- a/packages/repack/src/webpack/plugins/ModuleFederationPlugin.ts
+++ b/packages/repack/src/webpack/plugins/ModuleFederationPlugin.ts
@@ -137,8 +137,8 @@ export class ModuleFederationPlugin implements WebpackPlugin {
     const remotes = Array.isArray(this.config.remotes)
       ? this.config.remotes.map((remote) => this.replaceRemotes(remote))
       : this.replaceRemotes(this.config.remotes ?? {});
-
-    new container.ModuleFederationPlugin({
+    
+    const config = {
       ...this.config,
       filename:
         this.config.filename ?? this.config.exposes
@@ -156,6 +156,15 @@ export class ModuleFederationPlugin implements WebpackPlugin {
         'react-native': Federated.SHARED_REACT_NATIVE,
       },
       remotes,
-    }).apply(compiler);
+    }
+
+    if (config.library) {
+      compiler.options.output.library = {
+        ...compiler.options.output.library,
+        ...config.library,
+      }
+    }
+
+    new container.ModuleFederationPlugin(config).apply(compiler);
   }
 }

--- a/packages/repack/src/webpack/plugins/ModuleFederationPlugin.ts
+++ b/packages/repack/src/webpack/plugins/ModuleFederationPlugin.ts
@@ -137,7 +137,7 @@ export class ModuleFederationPlugin implements WebpackPlugin {
     const remotes = Array.isArray(this.config.remotes)
       ? this.config.remotes.map((remote) => this.replaceRemotes(remote))
       : this.replaceRemotes(this.config.remotes ?? {});
-    
+
     const config = {
       ...this.config,
       filename:

--- a/packages/repack/src/webpack/plugins/__tests__/ModuleFederationPlugin.test.ts
+++ b/packages/repack/src/webpack/plugins/__tests__/ModuleFederationPlugin.test.ts
@@ -1,4 +1,4 @@
-import { container } from 'webpack';
+import { Compiler, container } from 'webpack';
 import { ModuleFederationPlugin } from '../ModuleFederationPlugin';
 
 jest.mock('webpack', () => ({
@@ -95,6 +95,26 @@ describe('ModuleFederationPlugin', () => {
     expect(config.remotes.app1).toMatch(
       'http://localhost:6789/static/[name][ext]'
     );
+    (container.ModuleFederationPlugin as jest.Mock).mockClear();
+  });
+
+  it('should use unique name from config', () => {
+    class MockCompiler {
+      options: any = {
+        output: {}
+      }
+    }
+
+    const mockCompilerInstance = new MockCompiler()
+
+    new ModuleFederationPlugin({
+      name: 'uniqueModuleName',
+      exposes: {
+        './Home': './src/Home.ts'
+      }
+    }).apply(mockCompilerInstance as Compiler);
+
+    expect(mockCompilerInstance.options.output.library.name).toMatch('uniqueModuleName');
     (container.ModuleFederationPlugin as jest.Mock).mockClear();
   });
 });

--- a/packages/repack/src/webpack/plugins/__tests__/ModuleFederationPlugin.test.ts
+++ b/packages/repack/src/webpack/plugins/__tests__/ModuleFederationPlugin.test.ts
@@ -101,20 +101,22 @@ describe('ModuleFederationPlugin', () => {
   it('should use unique name from config', () => {
     class MockCompiler {
       options: any = {
-        output: {}
-      }
+        output: {},
+      };
     }
 
-    const mockCompilerInstance = new MockCompiler()
+    const mockCompilerInstance = new MockCompiler();
 
     new ModuleFederationPlugin({
       name: 'uniqueModuleName',
       exposes: {
-        './Home': './src/Home.ts'
-      }
+        './Home': './src/Home.ts',
+      },
     }).apply(mockCompilerInstance as Compiler);
 
-    expect(mockCompilerInstance.options.output.library.name).toMatch('uniqueModuleName');
+    expect(mockCompilerInstance.options.output.library.name).toMatch(
+      'uniqueModuleName'
+    );
     (container.ModuleFederationPlugin as jest.Mock).mockClear();
   });
 });


### PR DESCRIPTION
### Summary

Use `name` provided when configuring Module Federation plugin to determine `uniqueName` for Webpack

Fixes: #279

### Test plan

1. Run the steps mentioned [here](https://github.com/callstack/repack/issues/279), but set up Re.Pack locally from this branch
