### PR TITLE
chore: allow deploy-pr workflow to be run manually

### DIFF
--- a/.github/workflows/deploy-pr.yml
+++ b/.github/workflows/deploy-pr.yml
@@ -9,7 +9,9 @@ jobs:
     runs-on: ubuntu-latest
 
     # Skip running on forks since it won't have access to secrets
-    if: github.event.pull_request.head.repo.full_name == github.repository
+    if: >
+      github.event_name == 'pull_request' && 
+      github.event.pull_request.head.repo.full_name == github.repository
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
### Summary

Modified the condition in the `deploy-pr` workflow to allow for it to be run manually
