### PR TITLE
chore: node v18 compatibility

### DIFF
--- a/.changeset/clean-queens-collect.md
+++ b/.changeset/clean-queens-collect.md
@@ -1,0 +1,9 @@
+---
+"testerapp": patch
+"dashboard": patch
+"@callstack/repack-debugger-app": patch
+"@callstack/repack-dev-server": patch
+"@callstack/repack": patch
+---
+
+Make all packages compatible with Node v18

--- a/packages/TesterApp/package.json
+++ b/packages/TesterApp/package.json
@@ -38,7 +38,7 @@
     "terser-webpack-plugin": "^5.3.3",
     "typescript": "^4.7.3",
     "vitest": "^0.15.1",
-    "webpack": "^5.50.0"
+    "webpack": "^5.75.0"
   },
   "resolutions": {
     "@types/react": "^17"

--- a/packages/TesterApp/webpack.config.mjs
+++ b/packages/TesterApp/webpack.config.mjs
@@ -94,6 +94,7 @@ export default (env) => {
      */
     output: {
       clean: true,
+      hashFunction: 'xxhash64',
       path: path.join(dirname, 'build/generated', platform),
       filename: 'index.bundle',
       chunkFilename: '[name].chunk.bundle',

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -54,7 +54,7 @@
     "terser-webpack-plugin": "^5.2.4",
     "typescript": "^4.4.3",
     "url-loader": "^4.1.1",
-    "webpack": "^5.53.0",
+    "webpack": "^5.75.0",
     "webpack-cli": "^4.8.0",
     "webpack-dev-server": "^4.2.1"
   }

--- a/packages/dashboard/webpack.config.js
+++ b/packages/dashboard/webpack.config.js
@@ -15,6 +15,7 @@ module.exports = {
     clean: true,
     filename: 'static/js/[name].[contenthash:8].js',
     publicPath: '/dashboard/',
+    hashFunction: 'xxhash64',
   },
   resolve: {
     extensions: ['.ts', '.tsx', '.js', '.jsx', '.json'],

--- a/packages/debugger-app/package.json
+++ b/packages/debugger-app/package.json
@@ -45,7 +45,7 @@
     "mini-css-extract-plugin": "^2.6.0",
     "terser-webpack-plugin": "^5.3.3",
     "url-loader": "^4.1.1",
-    "webpack": "^5.50.0",
+    "webpack": "^5.75.0",
     "webpack-cli": "^4.9.2",
     "worker-loader": "^3.0.8"
   }

--- a/packages/debugger-app/webpack.config.cjs
+++ b/packages/debugger-app/webpack.config.cjs
@@ -19,6 +19,7 @@ module.exports = {
     clean: true,
     filename: 'static/js/[name].[contenthash:8].js',
     publicPath: '/debugger-ui/',
+    hashFunction: 'xxhash64',
   },
   module: {
     rules: [

--- a/packages/dev-server/package.json
+++ b/packages/dev-server/package.json
@@ -49,7 +49,7 @@
     "@callstack/repack-debugger-app": "^1.0.0",
     "@fastify/sensible": "^4.1.0",
     "@fastify/static": "^5.0.2",
-    "fastify": "^3.29.0",
+    "fastify": "^3.29.5",
     "fastify-favicon": "^3.2.0",
     "fastify-plugin": "^3.0.1",
     "metro-inspector-proxy": "^0.71.0",

--- a/packages/repack/package.json
+++ b/packages/repack/package.json
@@ -108,7 +108,7 @@
     "typedoc": "^0.22.17",
     "typedoc-plugin-markdown": "^3.12.1",
     "typescript": "^4.1.5",
-    "webpack": "^5.50.0",
+    "webpack": "^5.75.0",
     "webpack-virtual-modules": "^0.4.4"
   }
 }

--- a/templates/webpack.config.cjs
+++ b/templates/webpack.config.cjs
@@ -104,6 +104,7 @@ module.exports = (env) => {
      */
     output: {
       clean: true,
+      hashFunction: 'xxhash64',
       path: path.join(__dirname, 'build/generated', platform),
       filename: 'index.bundle',
       chunkFilename: '[name].chunk.bundle',

--- a/templates/webpack.config.mjs
+++ b/templates/webpack.config.mjs
@@ -106,6 +106,7 @@ export default (env) => {
      */
     output: {
       clean: true,
+      hashFunction: 'xxhash64',
       path: path.join(dirname, 'build/generated', platform),
       filename: 'index.bundle',
       chunkFilename: '[name].chunk.bundle',

--- a/yarn.lock
+++ b/yarn.lock
@@ -3670,7 +3670,7 @@ __metadata:
     "@types/ws": ^8.5.3
     babel-plugin-add-import-extension: ^1.6.0
     eslint: ^8.16.0
-    fastify: ^3.29.0
+    fastify: ^3.29.5
     fastify-favicon: ^3.2.0
     fastify-plugin: ^3.0.1
     metro-inspector-proxy: ^0.71.0
@@ -14817,6 +14817,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"fast-content-type-parse@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "fast-content-type-parse@npm:1.0.0"
+  checksum: 9e9187be17bea18a2ee715c5737b983181cbe84f286a291db0595e421e04b578da10ca10845639be08664a4db6a793f7709822935cf38cfdf9ecba38d84ead9e
+  languageName: node
+  linkType: hard
+
 "fast-decode-uri-component@npm:^1.0.1":
   version: 1.0.1
   resolution: "fast-decode-uri-component@npm:1.0.1"
@@ -14984,14 +14991,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fastify@npm:^3.29.0":
-  version: 3.29.0
-  resolution: "fastify@npm:3.29.0"
+"fastify@npm:^3.29.5":
+  version: 3.29.5
+  resolution: "fastify@npm:3.29.5"
   dependencies:
     "@fastify/ajv-compiler": ^1.0.0
     "@fastify/error": ^2.0.0
     abstract-logging: ^2.0.0
     avvio: ^7.1.2
+    fast-content-type-parse: ^1.0.0
     fast-json-stringify: ^2.5.2
     find-my-way: ^4.5.0
     flatstr: ^1.0.12
@@ -15003,7 +15011,7 @@ __metadata:
     secure-json-parse: ^2.0.0
     semver: ^7.3.2
     tiny-lru: ^8.0.1
-  checksum: ed2964035e34843d08c09eee80f5f14bd8cc0ab9b46ac9d146c6821b586a359a93e1354fca4004ac14e37b267afe5bb1ba3ddb555ecf09b74d9b6bf2f9893ba1
+  checksum: 6f97e67c25c509c584529aad2ffe0d4bf8943a860f09d847bf34a4736586cf73f5748bde154e0199c022b97ff76aba35c3094006e62b07100ab10c63205541e3
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3646,7 +3646,7 @@ __metadata:
     mini-css-extract-plugin: ^2.6.0
     terser-webpack-plugin: ^5.3.3
     url-loader: ^4.1.1
-    webpack: ^5.50.0
+    webpack: ^5.75.0
     webpack-cli: ^4.9.2
     worker-loader: ^3.0.8
   languageName: unknown
@@ -3737,7 +3737,7 @@ __metadata:
     typedoc: ^0.22.17
     typedoc-plugin-markdown: ^3.12.1
     typescript: ^4.1.5
-    webpack: ^5.50.0
+    webpack: ^5.75.0
     webpack-virtual-modules: ^0.4.4
   peerDependencies:
     "@react-native-community/cli": "*"
@@ -7186,16 +7186,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/eslint-scope@npm:^3.7.0":
-  version: 3.7.1
-  resolution: "@types/eslint-scope@npm:3.7.1"
-  dependencies:
-    "@types/eslint": "*"
-    "@types/estree": "*"
-  checksum: 4271c9adad19ad8a1d23062d9020468a51c7f81594b12b8e68f7d460c09e14d57cae3e82b077c402766369c0c17e2de72da72c405fa465d18a46c0b14ce92530
-  languageName: node
-  linkType: hard
-
 "@types/eslint-scope@npm:^3.7.3":
   version: 3.7.3
   resolution: "@types/eslint-scope@npm:3.7.3"
@@ -7216,7 +7206,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/estree@npm:*, @types/estree@npm:^0.0.50":
+"@types/estree@npm:*":
   version: 0.0.50
   resolution: "@types/estree@npm:0.0.50"
   checksum: 9a2b6a4a8c117f34d08fbda5e8f69b1dfb109f7d149b60b00fd7a9fb6ac545c078bc590aa4ec2f0a256d680cf72c88b3b28b60c326ee38a7bc8ee1ee95624922
@@ -12164,7 +12154,7 @@ __metadata:
     terser-webpack-plugin: ^5.2.4
     typescript: ^4.4.3
     url-loader: ^4.1.1
-    webpack: ^5.53.0
+    webpack: ^5.75.0
     webpack-cli: ^4.8.0
     webpack-dev-server: ^4.2.1
     zen-observable: ^0.8.15
@@ -13324,13 +13314,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"enhanced-resolve@npm:^5.8.0":
-  version: 5.8.2
-  resolution: "enhanced-resolve@npm:5.8.2"
+"enhanced-resolve@npm:^5.10.0":
+  version: 5.12.0
+  resolution: "enhanced-resolve@npm:5.12.0"
   dependencies:
     graceful-fs: ^4.2.4
     tapable: ^2.2.0
-  checksum: 6e871ec5b183220dbcdaff8580cbdacee5425e321790e5846abd1b573d20d2bcb37f73ee983fd10c6d6878d31a2d08e234e72fc91a81236d64623ee6ba7d6611
+  checksum: bf3f787facaf4ce3439bef59d148646344e372bef5557f0d37ea8aa02c51f50a925cd1f07b8d338f18992c29f544ec235a8c64bcdb56030196c48832a5494174
   languageName: node
   linkType: hard
 
@@ -13507,13 +13497,6 @@ __metadata:
   version: 0.10.5
   resolution: "es-module-lexer@npm:0.10.5"
   checksum: d2f9debd9d913323322095934653e0558bb8220177645eb76d316b4afd911e8d83ffee0b748b0faa9f3ce1560db3eee4a0ac68d6c2f750c11f4250adce84cf02
-  languageName: node
-  linkType: hard
-
-"es-module-lexer@npm:^0.7.1":
-  version: 0.7.1
-  resolution: "es-module-lexer@npm:0.7.1"
-  checksum: c66fb633cc521529862818caf603897d58d30442c885a1a1ed16823ddbbb8a437e3952454a4b2650242df1c1b4d0efa42fedbe49594e3ef2ceb3c891cf1211dd
   languageName: node
   linkType: hard
 
@@ -19346,7 +19329,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"json-parse-better-errors@npm:^1.0.1, json-parse-better-errors@npm:^1.0.2":
+"json-parse-better-errors@npm:^1.0.1":
   version: 1.0.2
   resolution: "json-parse-better-errors@npm:1.0.2"
   checksum: ff2b5ba2a70e88fd97a3cb28c1840144c5ce8fae9cbeeddba15afa333a5c407cf0e42300cd0a2885dbb055227fe68d405070faad941beeffbfde9cf3b2c78c5d
@@ -28650,7 +28633,7 @@ __metadata:
     terser-webpack-plugin: ^5.3.3
     typescript: ^4.7.3
     vitest: ^0.15.1
-    webpack: ^5.50.0
+    webpack: ^5.75.0
   languageName: unknown
   linkType: soft
 
@@ -30261,17 +30244,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"watchpack@npm:^2.2.0":
-  version: 2.2.0
-  resolution: "watchpack@npm:2.2.0"
-  dependencies:
-    glob-to-regexp: ^0.4.1
-    graceful-fs: ^4.1.2
-  checksum: e275f48fae29edee3195c51a8312b609581b9be5ce323d3102ffd082cb124f48d7a393ce05e4110239e4354379e04d78a97ceb26ae367746e7e218bf258135c8
-  languageName: node
-  linkType: hard
-
-"watchpack@npm:^2.3.1":
+"watchpack@npm:^2.3.1, watchpack@npm:^2.4.0":
   version: 2.4.0
   resolution: "watchpack@npm:2.4.0"
   dependencies:
@@ -30530,13 +30503,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"webpack-sources@npm:^3.2.0":
-  version: 3.2.0
-  resolution: "webpack-sources@npm:3.2.0"
-  checksum: 8f1d686bd6aab2eda330579a07e14803cb2e01415f5a603697402aea3c36e98c1d2731167c3e97e50170cf1b0214cf8ef945fc639b100d1e3b67c023feb35716
-  languageName: node
-  linkType: hard
-
 "webpack-sources@npm:^3.2.2, webpack-sources@npm:^3.2.3":
   version: 3.2.3
   resolution: "webpack-sources@npm:3.2.3"
@@ -30548,80 +30514,6 @@ __metadata:
   version: 0.4.4
   resolution: "webpack-virtual-modules@npm:0.4.4"
   checksum: 6720b4c47d76dc9cbaff557562506c192da7560a90395e9918a418e257a0c0cda9f5e3ac92107ec0789f8f23ad942313bd8cdebc95031d0adef1032bf6142bc7
-  languageName: node
-  linkType: hard
-
-"webpack@npm:^5.50.0":
-  version: 5.50.0
-  resolution: "webpack@npm:5.50.0"
-  dependencies:
-    "@types/eslint-scope": ^3.7.0
-    "@types/estree": ^0.0.50
-    "@webassemblyjs/ast": 1.11.1
-    "@webassemblyjs/wasm-edit": 1.11.1
-    "@webassemblyjs/wasm-parser": 1.11.1
-    acorn: ^8.4.1
-    acorn-import-assertions: ^1.7.6
-    browserslist: ^4.14.5
-    chrome-trace-event: ^1.0.2
-    enhanced-resolve: ^5.8.0
-    es-module-lexer: ^0.7.1
-    eslint-scope: 5.1.1
-    events: ^3.2.0
-    glob-to-regexp: ^0.4.1
-    graceful-fs: ^4.2.4
-    json-parse-better-errors: ^1.0.2
-    loader-runner: ^4.2.0
-    mime-types: ^2.1.27
-    neo-async: ^2.6.2
-    schema-utils: ^3.1.0
-    tapable: ^2.1.1
-    terser-webpack-plugin: ^5.1.3
-    watchpack: ^2.2.0
-    webpack-sources: ^3.2.0
-  peerDependenciesMeta:
-    webpack-cli:
-      optional: true
-  bin:
-    webpack: bin/webpack.js
-  checksum: 293bed1d9101ac127605f35a225a5cbc1bc89eac68d6e09e7feb3e284ec2693b3db7c1dd7710fadf6852f89ad39ed09413c35befa1cfc9738074b33299ac2b9e
-  languageName: node
-  linkType: hard
-
-"webpack@npm:^5.53.0":
-  version: 5.53.0
-  resolution: "webpack@npm:5.53.0"
-  dependencies:
-    "@types/eslint-scope": ^3.7.0
-    "@types/estree": ^0.0.50
-    "@webassemblyjs/ast": 1.11.1
-    "@webassemblyjs/wasm-edit": 1.11.1
-    "@webassemblyjs/wasm-parser": 1.11.1
-    acorn: ^8.4.1
-    acorn-import-assertions: ^1.7.6
-    browserslist: ^4.14.5
-    chrome-trace-event: ^1.0.2
-    enhanced-resolve: ^5.8.0
-    es-module-lexer: ^0.7.1
-    eslint-scope: 5.1.1
-    events: ^3.2.0
-    glob-to-regexp: ^0.4.1
-    graceful-fs: ^4.2.4
-    json-parse-better-errors: ^1.0.2
-    loader-runner: ^4.2.0
-    mime-types: ^2.1.27
-    neo-async: ^2.6.2
-    schema-utils: ^3.1.0
-    tapable: ^2.1.1
-    terser-webpack-plugin: ^5.1.3
-    watchpack: ^2.2.0
-    webpack-sources: ^3.2.0
-  peerDependenciesMeta:
-    webpack-cli:
-      optional: true
-  bin:
-    webpack: bin/webpack.js
-  checksum: f55c40e0a215d68633976ea54acbd9e92bf43f18593d25ffa2f4f1c33e7017d9c475ceabaddf1742d60310d84ec4600e564c1125e061378032948c11a2b18245
   languageName: node
   linkType: hard
 
@@ -30659,6 +30551,43 @@ __metadata:
   bin:
     webpack: bin/webpack.js
   checksum: aa434a241bad6176b68e1bf0feb1972da4dcbf27cb3d94ae24f6eb31acc37dceb9c4aae55e068edca75817bfe91f13cd20b023ac55d9b1b2f8b66a4037c9468f
+  languageName: node
+  linkType: hard
+
+"webpack@npm:^5.75.0":
+  version: 5.75.0
+  resolution: "webpack@npm:5.75.0"
+  dependencies:
+    "@types/eslint-scope": ^3.7.3
+    "@types/estree": ^0.0.51
+    "@webassemblyjs/ast": 1.11.1
+    "@webassemblyjs/wasm-edit": 1.11.1
+    "@webassemblyjs/wasm-parser": 1.11.1
+    acorn: ^8.7.1
+    acorn-import-assertions: ^1.7.6
+    browserslist: ^4.14.5
+    chrome-trace-event: ^1.0.2
+    enhanced-resolve: ^5.10.0
+    es-module-lexer: ^0.9.0
+    eslint-scope: 5.1.1
+    events: ^3.2.0
+    glob-to-regexp: ^0.4.1
+    graceful-fs: ^4.2.9
+    json-parse-even-better-errors: ^2.3.1
+    loader-runner: ^4.2.0
+    mime-types: ^2.1.27
+    neo-async: ^2.6.2
+    schema-utils: ^3.1.0
+    tapable: ^2.1.1
+    terser-webpack-plugin: ^5.1.3
+    watchpack: ^2.4.0
+    webpack-sources: ^3.2.3
+  peerDependenciesMeta:
+    webpack-cli:
+      optional: true
+  bin:
+    webpack: bin/webpack.js
+  checksum: 2bcc5f3c195f375944e8af2f00bf2feea39cb9fda5f763b0d1b00077f1c51783db25c94d3fae96a07dead9fa085e6ae7474417e5ab31719c9776ea5969ceb83a
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### Summary

When using node v18 there is an error related to outdated hashing function being used by `webpack`:

```
Error: error:0308010C:digital envelope routines::unsupported
    at new Hash (node:internal/crypto/hash:71:19)
    at Object.createHash (node:crypto:133:10)
    at BulkUpdateDecorator.hashFactory (/Users/jbroma/repack/main/node_modules/webpack/lib/util/createHash.js:145:18)
    at BulkUpdateDecorator.update (/Users/jbroma/repack/main/node_modules/webpack/lib/util/createHash.js:46:50)
    at OriginalSource.updateHash (/Users/jbroma/repack/main/node_modules/webpack-sources/lib/OriginalSource.js:138:8)
    at NormalModule._initBuildHash (/Users/jbroma/repack/main/node_modules/webpack/lib/NormalModule.js:880:17)
    at handleParseResult (/Users/jbroma/repack/main/node_modules/webpack/lib/NormalModule.js:946:10)
    at /Users/jbroma/repack/main/node_modules/webpack/lib/NormalModule.js:1040:4
    at processResult (/Users/jbroma/repack/main/node_modules/webpack/lib/NormalModule.js:755:11)
    at /Users/jbroma/repack/main/node_modules/webpack/lib/NormalModule.js:819:5
```

In order to resolve the issue, I've bumped the versions of `webpack` across the repository and introduced `output.hashFunction = 'xxhash64'` to the `webpack.config` files as well as the templates referenced in the docs. Previously, the default hashing function used by `webpack` was `md4` which was deemed unsafe with node v17+. The `xxhash64` type will be made the default in next major release of `webpack`. 
