### PR TITLE
chore: bump node version on CI to 18 & 20

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        node_version: ['14', '16']
+        node_version: ['18', '20']
         os: [ubuntu-latest]
 
     steps:


### PR DESCRIPTION
### Summary

Bumped node version on CI from `14` & `16` to `18` & `20`
