### PR TITLE
fix(repack): fix webpack's ModuleFederationPlugin configuration

### DIFF
--- a/.changeset/honest-coins-ring.md
+++ b/.changeset/honest-coins-ring.md
@@ -1,0 +1,5 @@
+---
+"@callstack/repack": patch
+---
+
+Fix ValidationError in ModuleFederationPlugin caused by reactNativeDeepImports prop

--- a/packages/repack/src/webpack/plugins/ModuleFederationPlugin.ts
+++ b/packages/repack/src/webpack/plugins/ModuleFederationPlugin.ts
@@ -244,7 +244,7 @@ export class ModuleFederationPlugin implements WebpackPlugin {
     );
 
     new container.ModuleFederationPlugin({
-      ...this.config,
+      exposes: this.config.exposes,
       filename:
         this.config.filename ?? this.config.exposes
           ? `${this.config.name}.container.bundle`
@@ -256,8 +256,12 @@ export class ModuleFederationPlugin implements WebpackPlugin {
             ...this.config.library,
           }
         : undefined,
+      name: this.config.name,
       shared: sharedDependencies,
+      shareScope: this.config.shareScope,
       remotes,
+      remoteType: this.config.remoteType,
+      runtime: this.config.runtime,
     }).apply(compiler);
   }
 }


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

Spread operator used inside of Re.Pack's `ModuleFederationPlugin` was passing `reactNativeDeepImports`  as a prop to webpack's `ModuleFederationPlugin` and causing schema validation error. Now all props from `config` are passed explicitly.
