### PR TITLE
feat(repack): builtin support for react-native deep imports for Module Federation

### DIFF
--- a/.changeset/sharp-penguins-worry.md
+++ b/.changeset/sharp-penguins-worry.md
@@ -1,0 +1,5 @@
+---
+"@callstack/repack": minor
+---
+
+Add builtin support for react-native deep imports when using Module Federation

--- a/packages/repack/src/webpack/plugins/ModuleFederationPlugin.ts
+++ b/packages/repack/src/webpack/plugins/ModuleFederationPlugin.ts
@@ -11,15 +11,24 @@ type ModuleFederationPluginOptions =
     ? O
     : never;
 
-type ExtractRemotesObject<T> = T extends {}
+type ExtractObject<T> = T extends {}
   ? T extends Array<any>
     ? never
     : T
   : never;
 
-type RemotesObject = ExtractRemotesObject<
-  ModuleFederationPluginOptions['remotes']
+type RemotesObject = ExtractObject<ModuleFederationPluginOptions['remotes']>;
+
+type SharedDependencies = Exclude<
+  ModuleFederationPluginOptions['shared'],
+  undefined
 >;
+
+type SharedObject = ExtractObject<SharedDependencies>;
+
+type SharedConfig = SharedObject extends { [key: string]: infer U }
+  ? Exclude<U, string>
+  : never;
 
 /**
  * {@link ModuleFederationPlugin} configuration options.
@@ -29,7 +38,10 @@ type RemotesObject = ExtractRemotesObject<
  * You can check documentation for all supported options here: https://webpack.js.org/plugins/module-federation-plugin/
  */
 export interface ModuleFederationPluginConfig
