### PR TITLE
chore: Relase 1.0.1 version of debugger-app package

### DIFF
--- a/packages/debugger-app/CHANGELOG.md
+++ b/packages/debugger-app/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @callstack/repack-debugger-app
 
+## 1.0.1
+
+### Patch Changes
+
+#### Windows related issues:
+
+- [#255](https://github.com/callstack/repack/pull/255) [`d974069`](https://github.com/callstack/repack/commit/d974069ab2e7abee2a4b7103a8a86fe476fc122a) Thanks [@meypod](https://github.com/meypod)! - Fix v3 `debugger-app` not working on Windows platform
+
 ## 1.0.0
 
 ### Major Changes

--- a/packages/debugger-app/package.json
+++ b/packages/debugger-app/package.json
@@ -2,7 +2,7 @@
   "name": "@callstack/repack-debugger-app",
   "description": "Browser debugger app for React Native applications as part of @callstack/repack.",
   "license": "MIT",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "type": "module",
   "main": "./index.js",
   "types": "./index.d.ts",


### PR DESCRIPTION
### Summary

I forgot to release `debugger-app` package when releasing repack `3.0.1` version. It includes one fix for Windows platform: https://github.com/callstack/repack/pull/255

