### PR TITLE
feat: code-signing integrated tokens

### DIFF
--- a/.changeset/blue-carrots-collect.md
+++ b/.changeset/blue-carrots-collect.md
@@ -1,0 +1,5 @@
+---
+"@callstack/repack": minor
+---
+
+Embed code-signing signatures into the bundles

--- a/packages/repack/android/src/main/java/com/callstack/repack/ChunkConfig.kt
+++ b/packages/repack/android/src/main/java/com/callstack/repack/ChunkConfig.kt
@@ -17,7 +17,6 @@ data class ScriptConfig(
     val body: RequestBody?,
     val timeout: Int,
     val headers: Headers,
-    val token: String?,
     val verifyScriptSignature: Boolean
 ) {
     companion object {
@@ -32,7 +31,6 @@ data class ScriptConfig(
             val bodyString = value.getString("body")
             val headersMap = value.getMap("headers")
             val timeout = value.getInt("timeout")
-            val token = value.getString("token")
             val verifyScriptSignature = value.getBoolean("verifyScriptSignature")
 
             val url = URL(
@@ -66,7 +64,6 @@ data class ScriptConfig(
                 body,
                 timeout,
                 headers.build(),
-                token,
                 verifyScriptSignature
             )
         }

--- a/packages/repack/android/src/main/java/com/callstack/repack/ChunkConfig.kt
+++ b/packages/repack/android/src/main/java/com/callstack/repack/ChunkConfig.kt
@@ -8,37 +8,38 @@ import okhttp3.RequestBody.Companion.toRequestBody
 import java.net.URL
 
 data class ScriptConfig(
-    val id: String,
-    val url: URL,
-    val query: String?,
-    val fetch: Boolean,
-    val absolute: Boolean,
-    val method: String,
-    val body: RequestBody?,
-    val timeout: Int,
-    val headers: Headers,
-    val verifyScriptSignature: Boolean
+        val id: String,
+        val url: URL,
+        val query: String?,
+        val fetch: Boolean,
+        val absolute: Boolean,
+        val method: String,
+        val body: RequestBody?,
+        val timeout: Int,
+        val headers: Headers,
+        val verifyScriptSignature: String,
 ) {
     companion object {
         fun fromReadableMap(id: String, value: ReadableMap): ScriptConfig {
             val urlString = value.getString("url")
-                ?: throw Error("ScriptManagerModule.load ScriptMissing url")
+                    ?: throw Error("ScriptManagerModule.load ScriptMissing url")
             val method = value.getString("method")
-                ?: throw Error("ScriptManagerModule.load ScriptMissing method")
+                    ?: throw Error("ScriptManagerModule.load ScriptMissing method")
             val fetch = value.getBoolean("fetch")
             val absolute = value.getBoolean("absolute")
             val query = value.getString("query")
             val bodyString = value.getString("body")
             val headersMap = value.getMap("headers")
             val timeout = value.getInt("timeout")
-            val verifyScriptSignature = value.getBoolean("verifyScriptSignature")
+            val verifyScriptSignature = value.getString("verifyScriptSignature")
+                    ?: throw Error("ScriptManagerModule.load ScriptMissing verifyScriptSignature")
 
             val url = URL(
-                if (query != null) {
-                    "$urlString?$query"
-                } else {
-                    urlString
-                }
+                    if (query != null) {
+                        "$urlString?$query"
+                    } else {
+                        urlString
+                    }
             )
 
             val headers = Headers.Builder()
@@ -55,16 +56,16 @@ data class ScriptConfig(
             val body = bodyString?.toRequestBody(contentType)
 
             return ScriptConfig(
-                id,
-                url,
-                query,
-                fetch,
-                absolute,
-                method,
-                body,
-                timeout,
-                headers.build(),
-                verifyScriptSignature
+                    id,
+                    url,
+                    query,
+                    fetch,
+                    absolute,
+                    method,
+                    body,
+                    timeout,
+                    headers.build(),
+                    verifyScriptSignature
             )
         }
     }

--- a/packages/repack/android/src/main/java/com/callstack/repack/CodeSigningUtils.kt
+++ b/packages/repack/android/src/main/java/com/callstack/repack/CodeSigningUtils.kt
@@ -6,6 +6,7 @@ import com.nimbusds.jose.JWSVerifier
 import com.nimbusds.jose.crypto.RSASSAVerifier
 import com.nimbusds.jwt.SignedJWT
 import java.math.BigInteger
+import java.nio.charset.Charset
 import java.security.KeyFactory
 import java.security.MessageDigest
 import java.security.NoSuchAlgorithmException
@@ -16,7 +17,7 @@ import java.security.spec.X509EncodedKeySpec
 
 class CodeSigningUtils {
     companion object {
-        private fun getHash(string: String): ByteArray? {
+        private fun getHash(bytes: ByteArray): ByteArray? {
             var digest: MessageDigest? = null
             try {
                 digest = MessageDigest.getInstance("SHA-256")
@@ -24,14 +25,14 @@ class CodeSigningUtils {
                 e1.printStackTrace()
             }
             digest?.reset()
-            return digest?.digest(string.toByteArray())
+            return digest?.digest(bytes)
         }
 
         private fun bin2hex(data: ByteArray): String {
             return java.lang.String.format("%0" + data.size * 2 + "x", BigInteger(1, data))
         }
 
-        private fun computeHash(content: String?): String? {
+        private fun computeHash(content: ByteArray?): String? {
             if (content == null) {
                 return null
             }
@@ -82,7 +83,7 @@ class CodeSigningUtils {
             return null
         }
 
-        fun verifyBundle(context: Context, token: String?, fileContent: String?) {
+        fun verifyBundle(context: Context, token: String?, fileContent: ByteArray?) {
             if (token == null) {
                 throw Exception("The bundle verification failed because no token for the bundle was found.")
             }
@@ -102,6 +103,28 @@ class CodeSigningUtils {
 
             if (contentHash != fileHash) {
                 throw Exception("The bundle verification failed because the bundle hash is invalid.")
+            }
+        }
+
+        fun extractBundleAndToken(fileContent: ByteArray): Pair<ByteArray, String?> {
+            val signatureSize = 1280
+            val startingSequence = "/* RCSSB */"
+
+            // Extract the last 1280 bytes from the ByteArray
+            val lastBytes = fileContent.takeLast(signatureSize).toByteArray()
+
+            val signatureString = lastBytes.toString(Charset.forName("UTF-8"))
+
+            return if (signatureString.startsWith(startingSequence)) {
+                // Bundle is signed
+                val bundle = fileContent.copyOfRange(0, fileContent.size - signatureSize)
+                val signature = signatureString.removePrefix(startingSequence)
+                        .replace("\u0000", "")
+                        .trim()
+                Pair(bundle, signature)
+            } else {
+                // The bundle is not signed, so consider all bytes as bundle
+                Pair(fileContent, null)
             }
         }
     }

--- a/packages/repack/android/src/main/java/com/callstack/repack/CodeSigningUtils.kt
+++ b/packages/repack/android/src/main/java/com/callstack/repack/CodeSigningUtils.kt
@@ -107,23 +107,26 @@ class CodeSigningUtils {
         }
 
         fun extractBundleAndToken(fileContent: ByteArray): Pair<ByteArray, String?> {
+            // in signed bundles, last 1280 bytes are reserved for the token
             val signatureSize = 1280
+            // used to denote beginning of the code-signing section of the bundle
+            // alias for "Repack Code-Signing Signature Begin"
             val startingSequence = "/* RCSSB */"
 
-            // Extract the last 1280 bytes from the ByteArray
+            // extract the last 1280 bytes from the ByteArray
             val lastBytes = fileContent.takeLast(signatureSize).toByteArray()
 
             val signatureString = lastBytes.toString(Charset.forName("UTF-8"))
 
             return if (signatureString.startsWith(startingSequence)) {
-                // Bundle is signed
+                // bundle is signed
                 val bundle = fileContent.copyOfRange(0, fileContent.size - signatureSize)
                 val signature = signatureString.removePrefix(startingSequence)
                         .replace("\u0000", "")
                         .trim()
                 Pair(bundle, signature)
             } else {
-                // The bundle is not signed, so consider all bytes as bundle
+                // bundle is not signed, so consider all bytes as bundle
                 Pair(fileContent, null)
             }
         }

--- a/packages/repack/android/src/main/java/com/callstack/repack/CodeSigningUtils.kt
+++ b/packages/repack/android/src/main/java/com/callstack/repack/CodeSigningUtils.kt
@@ -113,6 +113,10 @@ class CodeSigningUtils {
             // alias for "Repack Code-Signing Signature Begin"
             val startingSequence = "/* RCSSB */"
 
+            // if bundle is smaller than 1280 bytes, treat it as unsigned
+            if (fileContent.size < signatureSize) {
+                return Pair(fileContent, null)
+            }
             // extract the last 1280 bytes from the ByteArray
             val lastBytes = fileContent.takeLast(signatureSize).toByteArray()
 

--- a/packages/repack/android/src/main/java/com/callstack/repack/RemoteChunkLoader.kt
+++ b/packages/repack/android/src/main/java/com/callstack/repack/RemoteChunkLoader.kt
@@ -3,6 +3,7 @@ package com.callstack.repack
 import com.facebook.react.bridge.Promise
 import com.facebook.react.bridge.ReactContext
 import okhttp3.*
+import java.io.BufferedOutputStream
 import java.io.File
 import java.io.IOException
 import java.io.OutputStreamWriter
@@ -44,17 +45,21 @@ class RemoteScriptLoader(private val reactContext: ReactContext) {
                             File(reactContext.filesDir, scriptsDirName).mkdir()
                         }
 
-                        val body = response.body?.string()
+                        val rawBundle = response.body?.bytes()
 
-                        if (config.verifyScriptSignature == true) {
-                            CodeSigningUtils.verifyBundle(reactContext, config.token, body)
+                        val (bundle, token) = rawBundle?.let {
+                            CodeSigningUtils.extractBundleAndToken(rawBundle)
+                        } ?: Pair(null, null)
+
+                        if (config.verifyScriptSignature) {
+                            CodeSigningUtils.verifyBundle(reactContext, token, bundle)
                         }
 
                         file.createNewFile()
 
                         val outputStream = file.outputStream()
-                        val writer = OutputStreamWriter(outputStream)
-                        writer.write(body)
+                        val writer = BufferedOutputStream(outputStream)
+                        writer.write(bundle)
                         writer.close()
                         onSuccess()
                     } catch (error: Exception) {

--- a/packages/repack/android/src/main/java/com/callstack/repack/RemoteChunkLoader.kt
+++ b/packages/repack/android/src/main/java/com/callstack/repack/RemoteChunkLoader.kt
@@ -51,7 +51,7 @@ class RemoteScriptLoader(private val reactContext: ReactContext) {
                             CodeSigningUtils.extractBundleAndToken(rawBundle)
                         } ?: Pair(null, null)
 
-                        if (config.verifyScriptSignature) {
+                        if (config.verifyScriptSignature == "strict" || (config.verifyScriptSignature == "lax" && token != null)) {
                             CodeSigningUtils.verifyBundle(reactContext, token, bundle)
                         }
 

--- a/packages/repack/ios/CodeSigningUtils.swift
+++ b/packages/repack/ios/CodeSigningUtils.swift
@@ -103,7 +103,10 @@ public class CodeSigningUtils: NSObject {
     
     @objc
     public static func extractBundleAndToken(fileContent: NSData?) -> [String: Any] {
+        // in signed bundles, last 1280 bytes are reserved for the token
         let signatureSize = 1280
+        // used to denote beginning of the code-signing section of the bundle
+        // alias for "Repack Code-Signing Signature Begin"
         let startingSequence = "/* RCSSB */"
         
         guard let data = fileContent else {
@@ -112,11 +115,11 @@ public class CodeSigningUtils: NSObject {
         
         let fullData = Data(referencing: data)
         
-        // Extract the last 1280 bytes from the ByteArray
+        // extract the last 1280 bytes from the ByteArray
         let lastBytes = fullData.suffix(signatureSize)
         
         if let signatureString = String(data: lastBytes, encoding: .utf8), signatureString.hasPrefix(startingSequence) {
-            // Bundle is signed
+            // bundle is signed
             let bundle = fullData.prefix(fullData.count - signatureSize)
             let token = signatureString
                 .replacingOccurrences(of: startingSequence, with: "")
@@ -124,7 +127,7 @@ public class CodeSigningUtils: NSObject {
                 .trimmingCharacters(in: .whitespaces)
             return ["bundle": NSData(data: bundle), "token": token]
         } else {
-            // The bundle is not signed, so consider all bytes as bundle
+            // bundle is not signed, so consider all bytes as bundle
             return ["bundle": data, "token": NSNull()]
         }
     }

--- a/packages/repack/ios/CodeSigningUtils.swift
+++ b/packages/repack/ios/CodeSigningUtils.swift
@@ -115,6 +115,11 @@ public class CodeSigningUtils: NSObject {
         
         let fullData = Data(referencing: data)
         
+        // if bundle is smaller than 1280 bytes, treat it as unsigned
+        if fullData.count < signatureSize {
+            return ["bundle": data, "token": NSNull()]
+        }
+        
         // extract the last 1280 bytes from the ByteArray
         let lastBytes = fullData.suffix(signatureSize)
         

--- a/packages/repack/ios/ScriptConfig.h
+++ b/packages/repack/ios/ScriptConfig.h
@@ -12,7 +12,6 @@
 @property (readonly, nullable) NSData *body;
 @property (readonly, nullable) NSDictionary *headers;
 @property (readonly, nonnull) NSNumber *timeout;
-@property (readonly, nullable) NSString *token;
 @property (readonly) BOOL verifyScriptSignature;
 
 + (nonnull ScriptConfig *)fromConfigDictionary:(nonnull NSDictionary *)config
@@ -27,7 +26,6 @@
                    withHeaders:(nullable NSDictionary *)headers
                       withBody:(nullable NSData *)body
                    withTimeout:(nonnull NSNumber *)timeout
-                     withToken:(nullable NSString *)token
      withVerifyScriptSignature:(BOOL)verifyScriptSignature;
 
 @end

--- a/packages/repack/ios/ScriptConfig.h
+++ b/packages/repack/ios/ScriptConfig.h
@@ -12,7 +12,7 @@
 @property (readonly, nullable) NSData *body;
 @property (readonly, nullable) NSDictionary *headers;
 @property (readonly, nonnull) NSNumber *timeout;
-@property (readonly) BOOL verifyScriptSignature;
+@property (readonly, nonnull) NSString *verifyScriptSignature;
 
 + (nonnull ScriptConfig *)fromConfigDictionary:(nonnull NSDictionary *)config
                                   withScriptId:(nonnull NSString*)scriptId;
@@ -23,10 +23,10 @@
                      withQuery:(nullable NSString*)query
                      withFetch:(BOOL)fetch
                   withAbsolute:(BOOL)absolute
-                   withHeaders:(nullable NSDictionary *)headers
-                      withBody:(nullable NSData *)body
-                   withTimeout:(nonnull NSNumber *)timeout
-     withVerifyScriptSignature:(BOOL)verifyScriptSignature;
+                   withHeaders:(nullable NSDictionary*)headers
+                      withBody:(nullable NSData*)body
+                   withTimeout:(nonnull NSNumber*)timeout
+     withVerifyScriptSignature:(nonnull NSString*)verifyScriptSignature;
 
 @end
 

--- a/packages/repack/ios/ScriptConfig.m
+++ b/packages/repack/ios/ScriptConfig.m
@@ -21,7 +21,6 @@
     NSString *query = config[@"query"];
     NSString *method = config[@"method"];
     NSNumber *timeout = config[@"timeout"];
-    BOOL verifyScriptSignature = [config[@"verifyScriptSignature"] boolValue];
     
     if (!urlString) {
         @throw [NSError errorWithDomain:@"Missing url" code:1 userInfo:nil];
@@ -41,7 +40,6 @@
     BOOL fetch = [config[@"fetch"] boolValue];
     BOOL absolute = [config[@"absolute"] boolValue];
     
-    
     return [[ScriptConfig alloc] initWithScript:scriptId
                                           withURL:urlComponents.URL
                                        withMethod:method
@@ -51,7 +49,7 @@
                                       withHeaders:config[@"headers"]
                                          withBody:[config[@"body"] dataUsingEncoding:NSUTF8StringEncoding]
                                       withTimeout:config[@"timeout"]
-                        withVerifyScriptSignature:verifyScriptSignature];
+                        withVerifyScriptSignature:config[@"verifyScriptSignature"]];
 }
 
 - (id)init
@@ -71,7 +69,7 @@
                    withHeaders:(nullable NSDictionary *)headers
                       withBody:(nullable NSData *)body
                    withTimeout:(nonnull NSNumber *)timeout
-     withVerifyScriptSignature:(BOOL)verifyScriptSignature;
+     withVerifyScriptSignature:(NSString *)verifyScriptSignature;
 {
     _scriptId = scriptId;
     _url = url;

--- a/packages/repack/ios/ScriptConfig.m
+++ b/packages/repack/ios/ScriptConfig.m
@@ -12,7 +12,6 @@
 @synthesize body = _body;
 @synthesize headers = _headers;
 @synthesize timeout = _timeout;
-@synthesize token = _token;
 @synthesize verifyScriptSignature = _verifyScriptSignature;
 
 + (ScriptConfig *)fromConfigDictionary:(NSDictionary *)config
@@ -22,7 +21,6 @@
     NSString *query = config[@"query"];
     NSString *method = config[@"method"];
     NSNumber *timeout = config[@"timeout"];
-    NSString *token = config[@"token"];
     BOOL verifyScriptSignature = [config[@"verifyScriptSignature"] boolValue];
     
     if (!urlString) {
@@ -35,10 +33,6 @@
     
     if (!timeout) {
         @throw [NSError errorWithDomain:@"Missing timeout" code:3 userInfo:nil];
-    }
-    
-    if (verifyScriptSignature && !token) {
-        @throw [NSError errorWithDomain:@"Missing token" code:4 userInfo:nil];
     }
     
     NSURLComponents *urlComponents = [NSURLComponents componentsWithString:urlString];
@@ -57,7 +51,6 @@
                                       withHeaders:config[@"headers"]
                                          withBody:[config[@"body"] dataUsingEncoding:NSUTF8StringEncoding]
                                       withTimeout:config[@"timeout"]
-                                        withToken:config[@"token"]
                         withVerifyScriptSignature:verifyScriptSignature];
 }
 
@@ -78,7 +71,6 @@
                    withHeaders:(nullable NSDictionary *)headers
                       withBody:(nullable NSData *)body
                    withTimeout:(nonnull NSNumber *)timeout
-                     withToken:(nullable NSString *)token
      withVerifyScriptSignature:(BOOL)verifyScriptSignature;
 {
     _scriptId = scriptId;
@@ -90,7 +82,6 @@
     _body = body;
     _headers = headers;
     _timeout = timeout;
-    _token = token;
     _verifyScriptSignature = verifyScriptSignature;
     return self;
 }

--- a/packages/repack/ios/ScriptManager.mm
+++ b/packages/repack/ios/ScriptManager.mm
@@ -192,16 +192,20 @@ RCT_EXPORT_METHOD(invalidateScripts:(nonnull NSArray*)scripts
             callback(error);
         } else {
             @try {
+                NSDictionary<NSString *, id> *result = [CodeSigningUtils extractBundleAndTokenWithFileContent:data];
+                NSData *bundle = result[@"bundle"];
+                NSString *token = result[@"token"];
+                
                 if (config.verifyScriptSignature) {
                     NSError *codeSigningError = nil;
-                    [CodeSigningUtils verifyBundleWithToken:config.token fileContent:data error:&codeSigningError];
+                    [CodeSigningUtils verifyBundleWithToken:token fileContent:bundle error:&codeSigningError];
                     if (codeSigningError != nil) {
                         callback(codeSigningError);
                         return;
                     }
                 }
                 [self createScriptsDirectory:scriptsDirectoryPath];
-                [data writeToFile:scriptFilePath options:NSDataWritingAtomic error:&error];
+                [bundle writeToFile:scriptFilePath options:NSDataWritingAtomic error:&error];
                 callback(nil);
             } @catch (NSError *error) {
                 callback(error);

--- a/packages/repack/ios/ScriptManager.mm
+++ b/packages/repack/ios/ScriptManager.mm
@@ -193,10 +193,10 @@ RCT_EXPORT_METHOD(invalidateScripts:(nonnull NSArray*)scripts
         } else {
             @try {
                 NSDictionary<NSString *, id> *result = [CodeSigningUtils extractBundleAndTokenWithFileContent:data];
-                NSData *bundle = result[@"bundle"];
-                NSString *token = result[@"token"];
+                NSData *bundle = (result[@"bundle"] != [NSNull null]) ? result[@"bundle"] : nil;
+                NSString *token = (result[@"token"] != [NSNull null]) ? result[@"token"] : nil;
                 
-                if ([verifyScriptSignature isEqualToString:@"strict"] || ([verifyScriptSignature isEqualToString:@"lax"] && token != [NSNull null])) {
+                if ([config.verifyScriptSignature isEqualToString:@"strict"] || ([config.verifyScriptSignature isEqualToString:@"lax"] && token != nil)) {
                     NSError *codeSigningError = nil;
                     [CodeSigningUtils verifyBundleWithToken:token fileContent:bundle error:&codeSigningError];
                     if (codeSigningError != nil) {

--- a/packages/repack/ios/ScriptManager.mm
+++ b/packages/repack/ios/ScriptManager.mm
@@ -196,7 +196,7 @@ RCT_EXPORT_METHOD(invalidateScripts:(nonnull NSArray*)scripts
                 NSData *bundle = result[@"bundle"];
                 NSString *token = result[@"token"];
                 
-                if (config.verifyScriptSignature) {
+                if ([verifyScriptSignature isEqualToString:@"strict"] || ([verifyScriptSignature isEqualToString:@"lax"] && token != [NSNull null])) {
                     NSError *codeSigningError = nil;
                     [CodeSigningUtils verifyBundleWithToken:token fileContent:bundle error:&codeSigningError];
                     if (codeSigningError != nil) {

--- a/packages/repack/src/modules/ScriptManager/Script.ts
+++ b/packages/repack/src/modules/ScriptManager/Script.ts
@@ -114,7 +114,7 @@ export class Script {
         body,
         headers: Object.keys(headers).length ? headers : undefined,
         fetch: locator.cache === false ? true : fetch,
-        verifyScriptSignature: locator.verifyScriptSignature ?? false,
+        verifyScriptSignature: locator.verifyScriptSignature ?? 'off',
       },
       locator.cache
     );

--- a/packages/repack/src/modules/ScriptManager/Script.ts
+++ b/packages/repack/src/modules/ScriptManager/Script.ts
@@ -114,7 +114,6 @@ export class Script {
         body,
         headers: Object.keys(headers).length ? headers : undefined,
         fetch: locator.cache === false ? true : fetch,
-        token: locator.token,
         verifyScriptSignature: locator.verifyScriptSignature ?? false,
       },
       locator.cache

--- a/packages/repack/src/modules/ScriptManager/__tests__/ScriptManager.test.ts
+++ b/packages/repack/src/modules/ScriptManager/__tests__/ScriptManager.test.ts
@@ -92,7 +92,7 @@ describe('ScriptManagerAPI', () => {
       absolute: false,
       method: 'GET',
       timeout: Script.DEFAULT_TIMEOUT,
-      verifyScriptSignature: false,
+      verifyScriptSignature: 'off',
     });
 
     const {
@@ -120,7 +120,7 @@ describe('ScriptManagerAPI', () => {
       absolute: false,
       method: 'GET',
       timeout: Script.DEFAULT_TIMEOUT,
-      verifyScriptSignature: false,
+      verifyScriptSignature: 'off',
     });
   });
 
@@ -147,7 +147,7 @@ describe('ScriptManagerAPI', () => {
       absolute: false,
       method: 'GET',
       timeout: Script.DEFAULT_TIMEOUT,
-      verifyScriptSignature: false,
+      verifyScriptSignature: 'off',
     });
   });
 
@@ -174,7 +174,7 @@ describe('ScriptManagerAPI', () => {
       method: 'GET',
       query: 'accessCode=1234&accessUid=asdf',
       timeout: Script.DEFAULT_TIMEOUT,
-      verifyScriptSignature: false,
+      verifyScriptSignature: 'off',
     });
 
     ScriptManager.shared.removeAllResolvers();
@@ -214,7 +214,7 @@ describe('ScriptManagerAPI', () => {
       method: 'GET',
       headers: { 'x-hello': 'world' },
       timeout: Script.DEFAULT_TIMEOUT,
-      verifyScriptSignature: false,
+      verifyScriptSignature: 'off',
     });
 
     ScriptManager.shared.removeAllResolvers();
@@ -238,7 +238,7 @@ describe('ScriptManagerAPI', () => {
       method: 'GET',
       headers: { 'x-hello': 'world', 'x-changed': 'true' },
       timeout: Script.DEFAULT_TIMEOUT,
-      verifyScriptSignature: false,
+      verifyScriptSignature: 'off',
     });
   });
 
@@ -263,7 +263,7 @@ describe('ScriptManagerAPI', () => {
       method: 'POST',
       body: 'hello_world',
       timeout: Script.DEFAULT_TIMEOUT,
-      verifyScriptSignature: false,
+      verifyScriptSignature: 'off',
     });
 
     ScriptManager.shared.removeAllResolvers();
@@ -285,7 +285,7 @@ describe('ScriptManagerAPI', () => {
       method: 'POST',
       body: 'message',
       timeout: Script.DEFAULT_TIMEOUT,
-      verifyScriptSignature: false,
+      verifyScriptSignature: 'off',
     });
   });
 
@@ -313,7 +313,7 @@ describe('ScriptManagerAPI', () => {
       absolute: true,
       method: 'POST',
       timeout: Script.DEFAULT_TIMEOUT,
-      verifyScriptSignature: false,
+      verifyScriptSignature: 'off',
     });
   });
 

--- a/packages/repack/src/modules/ScriptManager/federated.ts
+++ b/packages/repack/src/modules/ScriptManager/federated.ts
@@ -217,43 +217,6 @@ export namespace Federated {
     };
   }
 
-  export function createTokenResolver(
-    tokens: Record<string, string> | undefined
-  ): (scriptId: string, caller?: string) => string | undefined {
-    let chunkKeys: string[];
-
-    if (tokens) {
-      chunkKeys = Object.keys(tokens).filter(
-        (key) => !key.includes('.container.bundle')
-      );
-    } else {
-      chunkKeys = [];
-    }
-
-    const resolver = (
-      chunkKeys: string[],
-      scriptId: string,
-      caller?: string
-    ) => {
-      let tokenKey;
-      if (caller === undefined) {
-        tokenKey = scriptId + '.container.bundle';
-      } else {
-        tokenKey = chunkKeys.find((key) => key.includes(scriptId));
-      }
-
-      if (!tokens || !tokenKey) {
-        return undefined;
-      }
-
-      return tokens[tokenKey];
-    };
-
-    return (scriptId, caller) => {
-      return resolver(chunkKeys, scriptId, caller);
-    };
-  }
-
   declare function __webpack_init_sharing__(scope: string): Promise<void>;
   declare var __webpack_share_scopes__: Record<string, any>;
   declare var self: Record<string, any>;

--- a/packages/repack/src/modules/ScriptManager/types.ts
+++ b/packages/repack/src/modules/ScriptManager/types.ts
@@ -89,7 +89,15 @@ export interface ScriptLocator {
    */
   cache?: boolean;
 
-  verifyScriptSignature?: boolean;
+  /**
+   * Flag to enable script's code-signature verification. By default set to `none`
+   *
+   * `strict` means that the script's code-signature will be verfied regardless of the signature being present in the bundle
+   * `lax` means that the script's code-signature will be verfied only when the signature is present in the bundle
+   *  if the signature is not present in the bundle, the script will be loaded without verification
+   * `off` means that the script's code-signature will not be verfied
+   */
+  verifyScriptSignature?: 'strict' | 'lax' | 'off';
   /**
    * Function called before loading or getting from the cache and after resolving the script locator.
    * It's an async function which should return a boolean indicating whether the script should be loaded or use default behaviour.
@@ -172,5 +180,6 @@ export interface NormalizedScriptLocator {
   /** Request body. */
   body?: string;
 
-  verifyScriptSignature?: boolean;
+  /** Whether script's signature should be verified or not */
+  verifyScriptSignature?: 'strict' | 'lax' | 'off';
 }

--- a/packages/repack/src/modules/ScriptManager/types.ts
+++ b/packages/repack/src/modules/ScriptManager/types.ts
@@ -89,8 +89,6 @@ export interface ScriptLocator {
    */
   cache?: boolean;
 
-  token?: string;
-
   verifyScriptSignature?: boolean;
   /**
    * Function called before loading or getting from the cache and after resolving the script locator.
@@ -173,8 +171,6 @@ export interface NormalizedScriptLocator {
 
   /** Request body. */
   body?: string;
-
-  token?: string;
 
   verifyScriptSignature?: boolean;
 }

--- a/packages/repack/src/webpack/plugins/CodeSigningPlugin.ts
+++ b/packages/repack/src/webpack/plugins/CodeSigningPlugin.ts
@@ -51,11 +51,7 @@ export class CodeSigningPlugin implements WebpackPlugin {
     compiler.hooks.thisCompilation.tap(pluginName, (compilation) => {
       // we need to make sure that assets are fully processed in order
       // to create a code-signing mapping.
-      compilation.hooks.afterProcessAssets.tap(pluginName, (assets) => {
-        // "assets" is an object that contains all assets
-        // in the compilation, the keys of the object are pathnames of the assets
-        // and the values are file sources.
-
+      compilation.hooks.afterProcessAssets.tap(pluginName, () => {
         // adjust for chunk name to filename
         compilation.chunks.forEach((chunk) => {
           chunk.files.forEach((file) => {

--- a/packages/repack/src/webpack/plugins/CodeSigningPlugin.ts
+++ b/packages/repack/src/webpack/plugins/CodeSigningPlugin.ts
@@ -99,11 +99,7 @@ export class CodeSigningPlugin implements WebpackPlugin {
 
             await fs.ensureDir(this.config.outputPath);
             await fs.writeFile(
-              path.join(
-                compiler.context,
-                this.config.outputPath,
-                `${chunk}.signed`
-              ),
+              path.join(compiler.context, this.config.outputPath, chunk),
               signedBundle
             );
           })

--- a/packages/repack/src/webpack/plugins/CodeSigningPlugin.ts
+++ b/packages/repack/src/webpack/plugins/CodeSigningPlugin.ts
@@ -9,10 +9,8 @@ import type { WebpackPlugin } from '../../types';
  * {@link CodeSigningPlugin} configuration options.
  */
 export interface CodeSigningPluginConfig {
-  /** Output file name. */
-  outputFile?: string;
-  /** Output path to a directory, where code-signing mapping file should be saved. */
-  outputPath?: string;
+  /** Output path to a directory, where signed bundles should be saved. */
+  outputPath: string;
   /** Path to the private key. */
   privateKeyPath: string;
   /** Names of chunks to exclude from being signed. */
@@ -26,8 +24,6 @@ export class CodeSigningPlugin implements WebpackPlugin {
    * @param config Plugin configuration options.
    */
   constructor(private config: CodeSigningPluginConfig) {
-    this.config.outputFile =
-      this.config.outputFile ?? 'code_signing_mapping.json';
     this.config.privateKeyPath = this.config.privateKeyPath ?? './private.pem';
   }
 
@@ -38,12 +34,15 @@ export class CodeSigningPlugin implements WebpackPlugin {
    */
   apply(compiler: webpack.Compiler) {
     const pluginName = CodeSigningPlugin.name;
+    // reserve 1280 bytes for the token even if it's smaller
+    // to leave some space for future additions to the JWT without breaking compatibility
+    const tokenBufferSize = 1280;
     const privateKeyPath = path.join(
       compiler.context,
       this.config.privateKeyPath
     );
     const privateKey = fs.readFileSync(privateKeyPath);
-
+    const chunkFiles = new Set<string>();
     // Tapping to the "thisCompilation" hook in order to further tap
     // to the compilation process on an later stage.
     compiler.hooks.thisCompilation.tap(pluginName, (compilation) => {
@@ -53,7 +52,7 @@ export class CodeSigningPlugin implements WebpackPlugin {
         // "assets" is an object that contains all assets
         // in the compilation, the keys of the object are pathnames of the assets
         // and the values are file sources.
-        const chunkFiles = new Set<string>();
+
         // adjust for chunk name to filename
         compilation.chunks.forEach((chunk) => {
           chunk.files.forEach((file) => {
@@ -68,12 +67,14 @@ export class CodeSigningPlugin implements WebpackPlugin {
             chunkFiles.add(file);
           });
         });
+      });
 
-        const content = Object.entries(assets)
-          .filter(([fileName]) => chunkFiles.has(fileName))
-          .reduce((acc, [fileName, file]) => {
-            // get bundle
-            const bundle = file.source();
+      compiler.hooks.afterEmit.tapPromise(pluginName, async (compilation) => {
+        await Promise.all(
+          Array.from(chunkFiles).map(async (chunk) => {
+            const bundle = await fs.readFile(
+              path.join(compilation.outputOptions.path!, chunk)
+            );
 
             // generate bundle hash
             const hash = crypto
@@ -86,29 +87,27 @@ export class CodeSigningPlugin implements WebpackPlugin {
               algorithm: 'RS256',
             });
 
-            acc[fileName] = token;
+            // combine the bundle and the token
+            const tokenBuffer = Buffer.from(token);
+            const signedBundle = Buffer.alloc(bundle.length + tokenBufferSize);
 
-            return acc;
-          }, {} as Record<string, string>);
+            bundle.copy(signedBundle);
+            tokenBuffer.copy(
+              signedBundle,
+              bundle.length + tokenBufferSize - tokenBuffer.length
+            );
 
-        const json = JSON.stringify(content);
-
-        if (this.config.outputPath) {
-          fs.ensureDirSync(this.config.outputPath);
-          fs.writeFileSync(
-            path.join(
-              compiler.context,
-              this.config.outputPath,
-              this.config.outputFile!
-            ),
-            json
-          );
-        } else {
-          compilation.emitAsset(
-            this.config.outputFile!,
-            new webpack.sources.RawSource(json)
-          );
-        }
+            await fs.ensureDir(this.config.outputPath);
+            await fs.writeFile(
+              path.join(
+                compiler.context,
+                this.config.outputPath,
+                `${chunk}.signed`
+              ),
+              signedBundle
+            );
+          })
+        );
       });
     });
   }

--- a/packages/repack/src/webpack/plugins/__tests__/CodeSigningPlugin.test.ts
+++ b/packages/repack/src/webpack/plugins/__tests__/CodeSigningPlugin.test.ts
@@ -110,7 +110,7 @@ describe('CodeSigningPlugin', () => {
     expect(bundle2.byteLength).toBeGreaterThan(1280);
   });
 
-  it('produces code-signing-mapping file with valid JWTs', async () => {
+  it('produces code-signed bundles with valid JWTs', async () => {
     const chunks = {
       'example.container.bundle': {
         id: 'example_container',

--- a/packages/repack/src/webpack/plugins/__tests__/CodeSigningPlugin.test.ts
+++ b/packages/repack/src/webpack/plugins/__tests__/CodeSigningPlugin.test.ts
@@ -1,4 +1,6 @@
-import crypto from 'crypto';
+/* eslint-disable promise/prefer-await-to-then */
+/* eslint-disable no-control-regex */
+
 import path from 'path';
 import fs from 'fs-extra';
 import jwt from 'jsonwebtoken';
@@ -31,7 +33,7 @@ const compilerMock = {
 
 const injectHookMocks = (
   chunks: Record<string, { id: string }>,
-  resolve: () => void,
+  control: { resolve: () => void; reject: () => void },
   mainOutputBundleFilename: string = 'index.bundle'
 ) => {
   compilerMock.hooks.thisCompilation.tap.mockImplementationOnce(
@@ -59,7 +61,9 @@ const injectHookMocks = (
         outputOptions: {
           path: path.join(__dirname, '__fixtures__'),
         },
-      }).then(resolve);
+      })
+        .then(control.resolve)
+        .catch(control.reject);
     }
   );
 };
@@ -83,8 +87,8 @@ describe('CodeSigningPlugin', () => {
       privateKeyPath: '__fixtures__/testRS256.pem',
     });
 
-    await new Promise<void>((resolve) => {
-      injectHookMocks(chunks, resolve);
+    await new Promise<void>((resolve, reject) => {
+      injectHookMocks(chunks, { resolve, reject });
       pluginInstance.apply(compilerMock as unknown as webpack.Compiler);
     });
 
@@ -121,8 +125,8 @@ describe('CodeSigningPlugin', () => {
       privateKeyPath: '__fixtures__/testRS256.pem',
     });
 
-    await new Promise<void>((resolve) => {
-      injectHookMocks(chunks, resolve);
+    await new Promise<void>((resolve, reject) => {
+      injectHookMocks(chunks, { resolve, reject });
       pluginInstance.apply(compilerMock as unknown as webpack.Compiler);
     });
 
@@ -171,8 +175,8 @@ describe('CodeSigningPlugin', () => {
       privateKeyPath: '__fixtures__/testRS256.pem',
     });
 
-    await new Promise<void>((resolve) => {
-      injectHookMocks(chunks, resolve, mainOutputBundleFilename);
+    await new Promise<void>((resolve, reject) => {
+      injectHookMocks(chunks, { resolve, reject }, mainOutputBundleFilename);
       pluginInstance.apply(compilerMock as unknown as webpack.Compiler);
     });
 
@@ -206,8 +210,8 @@ describe('CodeSigningPlugin', () => {
       excludeChunks: ['local_chunk'],
     });
 
-    await new Promise<void>((resolve) => {
-      injectHookMocks(chunks, resolve, 'main.bundle');
+    await new Promise<void>((resolve, reject) => {
+      injectHookMocks(chunks, { resolve, reject }, 'main.bundle');
       pluginInstance.apply(compilerMock as unknown as webpack.Compiler);
     });
 

--- a/packages/repack/src/webpack/plugins/__tests__/__fixtures__/example.chunk.bundle
+++ b/packages/repack/src/webpack/plugins/__tests__/__fixtures__/example.chunk.bundle
@@ -1,0 +1,1 @@
+var name = "example chunk bundle";

--- a/packages/repack/src/webpack/plugins/__tests__/__fixtures__/example.container.bundle
+++ b/packages/repack/src/webpack/plugins/__tests__/__fixtures__/example.container.bundle
@@ -1,0 +1,1 @@
+var name = "example container bundle";

--- a/packages/repack/src/webpack/plugins/__tests__/__fixtures__/local.chunk.bundle
+++ b/packages/repack/src/webpack/plugins/__tests__/__fixtures__/local.chunk.bundle
@@ -1,0 +1,1 @@
+var name = "local chunk bundle";

--- a/packages/repack/src/webpack/plugins/__tests__/__fixtures__/main.bundle
+++ b/packages/repack/src/webpack/plugins/__tests__/__fixtures__/main.bundle
@@ -1,0 +1,1 @@
+var name = "index bundle";


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

This PR integrates the the tokens generated by `CodeSigningPlugin` to the bundles. This removes the need for matching the tokens with the bundles in the `ScriptManager` setup.

### Description

By embedding the tokens directly into the bundles we can eliminate the need of creating `tokenResolver` and fetching the tokens separately. After downloading the bundle, RePack will now evaluate whether the bundle is signed or not, extract the token and perform verification (if enabled). This solution comes with one tradeoff

The behaviour of `verifyScriptSignature` flag (as well as it's type) was changed. From now on, by default, the flag is set to `none`, which means no code-signature verification will take place. You can set the flag to one of the following string literals to control the verification process: `strict`, `lax`, or `off`.

| Value   | Description |
|---------------|-------------|
| `strict` | The script's code-signature will be verified regardless of the signature being present in the bundle. |
| `lax`     | The script's code-signature will be verified only when the signature is present in the bundle. If the signature is not present in the bundle, the script will be loaded without verification. |
| `off`     | The script's code-signature will not be verified. |

This solution is also compatible with `.hbc` bundles produced by hermes compiler.

### Usage

1. Generate a pair of private & public RS256 keys that will be used for code-signing (like [this](https://gist.github.com/ygotthilf/baa58da5c3dd1f69fae9))
2. Add `Repack.CodeSigningPlugin` to the list of plugins in `webpack.config` and configure it with path to the private key and name of the output file.
```js
new Repack.plugins.CodeSigningPlugin({
        privateKeyPath: './private.pem',
        outputPath: path.join(dirname, 'build/outputs', platform, 'remote'),
        excludedChunks: [ 'local_chunk' ]
}),
```
3. Configure the ScriptManager. Inside of `ScriptManager.shared.addResolver` do the following:
  a. Add `verifyScriptSignature` key set to `true` and pass the resolved `token` from the previous step to the config returned from `ScriptManager.shared.addResolver`
```js
ScriptManager.shared.addResolver(async (scriptId, caller) => {
  // ...
  
  let url;
  let token;
  if (caller === 'main') {
    url = Script.getDevServerURL(scriptId);
  } else {
    url = resolveURL(scriptId, caller);
  }
  
  if (!url) {
    return undefined;
  }
  
  return {
    url,
    verifyScriptSignature: 'strict', // or 'lax' or 'off'
    query: { platform: Platform.OS },
  };
});
```

### Test plan

- UI tests
- tested on super-app-showcase
