### PR TITLE
feat: add enabled flag to CodeSigningPlugin

### DIFF
--- a/.changeset/afraid-gorillas-fix.md
+++ b/.changeset/afraid-gorillas-fix.md
@@ -1,0 +1,5 @@
+---
+"@callstack/repack": minor
+---
+
+Added enabled flag to CodeSigningPlugin, this is useful when you want to disable the plugin in development environment and only keep it in production. For now this flag defaults to true to prevent a breaking change.

--- a/packages/repack/src/webpack/plugins/CodeSigningPlugin.ts
+++ b/packages/repack/src/webpack/plugins/CodeSigningPlugin.ts
@@ -9,6 +9,8 @@ import type { WebpackPlugin } from '../../types';
  * {@link CodeSigningPlugin} configuration options.
  */
 export interface CodeSigningPluginConfig {
+  /** Whether the plugin is enabled. Defaults to true */
+  enabled?: boolean;
   /** Output path to a directory, where signed bundles should be saved. */
   outputPath: string;
   /** Path to the private key. */
@@ -33,6 +35,16 @@ export class CodeSigningPlugin implements WebpackPlugin {
    * @param compiler Webpack compiler instance.
    */
   apply(compiler: webpack.Compiler) {
+    /**
+     * For now this flag defaults to true to avoid a breaking change.
+     *
+     * TODO: In next major revision, we should consider removing the default here
+     * and align this option with other plugins.
+     */
+    if (this.config.enabled === false) {
+      return;
+    }
+
     const pluginName = CodeSigningPlugin.name;
     // reserve 1280 bytes for the token even if it's smaller
     // to leave some space for future additions to the JWT without breaking compatibility

--- a/packages/repack/src/webpack/plugins/__tests__/CodeSigningPlugin.test.ts
+++ b/packages/repack/src/webpack/plugins/__tests__/CodeSigningPlugin.test.ts
@@ -233,4 +233,17 @@ describe('CodeSigningPlugin', () => {
       )
     ).toThrowError();
   });
+
+  it('skips applying plugin when enabled flag is explicitly set to false', async () => {
+    const pluginInstance = new CodeSigningPlugin({
+      enabled: false,
+      outputPath: path.join('output', 'signed'),
+      privateKeyPath: '__fixtures__/testRS256.pem',
+    });
+
+    pluginInstance.apply(compilerMock as unknown as webpack.Compiler);
+
+    expect(compilerMock.hooks.thisCompilation.tap).not.toHaveBeenCalled();
+    expect(compilerMock.hooks.afterEmit.tapPromise).not.toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
### Summary

Added `enabled` flag to `CodeSigningPlugin` to make it possible to disable the plugin when running in development environment. This flag defaults to `true` now to prevent a breaking change.

### Test plan

Added unit test for the flag
