### PR TITLE
feat: over-the-air updates

### DIFF
--- a/.changeset/gold-cows-raise.md
+++ b/.changeset/gold-cows-raise.md
@@ -1,0 +1,17 @@
+---
+"@callstack/repack": minor
+---
+
+Since `ScriptManager` has `prefetchScript` and `loadScript` methods which use `resolveScript` under the hood, there is a possible way to add a point between resolving script and loading it. In this point user could control the way Repack updates the script (fetch from network or use cached one).
+
+There was introduced new optional callback `shouldUpdateScript`, that could be passed into so called locator or a kind of config in `addResolver` callback function return statement.
+```
+shouldUpdateScript?: (
+    scriptId?: string,
+    caller?: string,
+    isScriptCacheOutdated?: boolean
+) => Promise<boolean> | boolean;
+```
+`shouldUpdateScript` callback receives `scriptId` and `caller` to identify the script. New `isScriptCacheOutdated` argument helps to identify if script is changed comparing to the cached one, since user has no ability to work directly with cache. It compares method, url, query, headers and body of the script request and set true if any of this params was changed or false when the script cache is up to date or there is no cache for the script.
+Since `shouldUpdateScript` will be called on every `resolveScript` call it is necessary to provide correct conditions when script should be loaded or use already existing cache logic.
+If cache is opt-out for the script, `isScriptCacheOutdated` will always be false.

