### PR TITLE
fix: podspec fix

### DIFF
--- a/.changeset/serious-cameras-move.md
+++ b/.changeset/serious-cameras-move.md
@@ -1,0 +1,5 @@
+---
+"@callstack/repack": patch
+---
+
+Fix: stricter versions for dependencies inside podspec

--- a/packages/TesterApp/ios/Podfile.lock
+++ b/packages/TesterApp/ios/Podfile.lock
@@ -1,9 +1,9 @@
 PODS:
   - boost (1.76.0)
   - callstack-repack (3.2.0):
-    - JWTDecode (~> 3.0)
+    - JWTDecode (~> 3.0.0)
     - React-Core
-    - SwiftyRSA
+    - SwiftyRSA (~> 1.7)
   - CocoaAsyncSocket (7.6.5)
   - DoubleConversion (1.1.6)
   - FBLazyVector (0.71.8)
@@ -592,7 +592,7 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   boost: 57d2868c099736d80fcd648bf211b4431e51a558
-  callstack-repack: 3e48a96824e0e0411ae1f48749a2ab103aa62a3a
+  callstack-repack: 0ebf4a09df331e6e835034e651229fe0224bca5f
   CocoaAsyncSocket: 065fd1e645c7abab64f7a6a2007a48038fdc6a99
   DoubleConversion: 5189b271737e1565bdce30deb4a08d647e3f5f54
   FBLazyVector: f637f31eacba90d4fdeff3fa41608b8f361c173b

--- a/packages/repack/callstack-repack.podspec
+++ b/packages/repack/callstack-repack.podspec
@@ -18,6 +18,6 @@ Pod::Spec.new do |s|
   s.pod_target_xcconfig = { "DEFINES_MODULE" => "YES" }
   
   s.dependency "React-Core"
-  s.dependency 'JWTDecode', '~> 3.0'
-  s.dependency 'SwiftyRSA'
+  s.dependency 'JWTDecode', '~> 3.0.0'
+  s.dependency 'SwiftyRSA', '~> 1.7'
 end


### PR DESCRIPTION
### Summary

`JWTDecode` pod recently released new minor version of their library where they simply removed support for ios 12. Since we still want to support iOS 12, `.podspec` was modified to reflect what versions of the pod dependencies are needed for the project to work on iOS.

Closes https://github.com/callstack/repack/issues/389
