### PR TITLE
fix(repack): verifyScriptSignature defaults to false

### DIFF
--- a/.changeset/funny-clocks-play.md
+++ b/.changeset/funny-clocks-play.md
@@ -1,0 +1,5 @@
+---
+"@callstack/repack": patch
+---
+
+Fix verifyScriptSignature missing a default value

--- a/packages/repack/android/src/main/java/com/callstack/repack/ChunkConfig.kt
+++ b/packages/repack/android/src/main/java/com/callstack/repack/ChunkConfig.kt
@@ -8,38 +8,40 @@ import okhttp3.RequestBody.Companion.toRequestBody
 import java.net.URL
 
 data class ScriptConfig(
-        val id: String,
-        val url: URL,
-        val query: String?,
-        val fetch: Boolean,
-        val absolute: Boolean,
-        val method: String,
-        val body: RequestBody?,
-        val timeout: Int,
-        val headers: Headers,
-        val token: String?,
-        val verifyScriptSignature: Boolean?
+    val id: String,
+    val url: URL,
+    val query: String?,
+    val fetch: Boolean,
+    val absolute: Boolean,
+    val method: String,
+    val body: RequestBody?,
+    val timeout: Int,
+    val headers: Headers,
+    val token: String?,
+    val verifyScriptSignature: Boolean
 ) {
     companion object {
         fun fromReadableMap(id: String, value: ReadableMap): ScriptConfig {
             val urlString = value.getString("url")
-                    ?: throw Error("ScriptManagerModule.load ScriptMissing url")
+                ?: throw Error("ScriptManagerModule.load ScriptMissing url")
             val method = value.getString("method")
-                    ?: throw Error("ScriptManagerModule.load ScriptMissing method")
+                ?: throw Error("ScriptManagerModule.load ScriptMissing method")
             val fetch = value.getBoolean("fetch")
             val absolute = value.getBoolean("absolute")
             val query = value.getString("query")
             val bodyString = value.getString("body")
             val headersMap = value.getMap("headers")
-            val timeout = value.getInt("timeout") ?: throw Error("ScriptManagerModule.load ScriptMissing timeout")
             val token = value.getString("token")
+            val timeout = value.getInt("timeout")
             val verifyScriptSignature = value.getBoolean("verifyScriptSignature")
 
-            val url = URL(if (query != null) {
-                "$urlString?$query"
-            } else {
-                urlString
-            })
+            val url = URL(
+                if (query != null) {
+                    "$urlString?$query"
+                } else {
+                    urlString
+                }
+            )
 
             val headers = Headers.Builder()
             val keyIterator = headersMap?.keySetIterator()
@@ -55,17 +57,17 @@ data class ScriptConfig(
             val body = bodyString?.toRequestBody(contentType)
 
             return ScriptConfig(
-                    id,
-                    url,
-                    query,
-                    fetch,
-                    absolute,
-                    method,
-                    body,
-                    timeout,
-                    headers.build(),
-                    token,
-                    verifyScriptSignature
+                id,
+                url,
+                query,
+                fetch,
+                absolute,
+                method,
+                body,
+                timeout,
+                headers.build(),
+                token,
+                verifyScriptSignature
             )
         }
     }

--- a/packages/repack/android/src/main/java/com/callstack/repack/ChunkConfig.kt
+++ b/packages/repack/android/src/main/java/com/callstack/repack/ChunkConfig.kt
@@ -31,8 +31,8 @@ data class ScriptConfig(
             val query = value.getString("query")
             val bodyString = value.getString("body")
             val headersMap = value.getMap("headers")
-            val token = value.getString("token")
             val timeout = value.getInt("timeout")
+            val token = value.getString("token")
             val verifyScriptSignature = value.getBoolean("verifyScriptSignature")
 
             val url = URL(

--- a/packages/repack/src/modules/ScriptManager/Script.ts
+++ b/packages/repack/src/modules/ScriptManager/Script.ts
@@ -115,7 +115,7 @@ export class Script {
         headers: Object.keys(headers).length ? headers : undefined,
         fetch: locator.cache === false ? true : fetch,
         token: locator.token,
-        verifyScriptSignature: locator.verifyScriptSignature,
+        verifyScriptSignature: locator.verifyScriptSignature ?? false,
       },
       locator.cache
     );

--- a/packages/repack/src/modules/ScriptManager/__tests__/ScriptManager.test.ts
+++ b/packages/repack/src/modules/ScriptManager/__tests__/ScriptManager.test.ts
@@ -92,6 +92,7 @@ describe('ScriptManagerAPI', () => {
       absolute: false,
       method: 'GET',
       timeout: Script.DEFAULT_TIMEOUT,
+      verifyScriptSignature: false,
     });
 
     const {
@@ -119,6 +120,7 @@ describe('ScriptManagerAPI', () => {
       absolute: false,
       method: 'GET',
       timeout: Script.DEFAULT_TIMEOUT,
+      verifyScriptSignature: false,
     });
   });
 
@@ -145,6 +147,7 @@ describe('ScriptManagerAPI', () => {
       absolute: false,
       method: 'GET',
       timeout: Script.DEFAULT_TIMEOUT,
+      verifyScriptSignature: false,
     });
   });
 
@@ -171,6 +174,7 @@ describe('ScriptManagerAPI', () => {
       method: 'GET',
       query: 'accessCode=1234&accessUid=asdf',
       timeout: Script.DEFAULT_TIMEOUT,
+      verifyScriptSignature: false,
     });
 
     ScriptManager.shared.removeAllResolvers();
@@ -210,6 +214,7 @@ describe('ScriptManagerAPI', () => {
       method: 'GET',
       headers: { 'x-hello': 'world' },
       timeout: Script.DEFAULT_TIMEOUT,
+      verifyScriptSignature: false,
     });
 
     ScriptManager.shared.removeAllResolvers();
@@ -233,6 +238,7 @@ describe('ScriptManagerAPI', () => {
       method: 'GET',
       headers: { 'x-hello': 'world', 'x-changed': 'true' },
       timeout: Script.DEFAULT_TIMEOUT,
+      verifyScriptSignature: false,
     });
   });
 
@@ -257,6 +263,7 @@ describe('ScriptManagerAPI', () => {
       method: 'POST',
       body: 'hello_world',
       timeout: Script.DEFAULT_TIMEOUT,
+      verifyScriptSignature: false,
     });
 
     ScriptManager.shared.removeAllResolvers();
@@ -278,6 +285,7 @@ describe('ScriptManagerAPI', () => {
       method: 'POST',
       body: 'message',
       timeout: Script.DEFAULT_TIMEOUT,
+      verifyScriptSignature: false,
     });
   });
 
@@ -305,6 +313,7 @@ describe('ScriptManagerAPI', () => {
       absolute: true,
       method: 'POST',
       timeout: Script.DEFAULT_TIMEOUT,
+      verifyScriptSignature: false,
     });
   });
 


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

Fix for the case where native `ScriptConfig` object on Android was causing a crash because of missing key in `ReadableMap`
