### PR TITLE
chore(repack): Update kotlin-gradle-plugin version

### DIFF
--- a/.changeset/six-falcons-heal.md
+++ b/.changeset/six-falcons-heal.md
@@ -1,0 +1,5 @@
+---
+"@callstack/repack": patch
+---
+
+Updated kotlin-gradle-plugin version used by Repack to 1.7.0

--- a/packages/repack/android/gradle.properties
+++ b/packages/repack/android/gradle.properties
@@ -1,4 +1,4 @@
-RePack_kotlinVersion=1.4.10
+RePack_kotlinVersion=1.7.0
 RePack_compileSdkVersion=29
 RePack_buildToolsVersion=29.0.2
 RePack_targetSdkVersion=29


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

In clean RN project created using CLI (RN version – 0.71.1) there was an error while build Android app. More context can be found in this issue: #291. Upgrading kotlin-gradle-plugin version specified in Repack solves that issue without the need to manually specify kotlin-gradle-plugin version override in the repack consumers their codebases. 

### Test plan

Tested in latest RN version (0.71.1) and a reasonably old one – 0.67.5 – in both cases clean RN app configured to be built using repack is working fine (in both debug and release).
