### PR TITLE
fix: update nimbus-jose-jwt android dependency

### DIFF
--- a/.changeset/loud-lemons-grin.md
+++ b/.changeset/loud-lemons-grin.md
@@ -1,0 +1,5 @@
+---
+"@callstack/repack": patch
+---
+
+Update nimbus-jose-jwt android dependency to address security vulnerabilites

--- a/packages/repack/android/build.gradle
+++ b/packages/repack/android/build.gradle
@@ -128,5 +128,5 @@ dependencies {
   implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
   implementation "com.squareup.okhttp3:okhttp:4.9.0"
   implementation "com.squareup.okhttp3:okhttp-urlconnection:4.9.0"
-  implementation 'com.nimbusds:nimbus-jose-jwt:5.1'
+  implementation 'com.nimbusds:nimbus-jose-jwt:9.31'
 }


### PR DESCRIPTION
### Summary

Upgraded `com.nimbusds:nimbus-jose-jwt` to the newest version which is not listed as having security vulnerabilities

### Test plan

Tested locally on the super-app-showcase which utilises code-signing extensively
