### PR TITLE
chore: Add Close Stale PRs/Issues GH action

### DIFF
--- a/.github/workflows/close-stale.yml
+++ b/.github/workflows/close-stale.yml
@@ -1,0 +1,21 @@
+name: Close Stale Issues
+on:
+  schedule:
+    - cron: '0 0 * * *'  # Run every day at midnight
+jobs:
+  close_stale_prs:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Close stale pull requests
+        uses: actions/stale@v5
+        with:
+          days-before-stale: 30
+          days-before-pr-close: 60
+          days-before-close: 14
+          stale-issue-message: 'This issue has been marked as stale because it has been inactive for 30 days. Please update this issue or it will be automatically closed in 14 days.'
+          stale-pr-message: 'This pull request has been marked as stale because it has been inactive for 60 days. Please update this pull request or it will be automatically closed in 14 days.'
+          close-issue-message: 'This issue has been automatically closed because it has been inactive for more than 14 days. Please reopen if you want to add more context.'
+          close-pr-message: 'This pull request has been automatically closed because it has been inactive for more than 14 days. Please reopen if you still intend to submit this pull request.'
+          stale-pr-label: stale
+          stape-issue-label: stale
+        


### PR DESCRIPTION
### Summary

Add GH Action to close all of the stale issues/PRs – there are many in which we're waiting for the response from the author etc.


### Test plan

Run the action in debug only mode (no actions will be taken on your issues and pull requests) by passing debug-only to true as an argument to the action.
