### PR TITLE
fix(dev-server): fix Failed to open stack frame in editor error

### DIFF
--- a/.changeset/gold-bananas-think.md
+++ b/.changeset/gold-bananas-think.md
@@ -1,0 +1,5 @@
+---
+"@callstack/repack-dev-server": patch
+---
+
+fix(dev-server): fix Failed to open stack frame in editor error

--- a/packages/dev-server/src/plugins/devtools/devtoolsPlugin.ts
+++ b/packages/dev-server/src/plugins/devtools/devtoolsPlugin.ts
@@ -51,8 +51,10 @@ async function devtoolsPlugin(
     url: '/open-stack-frame',
     handler: async (request, reply) => {
       try {
-        const { file, lineNumber, column } = JSON.parse(
-          request.body as string
+        const { file, lineNumber, column } = (
+          typeof request.body === 'string'
+            ? JSON.parse(request.body)
+            : request.body
         ) as {
           file: string;
           lineNumber: number;


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

This PR fixes the `[DevServer] Failed to open stack frame in editor ` error.
<img width="729" alt="image" src="https://github.com/callstack/repack/assets/2612074/0a27ba3d-ae39-4505-b355-d94e2d0f8a28">

<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->

### Test plan
<img width="410" alt="image" src="https://github.com/callstack/repack/assets/2612074/460c3cbd-8758-48cb-a788-de7443964662">

This error occurs when attempting to open a file in an editor and using the dev tools plugin to get file info from the `request.body` by JSON.parse. However, the issue arises because the `request.body` is an object rather than a string, resulting in an error.

Here is an example of the request:
 `curl 'http://localhost:8081/open-stack-frame' \
-X POST \
-H 'Connection: Keep-Alive' \
-H 'User-Agent: okhttp/4.9.2' \
-H 'Content-Type: application/json' \
--data-raw '{"file":"webpack:///node_modules/react-native/Libraries/LogBox/Data/LogBoxData.js","lineNumber":195}'`

To avoid this error, it's important to verify the type of `request.body` before attempting to parse it.


<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
