### PR TITLE
fix: remote-assets url includes full publicPath now

### DIFF
--- a/.changeset/sour-meals-cough.md
+++ b/.changeset/sour-meals-cough.md
@@ -1,0 +1,5 @@
+---
+"@callstack/repack": patch
+---
+
+Fixed and issue where URL for remote asset only included basename from publicPath

--- a/packages/repack/src/webpack/loaders/assetsLoader/__tests__/assetsLoader.test.ts
+++ b/packages/repack/src/webpack/loaders/assetsLoader/__tests__/assetsLoader.test.ts
@@ -333,5 +333,30 @@ describe('assetLoader', () => {
         scale: prefferedScale,
       });
     });
+
+    it('with URL containing a path after basename', async () => {
+      const { code } = await compileBundle(
+        'ios', // platform doesn't matter for remote-assets
+        {
+          './index.js': "export { default } from './__fixtures__/logo.png';",
+        },
+        false,
+        {
+          enabled: true,
+          publicPath: 'http://localhost:9999/remote-assets',
+        }
+      );
+
+      const context: { Export?: { default: Record<string, any> } } = {};
+      vm.runInNewContext(code, context);
+
+      expect(context.Export?.default).toEqual({
+        __packager_asset: true,
+        uri: `http://localhost:9999/remote-assets/assets/__fixtures__/logo.png`,
+        height: 393,
+        width: 2292,
+        scale: 1,
+      });
+    });
   });
 });

--- a/packages/repack/src/webpack/loaders/assetsLoader/convertToRemoteAssets.ts
+++ b/packages/repack/src/webpack/loaders/assetsLoader/convertToRemoteAssets.ts
@@ -28,7 +28,8 @@ export function convertToRemoteAssets({
     .join(assetsDirname, resourceDirname)
     .replace(pathSeparatorRegexp, '/');
 
-  const publicPathURL = new URL(assetPath, remotePublicPath);
+  // works on both unix & windows
+  const publicPathURL = new URL(path.join(remotePublicPath, assetPath));
 
   const size = getImageSize({ resourcePath, resourceFilename, suffixPattern });
 


### PR DESCRIPTION
### Summary

Fixed an issue for remote-assets where only the basename from `publicPath` was included.

Example of the problem:
if `publicPath` was set to
```sh
http://localhost:9999/remote-assets
```
then final URL would look like this:
```sh
# remote-assets is removed from the path
http://localhost:9999/assets/image.png
```
instead of
```sh
http://localhost:9999/remote-assets/assets/image.png
```