-  extends ModuleFederationPluginOptions {}
+  extends ModuleFederationPluginOptions {
+  /** Enable or disable adding React Native deep imports to shared dependencies */
+  reactNativeDeepImports?: boolean;
+}
 
 /**
  * Webpack plugin to configure Module Federation with platform differences
@@ -97,7 +109,10 @@ export interface ModuleFederationPluginConfig
  * @category Webpack Plugin
  */
 export class ModuleFederationPlugin implements WebpackPlugin {
-  constructor(private config: ModuleFederationPluginConfig) {}
+  constructor(private config: ModuleFederationPluginConfig) {
+    this.config.reactNativeDeepImports =
+      this.config.reactNativeDeepImports ?? true;
+  }
 
   private replaceRemotes<T extends string | string[] | RemotesObject>(
     remote: T
@@ -128,6 +143,92 @@ export class ModuleFederationPlugin implements WebpackPlugin {
     return replaced as T;
   }
 
+  private getDefaultSharedDependencies(): SharedObject {
+    return {
+      react: Federated.SHARED_REACT,
+      'react-native': Federated.SHARED_REACT_NATIVE,
+    };
+  }
+
+  /**
+   * As including 'react-native' as a shared dependency is not enough to support
+   * deep imports from 'react-native' (e.g. 'react-native/Libraries/Utilities/PixelRatio'),
+   * we need to add deep imports using an undocumented feature of ModuleFederationPlugin.
+   *
+   * When a dependency has a trailing slash, deep imports of that dependency will be correctly
+   * resolved by reaching out to the shared scope. This also ensures single instances of things
+   * like 'assetsRegistry'. Additionally, we mark every package from '@react-native' group as shared
+   * as well, as these are used by React Native too.
+   *
+   * Reference: https://stackoverflow.com/questions/65636979/wp5-module-federation-sharing-deep-imports
+   * Reference: https://github.com/webpack/webpack/blob/main/lib/sharing/resolveMatchedConfigs.js#L77-L79
+   *
+   * @param shared shared dependencies configuration from ModuleFederationPlugin
+   * @returns adjusted shared dependencies configuration
+   *
+   * @internal
+   */
+  private adaptSharedDependencies(
+    shared: SharedDependencies
+  ): SharedDependencies {
+    const sharedDependencyConfig = (eager?: boolean) => ({
+      singleton: true,
+      eager: eager ?? true,
+      requiredVersion: '*',
+    });
+
+    const findSharedDependency = (
+      name: string,
+      dependencies: SharedDependencies
+    ): SharedConfig | string | undefined => {
+      if (Array.isArray(dependencies)) {
+        return dependencies.find((item) =>
+          typeof item === 'string' ? item === name : Boolean(item[name])
+        );
+      } else {
+        return dependencies[name];
+      }
+    };
+
+    const sharedReactNative = findSharedDependency('react-native', shared);
+    const reactNativeEager =
+      typeof sharedReactNative === 'object'
+        ? sharedReactNative.eager
+        : undefined;
+
+    if (!this.config.reactNativeDeepImports || !sharedReactNative) {
+      return shared;
+    }
+
+    if (Array.isArray(shared)) {
+      const adjustedSharedDependencies = [...shared];
+      if (!findSharedDependency('react-native/', shared)) {
+        adjustedSharedDependencies.push({
+          'react-native/': sharedDependencyConfig(reactNativeEager),
+        });
+      }
+      if (!findSharedDependency('@react-native/', shared)) {
+        adjustedSharedDependencies.push({
+          '@react-native/': sharedDependencyConfig(reactNativeEager),
+        });
+      }
+      return adjustedSharedDependencies;
+    } else {
+      const adjustedSharedDependencies = { ...shared };
+      if (!findSharedDependency('react-native/', shared)) {
+        Object.assign(adjustedSharedDependencies, {
+          'react-native/': sharedDependencyConfig(reactNativeEager),
+        });
+      }
+      if (!findSharedDependency('@react-native/', shared)) {
+        Object.assign(adjustedSharedDependencies, {
+          '@react-native/': sharedDependencyConfig(reactNativeEager),
+        });
+      }
+      return adjustedSharedDependencies;
+    }
+  }
+
   /**
    * Apply the plugin.
    *
@@ -137,6 +238,10 @@ export class ModuleFederationPlugin implements WebpackPlugin {
     const remotes = Array.isArray(this.config.remotes)
       ? this.config.remotes.map((remote) => this.replaceRemotes(remote))
       : this.replaceRemotes(this.config.remotes ?? {});
+
+    const sharedDependencies = this.adaptSharedDependencies(
+      this.config.shared ?? this.getDefaultSharedDependencies()
+    );
 
     new container.ModuleFederationPlugin({
       ...this.config,
@@ -151,10 +256,7 @@ export class ModuleFederationPlugin implements WebpackPlugin {
             ...this.config.library,
           }
         : undefined,
-      shared: this.config.shared ?? {
-        react: Federated.SHARED_REACT,
-        'react-native': Federated.SHARED_REACT_NATIVE,
-      },
+      shared: sharedDependencies,
       remotes,
     }).apply(compiler);
   }

--- a/packages/repack/src/webpack/plugins/__tests__/ModuleFederationPlugin.test.ts
+++ b/packages/repack/src/webpack/plugins/__tests__/ModuleFederationPlugin.test.ts
@@ -150,7 +150,6 @@ describe('ModuleFederationPlugin', () => {
 
   it('should not add deep imports to existing shared dependencies when react-native is not present', () => {
     new ModuleFederationPlugin({
-      reactNativeDeepImports: false,
       shared: {
         react: Federated.SHARED_REACT,
       },

--- a/packages/repack/src/webpack/plugins/__tests__/ModuleFederationPlugin.test.ts
+++ b/packages/repack/src/webpack/plugins/__tests__/ModuleFederationPlugin.test.ts
@@ -1,5 +1,6 @@
 import { container } from 'webpack';
 import { ModuleFederationPlugin } from '../ModuleFederationPlugin';
+import { Federated } from '../../federated';
 
 jest.mock('webpack', () => ({
   container: {
@@ -96,5 +97,110 @@ describe('ModuleFederationPlugin', () => {
       'http://localhost:6789/static/[name][ext]'
     );
     (container.ModuleFederationPlugin as jest.Mock).mockClear();
+  });
+
+  it('should add default shared dependencies', () => {
+    new ModuleFederationPlugin({}).apply(jest.fn() as any);
+    const config = (container.ModuleFederationPlugin as jest.Mock).mock
+      .calls[0][0];
+    expect(config.shared).toHaveProperty('react');
+    expect(config.shared).toHaveProperty('react-native');
+    expect(config.shared).toHaveProperty('react-native/');
+    expect(config.shared).toHaveProperty('@react-native/');
+  });
+
+  it('should not add deep imports to defaulted shared dependencies', () => {
+    new ModuleFederationPlugin({ reactNativeDeepImports: false }).apply(
+      jest.fn() as any
+    );
+    const config = (container.ModuleFederationPlugin as jest.Mock).mock
+      .calls[0][0];
+    expect(config.shared).toHaveProperty('react');
+    expect(config.shared).toHaveProperty('react-native');
+    expect(config.shared).not.toHaveProperty('react-native/');
+    expect(config.shared).not.toHaveProperty('@react-native/');
+  });
+
+  it('should add deep imports to existing shared dependencies', () => {
+    new ModuleFederationPlugin({
+      shared: {
+        react: Federated.SHARED_REACT,
+        'react-native': Federated.SHARED_REACT_NATIVE,
+      },
+    }).apply(jest.fn() as any);
+    const config = (container.ModuleFederationPlugin as jest.Mock).mock
+      .calls[0][0];
+    expect(config.shared).toHaveProperty('react-native/');
+    expect(config.shared).toHaveProperty('@react-native/');
+  });
+
+  it('should not add deep imports to existing shared dependencies', () => {
+    new ModuleFederationPlugin({
+      reactNativeDeepImports: false,
+      shared: {
+        react: Federated.SHARED_REACT,
+        'react-native': Federated.SHARED_REACT_NATIVE,
+      },
+    }).apply(jest.fn() as any);
+    const config = (container.ModuleFederationPlugin as jest.Mock).mock
+      .calls[0][0];
+    expect(config.shared).not.toHaveProperty('react-native/');
+    expect(config.shared).not.toHaveProperty('@react-native/');
+  });
+
+  it('should not add deep imports to existing shared dependencies when react-native is not present', () => {
+    new ModuleFederationPlugin({
+      reactNativeDeepImports: false,
+      shared: {
+        react: Federated.SHARED_REACT,
+      },
+    }).apply(jest.fn() as any);
+    const config = (container.ModuleFederationPlugin as jest.Mock).mock
+      .calls[0][0];
+    expect(config.shared).not.toHaveProperty('react-native/');
+    expect(config.shared).not.toHaveProperty('@react-native/');
+  });
+
+  it('should add deep imports to existing shared dependencies array', () => {
+    new ModuleFederationPlugin({
+      shared: ['react', 'react-native'],
+    }).apply(jest.fn() as any);
+    const config = (container.ModuleFederationPlugin as jest.Mock).mock
+      .calls[0][0];
+    expect(config.shared[2]).toHaveProperty('react-native/');
+    expect(config.shared[3]).toHaveProperty('@react-native/');
+  });
+
+  it('should not duplicate or override existing deep imports', () => {
+    new ModuleFederationPlugin({
+      shared: {
+        react: Federated.SHARED_REACT,
+        'react-native': Federated.SHARED_REACT_NATIVE,
+        'react-native/': { singleton: true, eager: true },
+      },
+    }).apply(jest.fn() as any);
+    const config = (container.ModuleFederationPlugin as jest.Mock).mock
+      .calls[0][0];
+    expect(config.shared).toHaveProperty('react-native/');
+    expect(config.shared).toHaveProperty('@react-native/');
+    expect(config.shared['react-native/']).toMatchObject({
+      singleton: true,
+      eager: true,
+    });
+  });
+
+  it('should determine eager based on shared react-native config', () => {
+    new ModuleFederationPlugin({
+      shared: {
+        react: { singleton: true, eager: true },
+        'react-native': { singleton: true, eager: false },
+      },
+    }).apply(jest.fn() as any);
+    const config = (container.ModuleFederationPlugin as jest.Mock).mock
+      .calls[0][0];
+    expect(config.shared).toHaveProperty('react-native/');
+    expect(config.shared).toHaveProperty('@react-native/');
+    expect(config.shared['react-native/'].eager).toBe(false);
+    expect(config.shared['@react-native/'].eager).toBe(false);
   });
 });


### PR DESCRIPTION
### Summary

**Problem Statement:**

In our current federated setup for React Native applications, a persistent issue emerged around the handling of shared dependencies, specifically with respect to deep imports from the 'react-native' library. These deep imports disrupted the efficient sharing of modules across federated boundaries. Furthermore, due to the challenges posed by these deep imports, our `assetsLoader` couldn't inline scaled assets in federated modules, leading to broken functionalities in some federated scenarios.

References:
[StackOverflow discussion on deep imports with Module Federation](https://stackoverflow.com/questions/65636979/wp5-module-federation-sharing-deep-imports)
[Webpack's resolveMatchedConfigs](https://github.com/webpack/webpack/blob/main/lib/sharing/resolveMatchedConfigs.js#L77-L79)

**Solution:**

This PR updates the `ModuleFederationPlugin` introducing mechanisms to better handle these shared dependencies, and by extension, fixing the `assetsLoader` issue.

**Changes Introduced:**

1. **Enhanced Configuration Options**:
   - Added `reactNativeDeepImports?: boolean` to `ModuleFederationPluginConfig` to allow the option to enable or disable adding React Native deep imports to shared dependencies.

2. **Deep Import Handling**:
   - Incorporated logic to adjust shared dependencies to account for deep imports from 'react-native' (e.g., `react-native/Libraries/Utilities/PixelRatio`). This was achieved using an undocumented feature of webpack's `ModuleFederationPlugin`.
   - Added a mechanism to ensure deep imports from the `react-native` library and packages from the `@react-native` group are correctly shared and resolved.

---

With this setup, the PR description begins by setting the context and outlining the problem, then presents the solution and the steps taken to achieve it.
### Test plan

- [x] Added unit tests for added functionality inside `ModuleFederationPlugin.test.ts`
