### PR TITLE
fix: `@expo` changed to `expo` in babel-loader config in webpack config templates

### DIFF
--- a/packages/TesterApp/webpack.config.mjs
+++ b/packages/TesterApp/webpack.config.mjs
@@ -160,7 +160,7 @@ export default (env) => {
             /node_modules(.*[/\\])+@react-native/,
             /node_modules(.*[/\\])+@react-navigation/,
             /node_modules(.*[/\\])+@react-native-community/,
-            /node_modules(.*[/\\])+@expo/,
+            /node_modules(.*[/\\])+expo/,
             /node_modules(.*[/\\])+pretty-format/,
             /node_modules(.*[/\\])+metro/,
             /node_modules(.*[/\\])+abort-controller/,

--- a/templates/webpack.config.cjs
+++ b/templates/webpack.config.cjs
@@ -153,7 +153,7 @@ module.exports = (env) => {
             /node_modules(.*[/\\])+@react-native/,
             /node_modules(.*[/\\])+@react-navigation/,
             /node_modules(.*[/\\])+@react-native-community/,
-            /node_modules(.*[/\\])+@expo/,
+            /node_modules(.*[/\\])+expo/,
             /node_modules(.*[/\\])+pretty-format/,
             /node_modules(.*[/\\])+metro/,
             /node_modules(.*[/\\])+abort-controller/,

--- a/templates/webpack.config.mjs
+++ b/templates/webpack.config.mjs
@@ -155,7 +155,7 @@ export default (env) => {
             /node_modules(.*[/\\])+@react-native/,
             /node_modules(.*[/\\])+@react-navigation/,
             /node_modules(.*[/\\])+@react-native-community/,
-            /node_modules(.*[/\\])+@expo/,
+            /node_modules(.*[/\\])+expo/,
             /node_modules(.*[/\\])+pretty-format/,
             /node_modules(.*[/\\])+metro/,
             /node_modules(.*[/\\])+abort-controller/,


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->

When using expo library or when using expo and repack,
Need to modify it to `expo` instead of `@expo` to work.

Can refer to this [comment](https://github.com/callstack/repack/issues/304#issuecomment-1809708696).

### Test plan

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
