### PR TITLE
chore(TesterApp): Improve remote assets and bundles serving for TesterApp

### DIFF
--- a/.changeset/famous-clouds-sparkle.md
+++ b/.changeset/famous-clouds-sparkle.md
@@ -1,0 +1,5 @@
+---
+"testerapp": patch
+---
+
+Improve the way remote assets and bundle are served for Release builds of the TesterApp

--- a/packages/TesterApp/index.js
+++ b/packages/TesterApp/index.js
@@ -21,7 +21,7 @@ ScriptManager.shared.addResolver(async (scriptId, _caller) => {
   }
 
   return {
-    url: Script.getRemoteURL(`http://localhost:5000/${scriptId}`),
+    url: Script.getRemoteURL(`http://localhost:9999/${scriptId}`),
   };
 });
 

--- a/packages/TesterApp/package.json
+++ b/packages/TesterApp/package.json
@@ -9,10 +9,10 @@
     "android": "react-native run-android",
     "ios": "react-native run-ios",
     "start": "react-native webpack-start",
-    "bundle": "react-native webpack-bundle --platform ios --entry-file index.js --dev=false",
-    "webpack": "webpack -c webpack.config.js --env platform=ios --env mode=production",
+    "bundle": "react-native webpack-bundle --platform android --entry-file index.js --dev=false",
+    "webpack": "webpack -c webpack.config.js --env platform=android --env mode=production",
     "test": "vitest run",
-    "serve-remote-assets": "yarn http-server -p 9999 build/output/ios/remote/remote-assets"
+    "serve-remote-assets": "yarn http-server -p 9999 build/output/android/remote && adb reverse tcp:9999 tcp:9999"
   },
   "dependencies": {
     "@callstack/repack": "3.2.0-rc.0",

--- a/packages/TesterApp/webpack.config.mjs
+++ b/packages/TesterApp/webpack.config.mjs
@@ -257,7 +257,7 @@ export default (env) => {
               scalableAssetExtensions: Repack.SCALABLE_ASSETS,
               remote: {
                 enabled: true,
-                publicPath: 'http://localhost:9999',
+                publicPath: 'http://localhost:9999/remote-assets',
               },
             },
           },


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

This PR improves how remote assets and bundles are served in the TesterApp.

After running `yarn serve-remote-assets` a simple server will be started, providing both remote assets and remote bundles. This will help test the release version of the TesterApp for which DevServer is not started and we need to serve remote bundles manually.

<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->

### Test plan

Follow these steps while being in the TesterApp directory:
- yarn bundle
- yarn server-remote-assets
- build the app in the Release scheme/variant
- Remote Chunks and mini-apps as well as Remote Assets should work

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
