### PR TITLE
chore(dev-server): upgrade source-map dependency

### DIFF
--- a/.changeset/proud-coins-yell.md
+++ b/.changeset/proud-coins-yell.md
@@ -1,0 +1,5 @@
+---
+"@callstack/repack-dev-server": patch
+---
+
+Upgraded source-map to 0.7.4

--- a/packages/dev-server/package.json
+++ b/packages/dev-server/package.json
@@ -56,7 +56,7 @@
     "open": "^8.4.0",
     "open-editor": "^4.0.0",
     "pretty-format": "^28.1.0",
-    "source-map": "^0.7.3",
+    "source-map": "^0.7.4",
     "ws": "^8.7.0"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4866,7 +4866,7 @@ __metadata:
     open: ^8.4.0
     open-editor: ^4.0.0
     pretty-format: ^28.1.0
-    source-map: ^0.7.3
+    source-map: ^0.7.4
     typedoc: ^0.22.17
     typedoc-plugin-markdown: ^3.12.1
     typescript: ^4.7.2
@@ -29875,6 +29875,13 @@ __metadata:
   version: 0.7.3
   resolution: "source-map@npm:0.7.3"
   checksum: cd24efb3b8fa69b64bf28e3c1b1a500de77e84260c5b7f2b873f88284df17974157cc88d386ee9b6d081f08fdd8242f3fc05c953685a6ad81aad94c7393dedea
+  languageName: node
+  linkType: hard
+
+"source-map@npm:^0.7.4":
+  version: 0.7.4
+  resolution: "source-map@npm:0.7.4"
+  checksum: 01cc5a74b1f0e1d626a58d36ad6898ea820567e87f18dfc9d24a9843a351aaa2ec09b87422589906d6ff1deed29693e176194dc88bcae7c9a852dc74b311dbf5
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### Summary

Upgraded `source-map` to `0.7.4`

Previous version was sometimes causing issues with `SourceMapConsumer` where it failed to initialize and therefore failed to symbolicate the stack trace. 

