### PR TITLE
[BREAKING] chore: update minimum node version to 18

### DIFF
--- a/.changeset/fast-geckos-wonder.md
+++ b/.changeset/fast-geckos-wonder.md
@@ -1,0 +1,7 @@
+---
+"@callstack/repack-dev-server": major
+"@callstack/repack-init": major
+"@callstack/repack": major
+---
+
+Upgrade to Node 18, drop support for Node 16

--- a/.changeset/fast-geckos-wonder.md
+++ b/.changeset/fast-geckos-wonder.md
@@ -4,4 +4,4 @@
 "@callstack/repack": major
 ---
 
-Upgrade to Node 18, drop support for Node 16
+BREAKING CHANGE: Upgrade to Node 18, drop support for Node 16.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        node_version: ['16', '18', '20']
+        node_version: ['18', '20']
         os: [ubuntu-latest]
 
     steps:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ We want this community to be friendly and respectful to each other. Please read 
 
 ## Requirements
 
-- Node 14+ (__recommended Node 16+__)
+- Node 18+
 - Yarn 3
 
 ## Our Development Process
@@ -15,7 +15,7 @@ All development is done directly on GitHub, and all work is public.
 
 ### Development workflow
 
-> **Working on your first pull request?** You can learn how from this *free* series: [How to Contribute to an Open Source Project on GitHub](https://egghead.io/series/how-to-contribute-to-an-open-source-project-on-github).
+> **Working on your first pull request?** You can learn how from this _free_ series: [How to Contribute to an Open Source Project on GitHub](https://egghead.io/series/how-to-contribute-to-an-open-source-project-on-github).
 
 1. Fork the repo and create your branch from default branch (usually `main`) (a guide on [how to fork a repository](https://help.github.com/articles/fork-a-repo/)).
 2. Run `yarn install` to install & set up the development environment.

--- a/packages/dev-server/babel.config.cjs
+++ b/packages/dev-server/babel.config.cjs
@@ -4,7 +4,7 @@ module.exports = {
       '@babel/preset-env',
       {
         targets: {
-          node: 14,
+          node: 18,
         },
         modules: false,
       },

--- a/packages/dev-server/package.json
+++ b/packages/dev-server/package.json
@@ -27,7 +27,7 @@
   ],
   "author": "zamotany <zamotany.oss@gmail.com>",
   "engines": {
-    "node": ">=14.x"
+    "node": ">=18"
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.org/",

--- a/packages/dev-server/package.json
+++ b/packages/dev-server/package.json
@@ -66,7 +66,7 @@
     "@babel/preset-typescript": "^7.17.12",
     "@callstack/eslint-config": "^12.0.2",
     "@types/babel__code-frame": "^7.0.3",
-    "@types/node": "14",
+    "@types/node": "18",
     "@types/ws": "^8.5.3",
     "babel-plugin-add-import-extension": "^1.6.0",
     "eslint": "^8.16.0",

--- a/packages/init/package.json
+++ b/packages/init/package.json
@@ -25,7 +25,7 @@
   ],
   "engineStrict": true,
   "engines": {
-    "node": ">=16"
+    "node": ">=18"
   },
   "type": "module",
   "scripts": {

--- a/packages/repack/babel.config.js
+++ b/packages/repack/babel.config.js
@@ -4,7 +4,7 @@ const defaultConfig = {
       '@babel/preset-env',
       {
         targets: {
-          node: 14,
+          node: 18,
         },
         // Disable CJS transform and add it manually.
         // Otherwise it will replace `import(...)` with `require(...)`, which

--- a/packages/repack/package.json
+++ b/packages/repack/package.json
@@ -97,7 +97,7 @@
     "@types/jsonwebtoken": "^9.0.0",
     "@types/lodash.throttle": "^4.1.7",
     "@types/mime-types": "^2.1.1",
-    "@types/node": "^14.14.28",
+    "@types/node": "^18",
     "@types/react-dom": "^17.0.7",
     "@types/react-native": "^0.67.8",
     "@types/shallowequal": "^1.1.1",

--- a/packages/repack/package.json
+++ b/packages/repack/package.json
@@ -33,7 +33,7 @@
   "author": "zamotany <zamotany.oss@gmail.com>",
   "license": "MIT",
   "engines": {
-    "node": ">=14.x"
+    "node": ">=18"
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.org/",

--- a/packages/repack/package.json
+++ b/packages/repack/package.json
@@ -79,7 +79,6 @@
     "react-refresh": "^0.14.0",
     "schema-utils": "^3.0.0",
     "shallowequal": "^1.1.0",
-    "string.prototype.replaceall": "^1.0.6",
     "tapable": "^2.1.1"
   },
   "devDependencies": {

--- a/packages/repack/src/index.ts
+++ b/packages/repack/src/index.ts
@@ -1,4 +1,3 @@
-import './shims';
 export * as plugins from './webpack/plugins';
 export * from './webpack/plugins/RepackPlugin';
 export * from './webpack/utils';

--- a/packages/repack/src/shims.ts
+++ b/packages/repack/src/shims.ts
@@ -1,5 +1,0 @@
-// @ts-ignore
-import replaceAll from 'string.prototype.replaceall';
-
-// `.replaceAll` has to be shimmed in Node 14
-replaceAll.shim();

--- a/website/docs/getting-started.mdx
+++ b/website/docs/getting-started.mdx
@@ -16,8 +16,8 @@ If you're already familiar with JavaScript, React Native and Webpack, then you'l
 
 ## Minimum requirements
 
-- `react-native` >= 0.69.0
-- Node >= 16 (**recommended Node 18 or newer**)
+- `react-native` >= 0.70.0
+- Node >= 18 (**recommended Node 20 or newer**)
 
 If you're using older versions of React Native, you can still try using Re.Pack, but your mileage may vary as they are not officially supported.
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4855,7 +4855,7 @@ __metadata:
     "@fastify/sensible": ^4.1.0
     "@fastify/static": ^5.0.2
     "@types/babel__code-frame": ^7.0.3
-    "@types/node": 14
+    "@types/node": 18
     "@types/ws": ^8.5.3
     babel-plugin-add-import-extension: ^1.6.0
     eslint: ^8.16.0
@@ -4920,7 +4920,7 @@ __metadata:
     "@types/jsonwebtoken": ^9.0.0
     "@types/lodash.throttle": ^4.1.7
     "@types/mime-types": ^2.1.1
-    "@types/node": ^14.14.28
+    "@types/node": ^18
     "@types/react-dom": ^17.0.7
     "@types/react-native": ^0.67.8
     "@types/shallowequal": ^1.1.1
@@ -9001,10 +9001,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/node@npm:14":
-  version: 14.18.18
-  resolution: "@types/node@npm:14.18.18"
-  checksum: a165225cd2603f6e62af8407449e4a4407305e03b41c1adf6b186fdf546e1a03c8214217659b5b36c556947c0c06234993ac880d4db6378136a7a810d47e0742
+"@types/node@npm:18, @types/node@npm:^18":
+  version: 18.18.0
+  resolution: "@types/node@npm:18.18.0"
+  checksum: 61bcffa28eb713e7a4c66fd369df603369c3f834a783faeced95fe3e78903faa25f1a704d49e054f41d71b7915eeb066d10a37cc699421fcf5dd267f96ad5808
   languageName: node
   linkType: hard
 
@@ -9012,13 +9012,6 @@ __metadata:
   version: 12.20.55
   resolution: "@types/node@npm:12.20.55"
   checksum: e4f86785f4092706e0d3b0edff8dca5a13b45627e4b36700acd8dfe6ad53db71928c8dee914d4276c7fd3b6ccd829aa919811c9eb708a2c8e4c6eb3701178c37
-  languageName: node
-  linkType: hard
-
-"@types/node@npm:^14.14.28":
-  version: 14.17.5
-  resolution: "@types/node@npm:14.17.5"
-  checksum: 8fba22a8df7bcea75039f08e00fcff8e331f6d367739a9631d3457bc3e8e5ddfdd60e1a5d685d9420312e9ed7cf2f2146d37224ec9f7d578fe8dd32ce3821e62
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4948,7 +4948,6 @@ __metadata:
     react-refresh: ^0.14.0
     schema-utils: ^3.0.0
     shallowequal: ^1.1.0
-    string.prototype.replaceall: ^1.0.6
     tapable: ^2.1.1
     terser-webpack-plugin: ^5.1.3
     typedoc: ^0.22.17
@@ -30248,20 +30247,6 @@ __metadata:
     regexp.prototype.flags: ^1.4.1
     side-channel: ^1.0.4
   checksum: fc09f3ccbfb325de0472bcc87a6be0598a7499e0b4a31db5789676155b15754a4cc4bb83924f15fc9ed48934dac7366ee52c8b9bd160bed6fd072c93b489e75c
-  languageName: node
-  linkType: hard
-
-"string.prototype.replaceall@npm:^1.0.6":
-  version: 1.0.6
-  resolution: "string.prototype.replaceall@npm:1.0.6"
-  dependencies:
-    call-bind: ^1.0.2
-    define-properties: ^1.1.3
-    es-abstract: ^1.19.1
-    get-intrinsic: ^1.1.1
-    has-symbols: ^1.0.2
-    is-regex: ^1.1.4
-  checksum: 5020755c7bc8931fc7fb8c73b2f5b3600bbc6ce0fc1df7fef834798f6623e49b57afc2b997e83a69d50686b94b2d47304571435a6adbe59ca53c02a9ceec3422
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

**Update Minimum Node Version to 18**

Given that Node v16 reached its End of Life (EOL) on September 11, 2023, this pull request updates various parts of our codebase to set the minimum supported Node version to 18.

**Details of the Changes:**

1. **GitHub Actions Workflow Update**:
    - Removed Node v16 from our testing matrix in `.github/workflows/test.yml`.

2. **Documentation Update**:
    - Updated the minimum recommended Node version in `CONTRIBUTING.md`.

3. **Codebase Updates**:
    - Updated the Babel config target version for both `packages/dev-server/babel.config.cjs` and `packages/repack/babel.config.js`.
    - Adjusted the "engines" field in `package.json` for `packages/dev-server`, `packages/init`, and `packages/repack` to reflect the new minimum Node version.
    - Updated the Node types version in `packages/dev-server/package.json` and `packages/repack/package.json`.

4. **Code Cleanup**:
    - Removed the shim for `.replaceAll` in `packages/repack/src/shims.ts` given that this is now natively supported in Node 18+. Consequently, the import statement in `packages/repack/src/index.ts` was also removed.