### PR TITLE
fix: don't run preview docs CI job when source branch comes from a fork

### DIFF
--- a/.github/workflows/deploy-pr.yml
+++ b/.github/workflows/deploy-pr.yml
@@ -9,18 +9,18 @@ jobs:
     runs-on: ubuntu-latest
 
     # Skip running on forks since it won't have access to secrets
-    if: github.repository == 'callstack/repack'
+    if: github.event.pull_request.head.repo.full_name == github.repository
 
     steps:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      
+
       - name: Use Node.js 18
         uses: actions/setup-node@v3
         with:
           node-version: 18
-          cache: 'yarn'
+          cache: "yarn"
 
       - name: Install dependencies
         run: yarn install --immutable


### PR DESCRIPTION
### Summary

When someone creates a PR from a fork, running a `Deploy Website` job will fail because it won't have access to secrets.
This change addresses that and won't waste time running a job that will eventually fail