### PR TITLE
feat(repack): resolve scale automatically for inlined assets

### DIFF
--- a/.changeset/honest-glasses-yell.md
+++ b/.changeset/honest-glasses-yell.md
@@ -1,0 +1,5 @@
+---
+"@callstack/repack": minor
+---
+
+Auto device scale resolution for inlined assets


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

Added automatic scale resolution for inlined assets. This change only affects scaled inlined assets. 
This resolves an issue where an unstyled `Image` with inlined source was not being displayed (the width & height won't be picked up properly unless it's a single `URISource`

Result of inlining scaled asset before:
```ts
[
  {
    uri: 'data:image/png;base64,...',
    scale: 1,
    width: 10,
    height: 10,
  },
  {
    uri: 'data:image/png;base64,...',
    scale: 2,
    width: 10,
    height: 10,
  },
]
```

Result of inlining scaled asset after:
```ts
{
  uri: 'data:image/png;base64,...',
  scale: 2,   // only the matching scale gets picked up
  width: 10,
  height: 10,
},
```


<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->

### Test plan

- UI tests