--- a/packages/repack/src/modules/ScriptManager/Script.ts
+++ b/packages/repack/src/modules/ScriptManager/Script.ts
@@ -135,6 +135,26 @@ export class Script {
   ) {}
 
   /**
+   * Check if the script was already cached and cache should be updated with new data.
+   *
+   * @param cachedData Cached data for the same script.
+   *
+   * @internal
+   */
+  shouldUpdateCache(
+    cachedData: Pick<
+      NormalizedScriptLocator,
+      'method' | 'url' | 'query' | 'headers' | 'body'
+    >
+  ) {
+    if (!this.cache || !cachedData) {
+      return false;
+    }
+
+    return this.checkIfCacheDataOutdated(cachedData);
+  }
+
+  /**
    * Check if the script should be fetched again or reused,
    * based on previous cached data.
    *
@@ -152,6 +172,22 @@ export class Script {
       return true;
     }
 
+    return this.checkIfCacheDataOutdated(cachedData);
+  }
+
+  /**
+   * Check if previous cached data is the same as the new one.
+   *
+   * @param cachedData Cached data for the same script.
+   *
+   * @internal
+   */
+  checkIfCacheDataOutdated(
+    cachedData: Pick<
+      NormalizedScriptLocator,
+      'method' | 'url' | 'query' | 'headers' | 'body'
+    >
+  ) {
     const diffs = [
       cachedData.method !== this.locator.method,
       cachedData.url !== this.locator.url,

--- a/packages/repack/src/modules/ScriptManager/ScriptManager.ts
+++ b/packages/repack/src/modules/ScriptManager/ScriptManager.ts
@@ -272,6 +272,24 @@ export class ScriptManager extends EventEmitter {
       const script = Script.from({ scriptId, caller }, locator, false);
       const cacheKey = `${scriptId}_${caller ?? 'unknown'}`;
 
+      if (locator.shouldLoad) {
+        const fetch = await locator.shouldLoad(
+          scriptId,
+          caller,
+          script.shouldUpdateCache(this.cache[cacheKey])
+        );
+
+        if (fetch) {
+          script.locator.fetch = true;
+          this.cache[cacheKey] = script.getCacheData();
+          await this.saveCache();
+        }
+
+        this.emit('resolved', script.toObject());
+
+        return script;
+      }
+
       if (!this.cache[cacheKey]) {
         script.locator.fetch = true;
         this.cache[cacheKey] = script.getCacheData();

--- a/packages/repack/src/modules/ScriptManager/ScriptManager.ts
+++ b/packages/repack/src/modules/ScriptManager/ScriptManager.ts
@@ -272,8 +272,8 @@ export class ScriptManager extends EventEmitter {
       const script = Script.from({ scriptId, caller }, locator, false);
       const cacheKey = `${scriptId}_${caller ?? 'unknown'}`;
 
-      if (locator.shouldLoad) {
-        const fetch = await locator.shouldLoad(
+      if (locator.shouldUpdateScript) {
+        const fetch = await locator.shouldUpdateScript(
           scriptId,
           caller,
           script.shouldUpdateCache(this.cache[cacheKey])

--- a/packages/repack/src/modules/ScriptManager/ScriptManager.ts
+++ b/packages/repack/src/modules/ScriptManager/ScriptManager.ts
@@ -290,10 +290,11 @@ export class ScriptManager extends EventEmitter {
 
         this.emit('resolved', script.toObject());
 
+        // if it returns false, we don't need to fetch the script
         return script;
       }
 
-      // If no custom shouldUpdateScript function was provided, we use the default one
+      // If no custom shouldUpdateScript function was provided, we use the default behaviour
       if (!this.cache[cacheKey]) {
         script.locator.fetch = true;
         this.cache[cacheKey] = script.getCacheData();

--- a/packages/repack/src/modules/ScriptManager/ScriptManager.ts
+++ b/packages/repack/src/modules/ScriptManager/ScriptManager.ts
@@ -272,13 +272,16 @@ export class ScriptManager extends EventEmitter {
       const script = Script.from({ scriptId, caller }, locator, false);
       const cacheKey = `${scriptId}_${caller ?? 'unknown'}`;
 
+      // Check if user provided a custom shouldUpdateScript function
       if (locator.shouldUpdateScript) {
+        // If so, we need to wait for it to resolve
         const fetch = await locator.shouldUpdateScript(
           scriptId,
           caller,
           script.shouldUpdateCache(this.cache[cacheKey])
         );
 
+        // If it returns true, we need to fetch the script
         if (fetch) {
           script.locator.fetch = true;
           this.cache[cacheKey] = script.getCacheData();
@@ -290,6 +293,7 @@ export class ScriptManager extends EventEmitter {
         return script;
       }
 
+      // If no custom shouldUpdateScript function was provided, we use the default one
       if (!this.cache[cacheKey]) {
         script.locator.fetch = true;
         this.cache[cacheKey] = script.getCacheData();

--- a/packages/repack/src/modules/ScriptManager/__tests__/ScriptManager.test.ts
+++ b/packages/repack/src/modules/ScriptManager/__tests__/ScriptManager.test.ts
@@ -371,10 +371,10 @@ describe('ScriptManagerAPI', () => {
       return {
         url: Script.getRemoteURL(`http://domain.ext/${scriptId}`),
         cache: false,
-        shouldUpdateScript: (_, __, isOutdated) => {
-          expect(isOutdated).toEqual(false);
+        shouldUpdateScript: (_, __, isScriptCacheOutdated) => {
+          expect(isScriptCacheOutdated).toEqual(false);
 
-          return !!isOutdated;
+          return !!isScriptCacheOutdated;
         },
       };
     });
@@ -393,10 +393,10 @@ describe('ScriptManagerAPI', () => {
       return {
         url: Script.getRemoteURL(`http://domain.ext/${scriptId}`),
         cache: true,
-        shouldUpdateScript: (_, __, isOutdated) => {
-          expect(isOutdated).toEqual(false);
+        shouldUpdateScript: (_, __, isScriptCacheOutdated) => {
+          expect(isScriptCacheOutdated).toEqual(false);
 
-          return !!isOutdated;
+          return !!isScriptCacheOutdated;
         },
       };
     });
@@ -415,10 +415,10 @@ describe('ScriptManagerAPI', () => {
       return {
         url: Script.getRemoteURL(`http://other.domain.ext/${scriptId}`),
         cache: true,
-        shouldUpdateScript: (_, __, isOutdated) => {
-          expect(isOutdated).toEqual(true);
+        shouldUpdateScript: (_, __, isScriptCacheOutdated) => {
+          expect(isScriptCacheOutdated).toEqual(true);
 
-          return !!isOutdated;
+          return !!isScriptCacheOutdated;
         },
       };
     });

--- a/packages/repack/src/modules/ScriptManager/__tests__/ScriptManager.test.ts
+++ b/packages/repack/src/modules/ScriptManager/__tests__/ScriptManager.test.ts
@@ -309,13 +309,18 @@ describe('ScriptManagerAPI', () => {
   });
 
   it('should resolve with shouldUpdateScript', async () => {
+    const domainURL = 'http://domain.ext/';
+    const otherDomainURL = 'http://other.domain.ext/';
+
     const cache = new FakeCache();
     ScriptManager.shared.setStorage(cache);
+
+    // First time, cache is opt-in, shouldUpdateScript is false, so the script is not fetched
     ScriptManager.shared.addResolver(async (scriptId, caller) => {
       expect(caller).toEqual('main');
 
       return {
-        url: Script.getRemoteURL(`http://domain.ext/${scriptId}`),
+        url: Script.getRemoteURL(`${domainURL}${scriptId}`),
         cache: true,
         shouldUpdateScript: () => false,
       };
@@ -329,11 +334,12 @@ describe('ScriptManagerAPI', () => {
 
     ScriptManager.shared.removeAllResolvers();
 
+    // Second time, cache is opt-in, shouldUpdateScript is true, so the script is fetched
     ScriptManager.shared.addResolver(async (scriptId, caller) => {
       expect(caller).toEqual('main');
 
       return {
-        url: Script.getRemoteURL(`http://domain.ext/${scriptId}`),
+        url: Script.getRemoteURL(`${domainURL}${scriptId}`),
         cache: true,
         shouldUpdateScript: () => true,
       };
@@ -347,11 +353,12 @@ describe('ScriptManagerAPI', () => {
 
     ScriptManager.shared.removeAllResolvers();
 
+    // Third time, cache is opt-out, shouldUpdateScript is false, but the script is fetched since cache is opt-out
     ScriptManager.shared.addResolver(async (scriptId, caller) => {
       expect(caller).toEqual('main');
 
       return {
-        url: Script.getRemoteURL(`http://domain.ext/${scriptId}`),
+        url: Script.getRemoteURL(`${domainURL}${scriptId}`),
         cache: false,
         shouldUpdateScript: () => false,
       };
@@ -365,11 +372,12 @@ describe('ScriptManagerAPI', () => {
 
     ScriptManager.shared.removeAllResolvers();
 
+    // Fourth time, cache is opt-out, isScriptCacheOutdated is false since cache is opt-out, but the script is fetched
     ScriptManager.shared.addResolver(async (scriptId, caller) => {
       expect(caller).toEqual('main');
 
       return {
-        url: Script.getRemoteURL(`http://domain.ext/${scriptId}`),
+        url: Script.getRemoteURL(`${domainURL}${scriptId}`),
         cache: false,
         shouldUpdateScript: (_, __, isScriptCacheOutdated) => {
           expect(isScriptCacheOutdated).toEqual(false);
@@ -387,11 +395,12 @@ describe('ScriptManagerAPI', () => {
 
     ScriptManager.shared.removeAllResolvers();
 
+    // Fifth time, cache is opt-in, isScriptCacheOutdated is false since domain url is not changed, so the script is not fetched since we return false in shouldUpdateScript
     ScriptManager.shared.addResolver(async (scriptId, caller) => {
       expect(caller).toEqual('main');
 
       return {
-        url: Script.getRemoteURL(`http://domain.ext/${scriptId}`),
+        url: Script.getRemoteURL(`${domainURL}${scriptId}`),
         cache: true,
         shouldUpdateScript: (_, __, isScriptCacheOutdated) => {
           expect(isScriptCacheOutdated).toEqual(false);
@@ -409,11 +418,12 @@ describe('ScriptManagerAPI', () => {
 
     ScriptManager.shared.removeAllResolvers();
 
+    // Sixth time, cache is opt-in, isScriptCacheOutdated is true since domain url is changed, so the script is fetched since we return true in shouldUpdateScript
     ScriptManager.shared.addResolver(async (scriptId, caller) => {
       expect(caller).toEqual('main');
 
       return {
-        url: Script.getRemoteURL(`http://other.domain.ext/${scriptId}`),
+        url: Script.getRemoteURL(`${otherDomainURL}${scriptId}`),
         cache: true,
         shouldUpdateScript: (_, __, isScriptCacheOutdated) => {
           expect(isScriptCacheOutdated).toEqual(true);

--- a/packages/repack/src/modules/ScriptManager/types.ts
+++ b/packages/repack/src/modules/ScriptManager/types.ts
@@ -93,13 +93,13 @@ export interface ScriptLocator {
    *
    * @param scriptId Id of the script to resolve.
    * @param caller Name of the calling script - it can be for example: name of the bundle, chunk or container.
-   * @param outdated Boolean indicating whether the script cache is outdated or not.
+   * @param isOutdated Boolean indicating whether the script cache is outdated or not.
    * @returns Boolean indicating whether the script should be loaded or not
    */
   shouldUpdateScript?: (
     scriptId?: string,
     caller?: string,
-    outdated?: boolean
+    isOutdated?: boolean
   ) => Promise<boolean> | boolean;
 }
 

--- a/packages/repack/src/modules/ScriptManager/types.ts
+++ b/packages/repack/src/modules/ScriptManager/types.ts
@@ -88,6 +88,17 @@ export interface ScriptLocator {
    * Setting this flat to `false`, disables that behavior.
    */
   cache?: boolean;
+  /**
+   * Function called before loading
+   *
+   * @param script Script to load
+   * @returns Boolean indicating whether the script should be loaded or not
+   */
+  shouldLoad?: (
+    scriptId?: string,
+    caller?: string,
+    outdated?: boolean
+  ) => Promise<boolean> | boolean;
 }
 
 /**

--- a/packages/repack/src/modules/ScriptManager/types.ts
+++ b/packages/repack/src/modules/ScriptManager/types.ts
@@ -89,12 +89,14 @@ export interface ScriptLocator {
    */
   cache?: boolean;
   /**
-   * Function called before loading
+   * Function called before loading or getting from the cache and after resolving the script locator.
    *
-   * @param script Script to load
+   * @param scriptId Id of the script to resolve.
+   * @param caller Name of the calling script - it can be for example: name of the bundle, chunk or container.
+   * @param outdated Boolean indicating whether the script cache is outdated or not.
    * @returns Boolean indicating whether the script should be loaded or not
    */
-  shouldLoad?: (
+  shouldUpdateScript?: (
     scriptId?: string,
     caller?: string,
     outdated?: boolean

--- a/packages/repack/src/modules/ScriptManager/types.ts
+++ b/packages/repack/src/modules/ScriptManager/types.ts
@@ -91,9 +91,15 @@ export interface ScriptLocator {
   /**
    * Function called before loading or getting from the cache and after resolving the script locator.
    *
+   * When `true` is returned, the script will be loaded from the network.
+   * When `false` is returned, the script will be loaded from the cache.
+   *
    * @param scriptId Id of the script to resolve.
    * @param caller Name of the calling script - it can be for example: name of the bundle, chunk or container.
-   * @param isOutdated Boolean indicating whether the script cache is outdated or not.
+   * @param isOutdated Boolean indicating whether the script cache is outdated or not. It's `true` when the script
+   * cache is outdated and `false` when the script cache is up to date or there is no cache for the script.
+   * Outdated cache means that the script was previously downloaded and put into cache,
+   * but the script locator data (method, url, query, headers, or body) has changed since then.
    * @returns Boolean indicating whether the script should be loaded or not
    */
   shouldUpdateScript?: (

--- a/packages/repack/src/modules/ScriptManager/types.ts
+++ b/packages/repack/src/modules/ScriptManager/types.ts
@@ -90,13 +90,16 @@ export interface ScriptLocator {
   cache?: boolean;
   /**
    * Function called before loading or getting from the cache and after resolving the script locator.
+   * It's an async function which should return a boolean indicating whether the script should be loaded or use default behaviour.
+   * This is useful when you want to load a script only when certain conditions are met
+   * (e.g. ask user if they want to update/download new version of the script)
    *
    * When `true` is returned, the script will be loaded from the network.
    * When `false` is returned, the script will be loaded from the cache.
    *
    * @param scriptId Id of the script to resolve.
    * @param caller Name of the calling script - it can be for example: name of the bundle, chunk or container.
-   * @param isOutdated Boolean indicating whether the script cache is outdated or not. It's `true` when the script
+   * @param isScriptCacheOutdated Boolean indicating whether the script cache is outdated or not. It's `true` when the script
    * cache is outdated and `false` when the script cache is up to date or there is no cache for the script.
    * Outdated cache means that the script was previously downloaded and put into cache,
    * but the script locator data (method, url, query, headers, or body) has changed since then.
@@ -105,7 +108,7 @@ export interface ScriptLocator {
   shouldUpdateScript?: (
     scriptId?: string,
     caller?: string,
-    isOutdated?: boolean
+    isScriptCacheOutdated?: boolean
   ) => Promise<boolean> | boolean;
 }
 


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary
Repack provides a way to implement OTA updates out-of-the-box.
Since `ScriptManager` has `prefetchScript` and `loadScript` methods which use `resolveScript` under the hood, there is a possible way to add a point between resolving script and loading it. In this point user could control the way Repack updates the script (fetch from network or use cached one).
This PR introduces new callback, that could be passed into so called locator or a kind of config in `addResolver` callback function return statement.
```
shouldUpdateScript?: (
    scriptId?: string,
    caller?: string,
    isScriptCacheOutdated?: boolean
) => Promise<boolean> | boolean;
```
it is worth to mention that all the changes are optional, so nothing will be broken if user will not provide new callback and will do no changes at all.
`ShouldUpdateScript` callback receives `scriptId` and `caller` to identify the script. New `isScriptCacheOutdated` argument helps to identify if script is changed comparing to the cached one, since user has no ability to work directly with cache. It compares method, url, query, headers and body of the script request and set true if any of this params was changed or false when the script cache is up to date or there is no cache for the script.
Since `shouldUpdateScript` will be called on every `resolveScript` call it is necessary to provide correct conditions when script should be loaded or use already existing cache logic. 
If cache is opt-out for the script, `isScriptCacheOutdated` will always be false.
Here is the example of `shouldUpdateScript` usage:
```
const callers = {};

<SOME CODE...>

shouldUpdateScript: async (scriptId, caller, isScriptCacheOutdated) => {
      if (caller && callers[caller] !== undefined) {
        return callers[caller];
      }

      if (!isScriptCacheOutdated) {
        return true;
      }

      const shouldUpdate = await alertAsync(
        'Update available',
        'A new version of the app is available. Do you want to update?',
      );

      if (!caller) {
        callers[scriptId] = shouldUpdate;
      }

      return shouldUpdate;
    },
```
The implementation above uses `isScriptCacheOutdated` argument to check if script is changed and could be updated. If it is true, then application will show an alert with the question should the new script version be loaded or use the previous one from the cache. Callers is an object which stores the first user answer regarding the script. Since Webpack with Module Federation creates bundle for each remote container and then creates small chunks for it exposed modules, `shouldUpdateScript` will be called on every script (container bundle and its chunks). Callers object saves the first value from the alert (true or false) and then use it for resolving chunks calls. E.g. Host app has `auth` remote container, so Repack calls `shouldUpdateScript` for the container bundle with `scriptId` `auth`, saves the answer in callers object with key `auth` and then it will use this value from the first `alertAsync` call on any chunk load intent from `auth` remote container (caller will be `auth` and `scriptId` will be the chunk script id).
<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->

### Test plan
To test new functionality you need to add `shouldUpdateScript` callback in `addResolver` callback return statement and return boolean value depending on your case.
<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
