### PR TITLE
fix: Pass entryName config from RepackPlugin to OutputPlugin

### DIFF
--- a/.changeset/hungry-ligers-reflect.md
+++ b/.changeset/hungry-ligers-reflect.md
@@ -1,0 +1,5 @@
+---
+"@callstack/repack": patch
+---
+
+Fix #258 – previously `entryName` config value was not passed from `RepackPlugin` to the `OutputPlugin`.

--- a/packages/repack/src/webpack/plugins/RepackPlugin.ts
+++ b/packages/repack/src/webpack/plugins/RepackPlugin.ts
@@ -137,6 +137,7 @@ export class RepackPlugin implements WebpackPlugin {
       enabled: !this.config.devServer,
       context: this.config.context,
       output: this.config.output,
+      entryName: this.config.entryName,
       extraChunks: this.config.extraChunks,
     }).apply(compiler);
 


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

This PR ensures the `entryName` optional config value is passed from `RepackPlugin` to the `OutputPlugin`. This fixes #258 

<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->
