### PR TITLE
fix(repack): move code-signing plugin execution to a later stage

### DIFF
--- a/.changeset/cool-otters-wash.md
+++ b/.changeset/cool-otters-wash.md
@@ -1,0 +1,5 @@
+---
+"@callstack/repack": patch
+---
+
+Code-Signing - move execution of the plugin to the later stage of compilation

--- a/packages/repack/src/webpack/plugins/__tests__/CodeSigningPlugin.test.ts
+++ b/packages/repack/src/webpack/plugins/__tests__/CodeSigningPlugin.test.ts
@@ -42,10 +42,12 @@ const injectThisCompilationHookMock = (
             files: new Set([file]),
           })),
           hooks: {
-            processAssets: {
-              tap: jest.fn().mockImplementationOnce((_, processAssetsCB) => {
-                processAssetsCB(assets);
-              }),
+            afterProcessAssets: {
+              tap: jest
+                .fn()
+                .mockImplementationOnce((_, afterProcessAssetsCB) => {
+                  afterProcessAssetsCB(assets);
+                }),
             },
           },
           emitAsset: emitAssetMock,


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

Due to reports of hashes not matching in some projects, the execution of the CodeSigningPlugin was moved to a later stage of compilation. Instead of hooking into `processAssets` hook, we now tap into `afterProcessAssets` hook, which should ensure that we generate the mapping file out of fully processed chunks.
<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->

### Test plan

- UI tests
<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
