### PR TITLE
Small fix to config example link in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Re.Pack is a next generation of [Haul](https://github.com/callstack/haul) — a 
 
 Re.Pack uses Webpack 5 and React Native CLI's plugin system to allow you to bundle your application using Webpack and allow to easily switch from Metro.
 
-__Check the base [`webpack.config.js`](https://github.com/callstack/repack/blob/main/templates/webpack.config.js) template, if you're curious how it all looks like.__
+__Check the base [`webpack.config.cjs`](https://github.com/callstack/repack/blob/main/templates/webpack.config.cjs) or [`webpack.config.mjs`](https://github.com/callstack/repack/blob/main/templates/webpack.config.mjs) template, if you're curious how it all looks like.__
 
 ## Features
 


### PR DESCRIPTION
Link to example config is not working.
Changed the link(s) to point to the new template files