### PR TITLE
fix: make webpack cache work

### DIFF
--- a/.changeset/serious-hairs-thank.md
+++ b/.changeset/serious-hairs-thank.md
@@ -1,0 +1,6 @@
+---
+"testerapp": patch
+"@callstack/repack": patch
+---
+
+Added the ability to fully leverage the webpack built-in caching mechanism to optimise cold build times.

--- a/packages/TesterApp/webpack.config.mjs
+++ b/packages/TesterApp/webpack.config.mjs
@@ -61,6 +61,10 @@ export default (env) => {
         entries: false,
       },
     },
+    cache: {
+      type: 'filesystem',
+      name: `${platform}-${mode}`,
+    },
     /**
      * `getInitializationEntries` will return necessary entries with setup and initialization code.
      * If you don't want to use Hot Module Replacement, set `hmr` option to `false`. By default,

--- a/packages/repack/src/commands/bundle.ts
+++ b/packages/repack/src/commands/bundle.ts
@@ -104,5 +104,17 @@ export async function bundle(
         }
       }
     });
+    // eslint-disable-next-line promise/prefer-await-to-then
+  }).then(() => {
+    return new Promise<void>((resolve, reject) => {
+      // make cache work: https://webpack.js.org/api/node/#run
+      compiler.close((error) => {
+        if (error) {
+          reject();
+        } else {
+          resolve();
+        }
+      });
+    });
   });
 }


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

See https://webpack.js.org/api/node/#run

> Don't forget to close the compiler, so that low-priority work (like persistent caching) have the opportunity to complete.


```sh
turbo run build && yarn workspace testerapp run bundle:ios

# without cache
webpack 5.75.0 compiled successfully in 14680 ms 
# with cache
webpack 5.75.0 compiled successfully in 1000 ms
```


### Test plan

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
