### PR TITLE
Revert "chore(repack): Add namespace to build.gradle for react-native 0.73+ compat (#379)"

### DIFF
--- a/.changeset/slow-knives-obey.md
+++ b/.changeset/slow-knives-obey.md
@@ -1,5 +1,0 @@
----
-"@callstack/repack": patch
----
-
-Move `namespace` from AndroidManifest.xml file to `android/build.gradle` which will be required starting from React Native version 0.73.x due to Android Gradle Pulugin update.

--- a/packages/repack/android/build.gradle
+++ b/packages/repack/android/build.gradle
@@ -26,7 +26,6 @@ def getExtOrIntegerDefault(name) {
 }
 
 android {
-  namespace "com.callstack.repack"
   compileSdkVersion getExtOrIntegerDefault('compileSdkVersion')
   buildToolsVersion getExtOrDefault('buildToolsVersion')
   defaultConfig {

--- a/packages/repack/android/src/main/AndroidManifest.xml
+++ b/packages/repack/android/src/main/AndroidManifest.xml
@@ -1,1 +1,4 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"></manifest>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+          package="com.callstack.repack">
+
+</manifest>


### PR DESCRIPTION
This reverts commit 229c4f87d2b1ebaf6380717a6088b919f97586cf.

It turns out, at least for now, that this change is a breaking one. Let's revert it and see whether the support for reading `namespace` field from the build.gradle will get backported to older versions of react-native-cli or maybe we will need to release a new major version of the Repack targeting react-native 71+
