### PR TITLE
fix(repack-init): monorepo & version range support

### DIFF
--- a/.changeset/beige-fireants-trade.md
+++ b/.changeset/beige-fireants-trade.md
@@ -1,0 +1,5 @@
+---
+"@callstack/repack-init": patch
+---
+
+Fix bad behaviour of repack-init when run inside of a monorepo

--- a/packages/init/package.json
+++ b/packages/init/package.json
@@ -34,6 +34,7 @@
     "lint": "eslint . --ext .ts"
   },
   "dependencies": {
+    "@manypkg/find-root": "^2.2.1",
     "chalk": "^5.2.0",
     "dedent": "^0.7.0",
     "detect-package-manager": "^2.0.1",

--- a/packages/init/src/tasks/addDependencies.ts
+++ b/packages/init/src/tasks/addDependencies.ts
@@ -12,7 +12,7 @@ const dependencies = [
 /**
  * Installs dependencies required by Re.Pack using the specified package manager
  *
- * @param packageManager yarn or npm
+ * @param packageManager yarn, npm or pnpm
  */
 export default async function addDependencies(packageManager: PM) {
   let installCommand: string;

--- a/packages/init/src/tasks/checkPackageManager.ts
+++ b/packages/init/src/tasks/checkPackageManager.ts
@@ -1,5 +1,5 @@
 import { detect, PM } from 'detect-package-manager';
-
+import { findRoot } from '@manypkg/find-root';
 import logger from '../utils/logger.js';
 
 /**
@@ -9,7 +9,8 @@ import logger from '../utils/logger.js';
  * @returns package manager name (one of 'npm', 'yarn', 'pnpm')
  */
 export default async function checkPackageManager(cwd: string): Promise<PM> {
-  const packageManager = await detect({ cwd });
+  const { rootDir } = await findRoot(cwd);
+  const packageManager = await detect({ cwd: rootDir });
   logger.info(`Using ${packageManager} as package manager`);
 
   return packageManager;

--- a/packages/init/src/tasks/checkReactNative.ts
+++ b/packages/init/src/tasks/checkReactNative.ts
@@ -1,6 +1,6 @@
 import fs from 'fs';
 import path from 'path';
-import semver from 'semver';
+import semver, { SemVer } from 'semver';
 
 import logger from '../utils/logger.js';
 
@@ -10,7 +10,7 @@ import logger from '../utils/logger.js';
  * @param cwd current working directory
  * @returns React-Native version
  */
-export default function checkReactNative(rootDir: string): string {
+export default function checkReactNative(rootDir: string): SemVer {
   const packageJsonPath = path.join(rootDir, 'package.json');
   const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf-8'));
 
@@ -19,7 +19,11 @@ export default function checkReactNative(rootDir: string): string {
     throw new Error('React-Native not found in package.json');
   }
 
-  const version = packageJson.dependencies['react-native'];
+  const version = semver.coerce(packageJson.dependencies['react-native']);
+
+  if (!version) {
+    throw new Error('Failed to parse React-Native version');
+  }
 
   logger.info(`Found React-Native@${version} in package.json`);
 

--- a/packages/init/src/tasks/checkReactNative.ts
+++ b/packages/init/src/tasks/checkReactNative.ts
@@ -5,9 +5,9 @@ import semver from 'semver';
 import logger from '../utils/logger.js';
 
 /**
- * Checks whether react-native is installed and returns it's version
+ * Checks whether React-Native is installed and returns it's version
  *
- * @param cwd
+ * @param cwd current working directory
  * @returns React-Native version
  */
 export default function checkReactNative(rootDir: string): string {

--- a/packages/init/src/tasks/createWebpackConfig.ts
+++ b/packages/init/src/tasks/createWebpackConfig.ts
@@ -39,7 +39,13 @@ function adjustEntryFilename(template: string, entry: string) {
 
   return template.replace(/entry\s=.*,/, `entry = '${entry}',`);
 }
-
+/**
+ * Adds webpack.config file to the project
+ *
+ * @param cwd current working directory
+ * @param templateType mjs or cjs
+ * @param entry name of the entry file for the application
+ */
 export default async function createWebpackConfig(
   cwd: string,
   templateType: 'mjs' | 'cjs',

--- a/packages/init/src/tasks/modifyAndroid.ts
+++ b/packages/init/src/tasks/modifyAndroid.ts
@@ -1,6 +1,6 @@
 import fs from 'fs';
 import path from 'path';
-import semver from 'semver';
+import semver, { SemVer } from 'semver';
 import dedent from 'dedent';
 
 import logger from '../utils/logger.js';
@@ -95,7 +95,7 @@ function modifyNewConfig(config: string): string {
  * @param cwd path for the root directory of the project
  * @param reactNativeVersion version of react-native in project
  */
-export default function modifyAndroid(cwd: string, reactNativeVersion: string) {
+export default function modifyAndroid(cwd: string, reactNativeVersion: SemVer) {
   const buildGradlePath = path.join(cwd, 'android', 'app', 'build.gradle');
   const config = fs.readFileSync(buildGradlePath, 'utf-8');
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4879,6 +4879,7 @@ __metadata:
   resolution: "@callstack/repack-init@workspace:packages/init"
   dependencies:
     "@callstack/eslint-config": ^13.0.2
+    "@manypkg/find-root": ^2.2.1
     chalk: ^5.2.0
     dedent: ^0.7.0
     detect-package-manager: ^2.0.1
@@ -6616,6 +6617,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@manypkg/find-root@npm:^2.2.1":
+  version: 2.2.1
+  resolution: "@manypkg/find-root@npm:2.2.1"
+  dependencies:
+    "@manypkg/tools": ^1.1.0
+    find-up: ^4.1.0
+    fs-extra: ^8.1.0
+  checksum: 7f31120c3ef0711f6e65857ea232fb4f7caf4db388080e738f82d979d7f72572dae60519c8fcd45c431a8e94095b6628257fbf7373b34401359def00687bab13
+  languageName: node
+  linkType: hard
+
 "@manypkg/get-packages@npm:^1.1.3":
   version: 1.1.3
   resolution: "@manypkg/get-packages@npm:1.1.3"
@@ -6627,6 +6639,18 @@ __metadata:
     globby: ^11.0.0
     read-yaml-file: ^1.1.0
   checksum: f5a756e5a659e0e1c33f48852d56826d170d5b10a3cdea89ce4fcaa77678d8799aa4004b30e1985c87b73dbc390b95bb6411b78336dd1e0db87c08c74b5c0e74
+  languageName: node
+  linkType: hard
+
+"@manypkg/tools@npm:^1.1.0":
+  version: 1.1.0
+  resolution: "@manypkg/tools@npm:1.1.0"
+  dependencies:
+    fs-extra: ^8.1.0
+    globby: ^11.0.0
+    jju: ^1.4.0
+    read-yaml-file: ^1.1.0
+  checksum: f0228435c0b12b4dec59a57c683f1431a3a0dea71640c73b231de27742ccaf5bb2f48d425184bdf330d24e940cb9ea7ecfc8b4ed5d3d6031f8132e251e728e80
   languageName: node
   linkType: hard
 
@@ -21337,6 +21361,13 @@ __metadata:
     jetifier-standalone: bin/jetifier-standalone
     jetify: bin/jetify
   checksum: 6cdecf7683bb2f6e89e48442365d8bac6244c74ffa286b1b45d97ffa2a833901d0f4b86d0b83d4babec2b71385104214248f1b8539d82e8909989adbf16d09b4
+  languageName: node
+  linkType: hard
+
+"jju@npm:^1.4.0":
+  version: 1.4.0
+  resolution: "jju@npm:1.4.0"
+  checksum: 3790481bd2b7827dd6336e6e3dc2dcc6d425679ba7ebde7b679f61dceb4457ea0cda330972494de608571f4973c6dfb5f70fab6f3c5037dbab19ac449a60424f
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### Summary

- fixed an issue where repack-init would fail to use proper package manager in monorepo environment
- fixed an issue where react-native version had a semver range like `^0.71.3` instead of a plain version, which caused the whole repack-init to fail with an error: `Invalid Version: ^0.71.3`.
- updated function definition docs

### Test plan

executable tested locally
