### PR TITLE
chore(repack): Remove deprecated jcenter repository from build.gradle

### DIFF
--- a/.changeset/breezy-cougars-learn.md
+++ b/.changeset/breezy-cougars-learn.md
@@ -1,0 +1,5 @@
+---
+"@callstack/repack": patch
+---
+
+Removed usage of deprecated jcenter repository in `build.gradle`

--- a/packages/repack/android/build.gradle
+++ b/packages/repack/android/build.gradle
@@ -4,7 +4,7 @@ buildscript {
 
   repositories {
     google()
-    jcenter()
+    mavenCentral()
   }
 
   dependencies {
@@ -33,9 +33,9 @@ android {
     targetSdkVersion getExtOrIntegerDefault('targetSdkVersion')
     versionCode 1
     versionName "1.0"
-    
+
   }
-  
+
   buildTypes {
     release {
       minifyEnabled false
@@ -52,7 +52,6 @@ android {
 
 repositories {
   mavenCentral()
-  jcenter()
   google()
 
   def found = false


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

JCenter artefacts repository is deprecated, according to these posts library maintainers should replace JCenter with other artefacts repositories like Maven Central
- https://developer.android.com/studio/build/jcenter-migration
- https://blog.gradle.org/jcenter-shutdown

