### PR TITLE
fix: skip chunks that have no files associated with them

### DIFF
--- a/.changeset/fluffy-flies-tell.md
+++ b/.changeset/fluffy-flies-tell.md
@@ -1,0 +1,5 @@
+---
+"@callstack/repack": patch
+---
+
+Fix OutputPlugin issue where chunks have no associated files with them

--- a/packages/repack/src/webpack/plugins/utils/AssetsCopyProcessor.ts
+++ b/packages/repack/src/webpack/plugins/utils/AssetsCopyProcessor.ts
@@ -45,6 +45,14 @@ export class AssetsCopyProcessor {
 
     // Chunk bundle e.g: `index.bundle`, `src_App_js.chunk.bundle`
     const [chunkFile] = [...chunk.files];
+
+    // Sometimes there are no files associated with the chunk and the OutputPlugin fails
+    // Skipping such chunks is a temporary workaround resulting in proper behaviour
+    // TODO: determine the real cause of this issue
+    if (!chunkFile) {
+      return;
+    }
+
     const relatedSourceMap =
       compilation.assetsInfo.get(chunkFile)?.related?.sourceMap;
     // Source map for the chunk e.g: `index.bundle.map`, `src_App_js.chunk.bundle.map`


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

Temporary workaround for the OutputPlugin's `assetsCopyProcessor` to fix the issue where the whole plugin would fail because of chunks that have no files associated with them.
<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
