### PR TITLE
chore(repack): Add namespace to build.gradle for react-native 0.73+ compat

### DIFF
--- a/.changeset/slow-knives-obey.md
+++ b/.changeset/slow-knives-obey.md
@@ -1,0 +1,5 @@
+---
+"@callstack/repack": patch
+---
+
+Move `namespace` from AndroidManifest.xml file to `android/build.gradle` which will be required starting from React Native version 0.73.x due to Android Gradle Pulugin update.

--- a/packages/repack/android/build.gradle
+++ b/packages/repack/android/build.gradle
@@ -26,6 +26,7 @@ def getExtOrIntegerDefault(name) {
 }
 
 android {
+  namespace "com.callstack.repack"
   compileSdkVersion getExtOrIntegerDefault('compileSdkVersion')
   buildToolsVersion getExtOrDefault('buildToolsVersion')
   defaultConfig {

--- a/packages/repack/android/src/main/AndroidManifest.xml
+++ b/packages/repack/android/src/main/AndroidManifest.xml
@@ -1,4 +1,1 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-          package="com.callstack.repack">
-
-</manifest>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"></manifest>


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

This is a change that'll be required starting from React Native 0.73.x. More context can be found here: https://github.com/react-native-community/discussions-and-proposals/issues/671

<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->

### Test plan

- [x] Build & run the app using updated Repack package in **RN 0.71.x** in both Debug and Release modes
- [x] Build & run the app using updated Repack package in **RN 0.67.x** in both Debug and Release modes

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
