### PR TITLE
fix(repack): fixed asset inlining for newer React Native versions

### DIFF
--- a/.changeset/fuzzy-panthers-brake.md
+++ b/.changeset/fuzzy-panthers-brake.md
@@ -1,0 +1,5 @@
+---
+"@callstack/repack": patch
+---
+
+Fix inlining assets in react-native versions >= 0.72

--- a/packages/repack/src/webpack/loaders/assetsLoader/inlineAssets.ts
+++ b/packages/repack/src/webpack/loaders/assetsLoader/inlineAssets.ts
@@ -38,7 +38,7 @@ export function inlineAssets({
    * ESM for PixelRatio, so we need to check if PixelRatio is an ESM module and if so, adjust the import.
    */
   return dedent`
-    var PixelRatio = require('react-native/Libraries/Utilities/PixelRatio').default;
+    var PixelRatio = require('react-native/Libraries/Utilities/PixelRatio');
     var AssetSourceResolver = require('react-native/Libraries/Image/AssetSourceResolver');
 
     if (PixelRatio.__esModule) PixelRatio = PixelRatio.default;

--- a/packages/repack/src/webpack/loaders/assetsLoader/inlineAssets.ts
+++ b/packages/repack/src/webpack/loaders/assetsLoader/inlineAssets.ts
@@ -31,11 +31,17 @@ export function inlineAssets({
 
   const scales = JSON.stringify(Object.keys(sourceSet).map(Number));
 
-  // we need to import PixelRatio to remain compatible
-  // with older versions of React-Native
+  /**
+   * To enable scale resolution in runtime we need to import PixelRatio & AssetSourceResolver
+   * Although we could use AssetSourceResolver as it is, we need to import PixelRatio to remain
+   * compatible with older versions of React-Native. Newer versions of React-Native use
+   * ESM for PixelRatio, so we need to check if PixelRatio is an ESM module and if so, adjust the import.
+   */
   return dedent`
-    var PixelRatio = require('react-native/Libraries/Utilities/PixelRatio');
+    var PixelRatio = require('react-native/Libraries/Utilities/PixelRatio').default;
     var AssetSourceResolver = require('react-native/Libraries/Image/AssetSourceResolver');
+
+    if (PixelRatio.__esModule) PixelRatio = PixelRatio.default;
     var prefferedScale = AssetSourceResolver.pickScale(${scales}, PixelRatio.get());
 
     module.exports = ${JSON.stringify(sourceSet)}[prefferedScale];


### PR DESCRIPTION
### Summary

**Fixed Asset Inlining for Newer React-Native Versions**

This PR addresses an issue with inlining assets in React-Native versions >= 0.72. The changes ensure that the `PixelRatio` import remains compatible with both older and newer versions of React-Native. We've added a check to determine if `PixelRatio` is an ESM module and adjust the import accordingly.

Changes:
- Updated logic in `inlineAssets.ts` to correctly import `PixelRatio` based on its module type.
- Enhanced code comments to provide clarity on the need for PixelRatio & AssetSourceResolver imports.

---

Note: For a more detailed understanding, refer to the changes in `.changeset/fuzzy-panthers-brake.md` and `inlineAssets.ts`.

### Test plan

- [x] Tested on super-app-example
