### PR TITLE
fix(reapck): compatible with @pmmmwh/react-refresh-webpack-plugin@0.5.x

### DIFF
--- a/.changeset/fresh-pandas-lie.md
+++ b/.changeset/fresh-pandas-lie.md
@@ -1,0 +1,5 @@
+---
+"@callstack/repack": patch
+---
+
+Fix #251 - restore working React Devtools


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

close #251 

After the 0.5.x version of `@pmmmwh/react-refresh-webpack-plugin`, it inserts RefreshEntry into webpack by `EntryPlugin` instead of `compiler.options.entry`. Therefore, our current method cannot find the RefreshEntry entry file from `compiler.options.entry` and then adjust its order.

This merge is to fix this problem, a entry file added by EntryPlugin will end up stored in`compilation.globalEntry.dependencies`, we just need to move it to `compiler.options.entry`.
