### PR TITLE
Add cli-progress to the repack cli

### DIFF
--- a/packages/repack/package.json
+++ b/packages/repack/package.json
@@ -60,6 +60,7 @@
   "dependencies": {
     "@callstack/repack-dev-server": "^1.0.1",
     "@pmmmwh/react-refresh-webpack-plugin": "^0.5.7",
+    "cli-progress": "^3.12.0",
     "colorette": "^1.2.2",
     "dedent": "^0.7.0",
     "escape-string-regexp": "^4.0.0",

--- a/packages/repack/package.json
+++ b/packages/repack/package.json
@@ -91,6 +91,7 @@
     "@callstack/eslint-config": "^11.0.0",
     "@react-native-community/cli": "5.0.1-alpha.1",
     "@react-native-community/cli-types": "5.0.1-alpha.1",
+    "@types/cli-progress": "^3.11.0",
     "@types/dedent": "^0.7.0",
     "@types/fs-extra": "^9.0.11",
     "@types/jest": "^28.1.1",

--- a/packages/repack/src/logging/reporters/ConsoleReporter.ts
+++ b/packages/repack/src/logging/reporters/ConsoleReporter.ts
@@ -34,7 +34,7 @@ export class ConsoleReporter implements Reporter {
 }
 
 class JsonConsoleReporter implements Reporter {
-  constructor(private config: ConsoleReporterConfig) { }
+  constructor(private config: ConsoleReporterConfig) {}
 
   process(log: LogEntry) {
     console.log(JSON.stringify(log));
@@ -79,7 +79,8 @@ class InteractiveConsoleReporter implements Reporter {
 
   constructor(private config: ConsoleReporterConfig) {
     this.bar.start(100, 0);
-   }
+    this.bar.update(0, { platform: '' });
+  }
 
   process(log: LogEntry) {
     // Do not log anything in silent mode
@@ -120,7 +121,15 @@ class InteractiveConsoleReporter implements Reporter {
     };
 
     const percentage = Math.floor(value * 100);
-    this.bar.update(percentage,{platform})  }, 2000);
+    if (percentage > 0) {
+      // Update the progress bar label only if the percentage is greater than 0
+      this.bar.update(percentage, { platform });
+    } else {
+      // For 0% progress, update the label to an empty string
+      this.bar.update(percentage, { platform: '' });
+    }
+  }, 2000);
+ 
 
   private normalizeLog(log: LogEntry): LogEntry | undefined {
     const message = [];

--- a/yarn.lock
+++ b/yarn.lock
@@ -4912,6 +4912,7 @@ __metadata:
     "@pmmmwh/react-refresh-webpack-plugin": ^0.5.7
     "@react-native-community/cli": 5.0.1-alpha.1
     "@react-native-community/cli-types": 5.0.1-alpha.1
+    "@types/cli-progress": ^3.11.0
     "@types/dedent": ^0.7.0
     "@types/fs-extra": ^9.0.11
     "@types/jest": ^28.1.1
@@ -4924,6 +4925,7 @@ __metadata:
     "@types/shallowequal": ^1.1.1
     babel-jest: ^28.1.1
     babel-loader: ^8.2.2
+    cli-progress: ^3.12.0
     colorette: ^1.2.2
     dedent: ^0.7.0
     escape-string-regexp: ^4.0.0
@@ -8576,6 +8578,15 @@ __metadata:
   dependencies:
     classnames: "*"
   checksum: 09a17ea08fcb83380921efdfdac94cfa162f87025cae0bf6f4ba508c2fa5f436459ce7612905a3f968fdddb68c03b8e6ff08e762ed2d0c110c5c4fceb244dc55
+  languageName: node
+  linkType: hard
+
+"@types/cli-progress@npm:^3.11.0":
+  version: 3.11.0
+  resolution: "@types/cli-progress@npm:3.11.0"
+  dependencies:
+    "@types/node": "*"
+  checksum: d4401622333e888925b47c5d5bb0b89dddae17cc020f909a64ad7275b326bf3c6e9cd467f625a197fd958a1e49220d32f4a2b0bf2948fee330c719a9b985674e
   languageName: node
   linkType: hard
 
@@ -12592,6 +12603,15 @@ __metadata:
   dependencies:
     restore-cursor: ^4.0.0
   checksum: ab3f3ea2076e2176a1da29f9d64f72ec3efad51c0960898b56c8a17671365c26e67b735920530eaf7328d61f8bd41c27f46b9cf6e4e10fe2fa44b5e8c0e392cc
+  languageName: node
+  linkType: hard
+
+"cli-progress@npm:^3.12.0":
+  version: 3.12.0
+  resolution: "cli-progress@npm:3.12.0"
+  dependencies:
+    string-width: ^4.2.3
+  checksum: e8390dc3cdf3c72ecfda0a1e8997bfed63a0d837f97366bbce0ca2ff1b452da386caed007b389f0fe972625037b6c8e7ab087c69d6184cc4dfc8595c4c1d3e6e
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Closes #369 

I've been using Repack for quite a while and although the functionalities of this project impressed me, I wasn't happy with the way progress of bundling process was shown in the terminal. So, I rolled up my sleeves and tried to make it neater and as informative as before for the developers who want to utilize this package.

The package that I used for this matter is "cli-progress" and changed the "consoleReporters.js" file. Feel free to change the way progress is shown on the Terminal by changing the presets bundled with the mentioned package and let me know if any changes from my side was required.
