### PR TITLE
fix: Replace too broad regexp in babel-loader config in webpack config templates

### DIFF
--- a/packages/TesterApp/webpack.config.mjs
+++ b/packages/TesterApp/webpack.config.mjs
@@ -139,7 +139,7 @@ export default (env) => {
           test: /\.[jt]sx?$/,
           include: [
             /node_modules(.*[/\\])+react\//,
-            /node_modules(.*[/\\])+react-native\//,
+            /node_modules(.*[/\\])+react-native/,
             /node_modules(.*[/\\])+@react-native/,
             /node_modules(.*[/\\])+@react-navigation/,
             /node_modules(.*[/\\])+@react-native-community/,

--- a/packages/TesterApp/webpack.config.mjs
+++ b/packages/TesterApp/webpack.config.mjs
@@ -138,7 +138,8 @@ export default (env) => {
         {
           test: /\.[jt]sx?$/,
           include: [
-            /node_modules(.*[/\\])+react/,
+            /node_modules(.*[/\\])+react\//,
+            /node_modules(.*[/\\])+react-native\//,
             /node_modules(.*[/\\])+@react-native/,
             /node_modules(.*[/\\])+@react-navigation/,
             /node_modules(.*[/\\])+@react-native-community/,

--- a/templates/webpack.config.cjs
+++ b/templates/webpack.config.cjs
@@ -148,7 +148,8 @@ module.exports = (env) => {
         {
           test: /\.[jt]sx?$/,
           include: [
-            /node_modules(.*[/\\])+react/,
+            /node_modules(.*[/\\])+react\//,
+            /node_modules(.*[/\\])+react-native\//,
             /node_modules(.*[/\\])+@react-native/,
             /node_modules(.*[/\\])+@react-navigation/,
             /node_modules(.*[/\\])+@react-native-community/,

--- a/templates/webpack.config.cjs
+++ b/templates/webpack.config.cjs
@@ -149,7 +149,7 @@ module.exports = (env) => {
           test: /\.[jt]sx?$/,
           include: [
             /node_modules(.*[/\\])+react\//,
-            /node_modules(.*[/\\])+react-native\//,
+            /node_modules(.*[/\\])+react-native/,
             /node_modules(.*[/\\])+@react-native/,
             /node_modules(.*[/\\])+@react-navigation/,
             /node_modules(.*[/\\])+@react-native-community/,

--- a/templates/webpack.config.mjs
+++ b/templates/webpack.config.mjs
@@ -49,7 +49,7 @@ export default (env) => {
   // if (devServer) {
   //   devServer.hmr = false;
   // }
-  
+
   /**
    * Depending on your Babel configuration you might want to keep it.
    * If you don't use `env` in your Babel config, you can remove it.
@@ -150,7 +150,8 @@ export default (env) => {
         {
           test: /\.[jt]sx?$/,
           include: [
-            /node_modules(.*[/\\])+react/,
+            /node_modules(.*[/\\])+react\//,
+            /node_modules(.*[/\\])+react-native\//,
             /node_modules(.*[/\\])+@react-native/,
             /node_modules(.*[/\\])+@react-navigation/,
             /node_modules(.*[/\\])+@react-native-community/,

--- a/templates/webpack.config.mjs
+++ b/templates/webpack.config.mjs
@@ -151,7 +151,7 @@ export default (env) => {
           test: /\.[jt]sx?$/,
           include: [
             /node_modules(.*[/\\])+react\//,
-            /node_modules(.*[/\\])+react-native\//,
+            /node_modules(.*[/\\])+react-native/,
             /node_modules(.*[/\\])+@react-native/,
             /node_modules(.*[/\\])+@react-navigation/,
             /node_modules(.*[/\\])+@react-native-community/,

--- a/website/static/diffs/repack_v2-v3.diff
+++ b/website/static/diffs/repack_v2-v3.diff
@@ -8,12 +8,12 @@ index 6ff525d..af917c4 100644
  const TerserPlugin = require('terser-webpack-plugin');
 -const ReactNative = require('@callstack/repack');
 +const Repack = require('@callstack/repack');
- 
+
  /**
   * More documentation, installation, usage, motivation and differences with Metro is available at:
 @@ -12,292 +11,223 @@ const ReactNative = require('@callstack/repack');
   */
- 
+
  /**
 - * This is the Webpack configuration file for your React Native project.
 - * It can be used in 2 ways:
@@ -50,7 +50,7 @@ index 6ff525d..af917c4 100644
 +    assetsPath = undefined,
 +    reactNativePath = require.resolve('react-native'),
 +  } = env;
- 
+
 -const mode = ReactNative.getMode({ fallback: 'development' });
 -const dev = mode === 'development';
 -const context = ReactNative.getContext();
@@ -72,7 +72,7 @@ index 6ff525d..af917c4 100644
 +  if (!platform) {
 +    throw new Error('Missing platform');
 +  }
- 
+
 -/**
 - * Webpack configuration.
 - */
@@ -230,7 +230,7 @@ index 6ff525d..af917c4 100644
 -        test: /\.[jt]sx?$/,
 -        include: [
 -          /node_modules(.*[/\\])+react\//,
--          /node_modules(.*[/\\])+react-native\//,
+-          /node_modules(.*[/\\])+react-native/,
 -          /node_modules(.*[/\\])+@react-native/,
 -          /node_modules(.*[/\\])+@react-navigation/,
 -          /node_modules(.*[/\\])+@react-native-community/,
@@ -287,7 +287,7 @@ index 6ff525d..af917c4 100644
 +          test: /\.[jt]sx?$/,
 +          include: [
 +            /node_modules(.*[/\\])+react\//,
-+            /node_modules(.*[/\\])+react-native\//,
++            /node_modules(.*[/\\])+react-native/,
 +            /node_modules(.*[/\\])+@react-native/,
 +            /node_modules(.*[/\\])+@react-navigation/,
 +            /node_modules(.*[/\\])+@react-native-community/,

--- a/website/static/diffs/repack_v2-v3.diff
+++ b/website/static/diffs/repack_v2-v3.diff
@@ -229,7 +229,8 @@ index 6ff525d..af917c4 100644
 -      {
 -        test: /\.[jt]sx?$/,
 -        include: [
--          /node_modules(.*[/\\])+react/,
+-          /node_modules(.*[/\\])+react\//,
+-          /node_modules(.*[/\\])+react-native\//,
 -          /node_modules(.*[/\\])+@react-native/,
 -          /node_modules(.*[/\\])+@react-navigation/,
 -          /node_modules(.*[/\\])+@react-native-community/,
@@ -285,7 +286,8 @@ index 6ff525d..af917c4 100644
 +        {
 +          test: /\.[jt]sx?$/,
 +          include: [
-+            /node_modules(.*[/\\])+react/,
++            /node_modules(.*[/\\])+react\//,
++            /node_modules(.*[/\\])+react-native\//,
 +            /node_modules(.*[/\\])+@react-native/,
 +            /node_modules(.*[/\\])+@react-navigation/,
 +            /node_modules(.*[/\\])+@react-native-community/,


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

This PR addresses the issue of a too-broad regexp used in the webpack config templates – specifically `babel-loader` `include` array. The regexp at issue matched every package with a name starting with `react`. Merging this PR will prevent issues like #358. Unfortunately, since the template is not a part of Repack, this fix cannot be released and pulled by Repack users – everyone already using Repack would have to change the config manually.

For all new apps created using `repack-init`, this wouldn't be a problem since the script is using the latest version of the templates from the `main` branch.
