### PR TITLE
New arch migration

### DIFF
--- a/.changeset/warm-numbers-doubt.md
+++ b/.changeset/warm-numbers-doubt.md
@@ -1,0 +1,6 @@
+---
+"@callstack/repack": major
+"testerapp": patch
+---
+
+Support for New Architecture

--- a/packages/TesterApp/ios/Podfile.lock
+++ b/packages/TesterApp/ios/Podfile.lock
@@ -1,23 +1,33 @@
 PODS:
   - boost (1.83.0)
   - callstack-repack (3.7.0):
+    - glog
+    - hermes-engine
     - JWTDecode (~> 3.0.0)
+    - RCT-Folly (= 2022.05.16.00)
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Codegen
     - React-Core
+    - React-debug
+    - React-Fabric
+    - React-graphics
+    - React-ImageManager
+    - React-NativeModulesApple
+    - React-RCTFabric
+    - React-rendererdebug
+    - React-utils
+    - ReactCommon/turbomodule/bridging
+    - ReactCommon/turbomodule/core
     - SwiftyRSA (~> 1.7)
+    - Yoga
   - DoubleConversion (1.1.6)
   - FBLazyVector (0.73.2)
-  - FBReactNativeSpec (0.73.2):
-    - RCT-Folly (= 2022.05.16.00)
-    - RCTRequired (= 0.73.2)
-    - RCTTypeSafety (= 0.73.2)
-    - React-Core (= 0.73.2)
-    - React-jsi (= 0.73.2)
-    - ReactCommon/turbomodule/core (= 0.73.2)
   - fmt (6.2.1)
   - glog (0.3.5)
-  - hermes-engine (0.73.0):
-    - hermes-engine/Pre-built (= 0.73.0)
-  - hermes-engine/Pre-built (0.73.0)
+  - hermes-engine (0.73.2):
+    - hermes-engine/Pre-built (= 0.73.2)
+  - hermes-engine/Pre-built (0.73.2)
   - JWTDecode (3.0.1)
   - libevent (2.1.12)
   - RCT-Folly (2022.05.16.00):
@@ -63,17 +73,21 @@ PODS:
   - React-callinvoker (0.73.2)
   - React-Codegen (0.73.2):
     - DoubleConversion
-    - FBReactNativeSpec
     - glog
     - hermes-engine
     - RCT-Folly
     - RCTRequired
     - RCTTypeSafety
     - React-Core
+    - React-debug
+    - React-Fabric
+    - React-FabricImage
+    - React-graphics
     - React-jsi
     - React-jsiexecutor
     - React-NativeModulesApple
-    - React-rncore
+    - React-rendererdebug
+    - React-utils
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
   - React-Core (0.73.2):
@@ -886,6 +900,8 @@ PODS:
     - React-jsi (= 0.73.2)
     - React-perflogger (= 0.73.2)
   - React-jsinspector (0.73.2)
+  - React-jsitracing (0.73.2):
+    - React-jsi
   - React-logger (0.73.2):
     - glog
   - React-Mapbuffer (0.73.2):
@@ -919,13 +935,21 @@ PODS:
     - RCTTypeSafety
     - React-Core
     - React-CoreModules
+    - React-debug
+    - React-Fabric
+    - React-graphics
     - React-hermes
     - React-nativeconfig
     - React-NativeModulesApple
     - React-RCTFabric
     - React-RCTImage
     - React-RCTNetwork
+    - React-rendererdebug
+    - React-RuntimeApple
+    - React-RuntimeCore
+    - React-RuntimeHermes
     - React-runtimescheduler
+    - React-utils
     - ReactCommon
   - React-RCTBlob (0.73.2):
     - hermes-engine
@@ -1003,8 +1027,42 @@ PODS:
     - RCT-Folly (= 2022.05.16.00)
     - React-debug
   - React-rncore (0.73.2)
+  - React-RuntimeApple (0.73.2):
+    - hermes-engine
+    - RCT-Folly/Fabric (= 2022.05.16.00)
+    - React-callinvoker
+    - React-Core/Default
+    - React-CoreModules
+    - React-cxxreact
+    - React-jserrorhandler
+    - React-jsi
+    - React-jsiexecutor
+    - React-Mapbuffer
+    - React-NativeModulesApple
+    - React-RCTFabric
+    - React-RuntimeCore
+    - React-runtimeexecutor
+    - React-RuntimeHermes
+    - React-utils
+  - React-RuntimeCore (0.73.2):
+    - glog
+    - hermes-engine
+    - RCT-Folly/Fabric (= 2022.05.16.00)
+    - React-cxxreact
+    - React-jserrorhandler
+    - React-jsi
+    - React-jsiexecutor
+    - React-runtimeexecutor
+    - React-runtimescheduler
   - React-runtimeexecutor (0.73.2):
     - React-jsi (= 0.73.2)
+  - React-RuntimeHermes (0.73.2):
+    - hermes-engine
+    - RCT-Folly/Fabric (= 2022.05.16.00)
+    - React-jsi
+    - React-jsitracing
+    - React-nativeconfig
+    - React-utils
   - React-runtimescheduler (0.73.2):
     - glog
     - hermes-engine
@@ -1059,9 +1117,63 @@ PODS:
     - React-logger (= 0.73.2)
     - React-perflogger (= 0.73.2)
   - RNCAsyncStorage (1.21.0):
+    - glog
+    - hermes-engine
+    - RCT-Folly (= 2022.05.16.00)
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Codegen
     - React-Core
-  - RNSVG (13.8.0):
+    - React-debug
+    - React-Fabric
+    - React-graphics
+    - React-ImageManager
+    - React-NativeModulesApple
+    - React-RCTFabric
+    - React-rendererdebug
+    - React-utils
+    - ReactCommon/turbomodule/bridging
+    - ReactCommon/turbomodule/core
+    - Yoga
+  - RNSVG (14.1.0):
+    - glog
+    - hermes-engine
+    - RCT-Folly (= 2022.05.16.00)
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Codegen
     - React-Core
+    - React-debug
+    - React-Fabric
+    - React-graphics
+    - React-ImageManager
+    - React-NativeModulesApple
+    - React-RCTFabric
+    - React-rendererdebug
+    - React-utils
+    - ReactCommon/turbomodule/bridging
+    - ReactCommon/turbomodule/core
+    - RNSVG/common (= 14.1.0)
+    - Yoga
+  - RNSVG/common (14.1.0):
+    - glog
+    - hermes-engine
+    - RCT-Folly (= 2022.05.16.00)
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Codegen
+    - React-Core
+    - React-debug
+    - React-Fabric
+    - React-graphics
+    - React-ImageManager
+    - React-NativeModulesApple
+    - React-RCTFabric
+    - React-rendererdebug
+    - React-utils
+    - ReactCommon/turbomodule/bridging
+    - ReactCommon/turbomodule/core
+    - Yoga
   - SocketRocket (0.6.1)
   - SwiftyRSA (1.7.0):
     - SwiftyRSA/ObjC (= 1.7.0)
@@ -1073,7 +1185,6 @@ DEPENDENCIES:
   - "callstack-repack (from `../node_modules/@callstack/repack`)"
   - DoubleConversion (from `../node_modules/react-native/third-party-podspecs/DoubleConversion.podspec`)
   - FBLazyVector (from `../node_modules/react-native/Libraries/FBLazyVector`)
-  - FBReactNativeSpec (from `../node_modules/react-native/React/FBReactNativeSpec`)
   - glog (from `../node_modules/react-native/third-party-podspecs/glog.podspec`)
   - hermes-engine (from `../node_modules/react-native/sdks/hermes-engine/hermes-engine.podspec`)
   - libevent (~> 2.1.12)
@@ -1098,6 +1209,7 @@ DEPENDENCIES:
   - React-jsi (from `../node_modules/react-native/ReactCommon/jsi`)
   - React-jsiexecutor (from `../node_modules/react-native/ReactCommon/jsiexecutor`)
   - React-jsinspector (from `../node_modules/react-native/ReactCommon/jsinspector-modern`)
+  - React-jsitracing (from `../node_modules/react-native/ReactCommon/hermes/executor/`)
   - React-logger (from `../node_modules/react-native/ReactCommon/logger`)
   - React-Mapbuffer (from `../node_modules/react-native/ReactCommon`)
   - React-nativeconfig (from `../node_modules/react-native/ReactCommon`)
@@ -1116,7 +1228,10 @@ DEPENDENCIES:
   - React-RCTVibration (from `../node_modules/react-native/Libraries/Vibration`)
   - React-rendererdebug (from `../node_modules/react-native/ReactCommon/react/renderer/debug`)
   - React-rncore (from `../node_modules/react-native/ReactCommon`)
+  - React-RuntimeApple (from `../node_modules/react-native/ReactCommon/react/runtime/platform/ios`)
+  - React-RuntimeCore (from `../node_modules/react-native/ReactCommon/react/runtime`)
   - React-runtimeexecutor (from `../node_modules/react-native/ReactCommon/runtimeexecutor`)
+  - React-RuntimeHermes (from `../node_modules/react-native/ReactCommon/react/runtime`)
   - React-runtimescheduler (from `../node_modules/react-native/ReactCommon/react/renderer/runtimescheduler`)
   - React-utils (from `../node_modules/react-native/ReactCommon/react/utils`)
   - ReactCommon/turbomodule/core (from `../node_modules/react-native/ReactCommon`)
@@ -1141,8 +1256,6 @@ EXTERNAL SOURCES:
     :podspec: "../node_modules/react-native/third-party-podspecs/DoubleConversion.podspec"
   FBLazyVector:
     :path: "../node_modules/react-native/Libraries/FBLazyVector"
-  FBReactNativeSpec:
-    :path: "../node_modules/react-native/React/FBReactNativeSpec"
   glog:
     :podspec: "../node_modules/react-native/third-party-podspecs/glog.podspec"
   hermes-engine:
@@ -1186,6 +1299,8 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native/ReactCommon/jsiexecutor"
   React-jsinspector:
     :path: "../node_modules/react-native/ReactCommon/jsinspector-modern"
+  React-jsitracing:
+    :path: "../node_modules/react-native/ReactCommon/hermes/executor/"
   React-logger:
     :path: "../node_modules/react-native/ReactCommon/logger"
   React-Mapbuffer:
@@ -1222,8 +1337,14 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native/ReactCommon/react/renderer/debug"
   React-rncore:
     :path: "../node_modules/react-native/ReactCommon"
+  React-RuntimeApple:
+    :path: "../node_modules/react-native/ReactCommon/react/runtime/platform/ios"
+  React-RuntimeCore:
+    :path: "../node_modules/react-native/ReactCommon/react/runtime"
   React-runtimeexecutor:
     :path: "../node_modules/react-native/ReactCommon/runtimeexecutor"
+  React-RuntimeHermes:
+    :path: "../node_modules/react-native/ReactCommon/react/runtime"
   React-runtimescheduler:
     :path: "../node_modules/react-native/ReactCommon/react/renderer/runtimescheduler"
   React-utils:
@@ -1238,14 +1359,13 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native/ReactCommon/yoga"
 
 SPEC CHECKSUMS:
-  boost: 26fad476bfa736552bbfa698a06cc530475c1505
-  callstack-repack: bbcb691e5e6a19845295770a1178bdf54b1be018
+  boost: d3f49c53809116a5d38da093a8aa78bf551aed09
+  callstack-repack: 3aae6e71aaa42062c15b01366dee3dc1b529e5bc
   DoubleConversion: fea03f2699887d960129cc54bba7e52542b6f953
   FBLazyVector: fbc4957d9aa695250b55d879c1d86f79d7e69ab4
-  FBReactNativeSpec: 86de768f89901ef6ed3207cd686362189d64ac88
   fmt: ff9d55029c625d3757ed641535fd4a75fedc7ce9
   glog: c5d68082e772fa1c511173d6b30a9de2c05a69a2
-  hermes-engine: 34304f8c6e8fa68f63a5fe29af82f227d817d7a7
+  hermes-engine: b361c9ef5ef3cda53f66e195599b47e1f84ffa35
   JWTDecode: 2eed97c2fa46ccaf3049a787004eedf0be474a87
   libevent: 4049cae6c81cdb3654a443be001fb9bdceff7913
   RCT-Folly: 7169b2b1c44399c76a47b5deaaba715eeeb476c0
@@ -1253,7 +1373,7 @@ SPEC CHECKSUMS:
   RCTTypeSafety: a759e3b086eccf3e2cbf2493d22f28e082f958e6
   React: 805f5dd55bbdb92c36b4914c64aaae4c97d358dc
   React-callinvoker: 6a697867607c990c2c2c085296ee32cfb5e47c01
-  React-Codegen: c4447ffa339f4e7a22e0c9c800eec9084f31899c
+  React-Codegen: f3cb992539e5c21675f087e536d64b1f2a448655
   React-Core: 49f66fecc7695464e9b7bc7dc7cd9473d2c60584
   React-CoreModules: 710e7c557a1a8180bd1645f5b4bf79f4bd3f5417
   React-cxxreact: 345857b5e4be000c0527df78be3b41a0677a20ce
@@ -1267,6 +1387,7 @@ SPEC CHECKSUMS:
   React-jsi: a182068133f80918cd0eec77875abaf943a0b6be
   React-jsiexecutor: dacd00ce8a18fc00a0ae6c25e3015a6437e5d2e8
   React-jsinspector: 03644c063fc3621c9a4e8bf263a8150909129618
+  React-jsitracing: 7c77101b38fcc8fa7f198de7e1d834350a85af90
   React-logger: 66b168e2b2bee57bd8ce9e69f739d805732a5570
   React-Mapbuffer: 9ee041e1d7be96da6d76a251f92e72b711c651d6
   React-nativeconfig: d753fbbc8cecc8ae413d615599ac378bbf6999bb
@@ -1274,7 +1395,7 @@ SPEC CHECKSUMS:
   React-perflogger: 29efe63b7ef5fbaaa50ef6eaa92482f98a24b97e
   React-RCTActionSheet: 69134c62aefd362027b20da01cd5d14ffd39db3f
   React-RCTAnimation: 3b5a57087c7a5e727855b803d643ac1d445488f5
-  React-RCTAppDelegate: a3ce9b69c0620a1717d08e826d4dc7ad8a3a3cae
+  React-RCTAppDelegate: cb1a9a8447ddad006f934988016390f4df472e74
   React-RCTBlob: 26ea660f2be1e6de62f2d2ad9a9c7b9bfabb786f
   React-RCTFabric: bb6dbbff2f80b9489f8b2f1d2554aa040aa2e3cd
   React-RCTImage: 27b27f4663df9e776d0549ed2f3536213e793f1b
@@ -1284,13 +1405,16 @@ SPEC CHECKSUMS:
   React-RCTText: 73006e95ca359595c2510c1c0114027c85a6ddd3
   React-RCTVibration: 599f427f9cbdd9c4bf38959ca020e8fef0717211
   React-rendererdebug: f2946e0a1c3b906e71555a7c4a39aa6a6c0e639b
-  React-rncore: 74030de0ffef7b1a3fb77941168624534cc9ae7f
+  React-rncore: 6e3139cf51cea08068f008da426821d1deaa24b9
+  React-RuntimeApple: 08c29690996ed935e35054965bcfb70ebea67318
+  React-RuntimeCore: 5b73f40b46d78a825cf71714e1e5044d389702d6
   React-runtimeexecutor: 2d1f64f58193f00a3ad71d3f89c2bfbfe11cf5a5
+  React-RuntimeHermes: 01dcb5a4e9073496f6f981a8648843771e3f6516
   React-runtimescheduler: df8945a656356ff10f58f65a70820478bfcf33ad
   React-utils: f5bc61e7ea3325c0732ae2d755f4441940163b85
   ReactCommon: 45b5d4f784e869c44a6f5a8fad5b114ca8f78c53
-  RNCAsyncStorage: 618d03a5f52fbccb3d7010076bc54712844c18ef
-  RNSVG: c1e76b81c76cdcd34b4e1188852892dc280eb902
+  RNCAsyncStorage: 559f22cc4b582414e783fd7255974b29e24b451c
+  RNSVG: db32cfcad0a221fd175e0882eff7bcba7690380a
   SocketRocket: f32cd54efbe0f095c4d7594881e52619cfe80b17
   SwiftyRSA: 8c6dd1ea7db1b8dc4fb517a202f88bb1354bc2c6
   Yoga: e64aa65de36c0832d04e8c7bd614396c77a80047

--- a/packages/TesterApp/ios/TesterApp.xcodeproj/project.pbxproj
+++ b/packages/TesterApp/ios/TesterApp.xcodeproj/project.pbxproj
@@ -575,12 +575,16 @@
 				);
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
-				OTHER_CFLAGS = "$(inherited)";
+				OTHER_CFLAGS = (
+					"$(inherited)",
+					"-DRN_FABRIC_ENABLED",
+				);
 				OTHER_CPLUSPLUSFLAGS = (
 					"$(OTHER_CFLAGS)",
 					"-DFOLLY_NO_CONFIG",
 					"-DFOLLY_MOBILE=1",
 					"-DFOLLY_USE_LIBCPP=1",
+					"-DRN_FABRIC_ENABLED",
 				);
 				OTHER_LDFLAGS = (
 					"$(inherited)",
@@ -650,12 +654,16 @@
 					"\"$(inherited)\"",
 				);
 				MTL_ENABLE_DEBUG_INFO = NO;
-				OTHER_CFLAGS = "$(inherited)";
+				OTHER_CFLAGS = (
+					"$(inherited)",
+					"-DRN_FABRIC_ENABLED",
+				);
 				OTHER_CPLUSPLUSFLAGS = (
 					"$(OTHER_CFLAGS)",
 					"-DFOLLY_NO_CONFIG",
 					"-DFOLLY_MOBILE=1",
 					"-DFOLLY_USE_LIBCPP=1",
+					"-DRN_FABRIC_ENABLED",
 				);
 				OTHER_LDFLAGS = (
 					"$(inherited)",

--- a/packages/TesterApp/package.json
+++ b/packages/TesterApp/package.json
@@ -22,7 +22,7 @@
     "lodash.throttle": "^4.1.1",
     "react": "18.2.0",
     "react-native": "0.73.2",
-    "react-native-svg": "^13.7.0"
+    "react-native-svg": "14.1.0"
   },
   "devDependencies": {
     "@babel/core": "^7.20.0",

--- a/packages/repack/android/build.gradle
+++ b/packages/repack/android/build.gradle
@@ -14,6 +14,10 @@ buildscript {
   }
 }
 
+def isNewArchitectureEnabled() {
+  return rootProject.hasProperty("newArchEnabled") && rootProject.getProperty("newArchEnabled") == "true"
+}
+
 apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
@@ -47,6 +51,20 @@ android {
   compileOptions {
     sourceCompatibility JavaVersion.VERSION_1_8
     targetCompatibility JavaVersion.VERSION_1_8
+  }
+
+  sourceSets {
+    main {
+      if (isNewArchitectureEnabled()) {
+        java.srcDirs += [
+          "src/newarch",
+          // This is needed to build Kotlin project with NewArch enabled
+          "${project.buildDir}/generated/source/codegen/java"
+        ]
+      } else {
+        java.srcDirs += ["src/oldarch"]
+      }
+    }
   }
 }
 

--- a/packages/repack/android/build.gradle
+++ b/packages/repack/android/build.gradle
@@ -21,6 +21,10 @@ def isNewArchitectureEnabled() {
 apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
+if (isNewArchitectureEnabled()) {
+  apply plugin: "com.facebook.react"
+}
+
 def getExtOrDefault(name) {
   return rootProject.ext.has(name) ? rootProject.ext.get(name) : project.properties['RePack_' + name]
 }
@@ -33,11 +37,11 @@ android {
   compileSdkVersion getExtOrIntegerDefault('compileSdkVersion')
   buildToolsVersion getExtOrDefault('buildToolsVersion')
   defaultConfig {
-    minSdkVersion 16
+    minSdkVersion 21
     targetSdkVersion getExtOrIntegerDefault('targetSdkVersion')
     versionCode 1
     versionName "1.0"
-
+    buildConfigField "boolean", "IS_NEW_ARCHITECTURE_ENABLED", isNewArchitectureEnabled().toString()
   }
 
   buildTypes {

--- a/packages/repack/android/src/main/java/com/callstack/repack/ChunkManagerModule.kt
+++ b/packages/repack/android/src/main/java/com/callstack/repack/ChunkManagerModule.kt
@@ -57,22 +57,23 @@ class ScriptManagerModule(reactContext: ReactApplicationContext) : ScriptManager
         if (!config.fetch) {
             // Do nothing, script is already prefetched
             promise.resolve(null);
-        } else {
-            runInBackground {
-                when {
-                    config.url.protocol.startsWith("http") -> {
-                        remoteLoader.prefetch(config, promise)
-                    }
+            return
+        }
+        runInBackground {
+            when {
+                config.url.protocol.startsWith("http") -> {
+                    remoteLoader.prefetch(config, promise)
+                }
 
-                    else -> {
-                        promise.reject(
-                            ScriptLoadingError.UnsupportedScheme.code,
-                            "Scheme in URL: '${config.url}' is not supported"
-                        )
-                    }
+                else -> {
+                    promise.reject(
+                        ScriptLoadingError.UnsupportedScheme.code,
+                        "Scheme in URL: '${config.url}' is not supported"
+                    )
                 }
             }
         }
+
     }
 
     @ReactMethod

--- a/packages/repack/android/src/main/java/com/callstack/repack/ChunkManagerModule.kt
+++ b/packages/repack/android/src/main/java/com/callstack/repack/ChunkManagerModule.kt
@@ -9,7 +9,7 @@ class ScriptManagerModule(reactContext: ReactApplicationContext) : ScriptManager
         FileSystemScriptLoader(reactApplicationContext)
 
     override fun getName(): String {
-        return "ScriptManager"
+        return NAME
     }
 
     private fun runInBackground(fn: () -> Unit) {
@@ -96,5 +96,9 @@ class ScriptManagerModule(reactContext: ReactApplicationContext) : ScriptManager
                 }
             }
         }
+    }
+
+    companion object {
+        const val NAME = "ScriptManager"
     }
 }

--- a/packages/repack/android/src/main/java/com/callstack/repack/ChunkManagerPackage.kt
+++ b/packages/repack/android/src/main/java/com/callstack/repack/ChunkManagerPackage.kt
@@ -1,17 +1,35 @@
 package com.callstack.repack
 
-import com.facebook.react.ReactPackage
-import com.facebook.react.bridge.NativeModule
+import com.facebook.react.TurboReactPackage
 import com.facebook.react.bridge.ReactApplicationContext
-import com.facebook.react.uimanager.ViewManager
+import com.facebook.react.bridge.NativeModule
+import com.facebook.react.module.model.ReactModuleInfoProvider
+import com.facebook.react.module.model.ReactModuleInfo
+import java.util.HashMap
 
-
-class ScriptManagerPackage : ReactPackage {
-    override fun createNativeModules(reactContext: ReactApplicationContext): List<NativeModule> {
-        return listOf(ScriptManagerModule(reactContext))
+class ScriptManagerPackage : TurboReactPackage() {
+    override fun getModule(name: String, reactContext: ReactApplicationContext): NativeModule? {
+        return if (name == ScriptManagerModule.NAME) {
+            ScriptManagerModule(reactContext)
+        } else {
+            null
+        }
     }
 
-    override fun createViewManagers(reactContext: ReactApplicationContext): List<ViewManager<*, *>> {
-        return emptyList()
+    override fun getReactModuleInfoProvider(): ReactModuleInfoProvider {
+        return ReactModuleInfoProvider {
+            val moduleInfos: MutableMap<String, ReactModuleInfo> = HashMap()
+            val isTurboModule: Boolean = BuildConfig.IS_NEW_ARCHITECTURE_ENABLED
+            moduleInfos[ScriptManagerModule.NAME] = ReactModuleInfo(
+                ScriptManagerModule.NAME,
+                ScriptManagerModule.NAME,
+                false,  // canOverrideExistingModule
+                false,  // needsEagerInit
+                true,  // hasConstants
+                false,  // isCxxModule
+                isTurboModule // isTurboModule
+            )
+            moduleInfos
+        }
     }
 }

--- a/packages/repack/android/src/main/java/com/callstack/repack/ChunkManagerPackage.kt
+++ b/packages/repack/android/src/main/java/com/callstack/repack/ChunkManagerPackage.kt
@@ -24,7 +24,7 @@ class ScriptManagerPackage : TurboReactPackage() {
                 ScriptManagerModule.NAME,
                 ScriptManagerModule.NAME,
                 false,  // canOverrideExistingModule
-                /** default value is true, but we should initialize it as quick as possible*/
+                /** default value is false, but we should initialize it as quick as possible*/
                 true,  // needsEagerInit
                 false,  // isCxxModule
                 isTurboModule // isTurboModule

--- a/packages/repack/android/src/main/java/com/callstack/repack/ChunkManagerPackage.kt
+++ b/packages/repack/android/src/main/java/com/callstack/repack/ChunkManagerPackage.kt
@@ -24,8 +24,8 @@ class ScriptManagerPackage : TurboReactPackage() {
                 ScriptManagerModule.NAME,
                 ScriptManagerModule.NAME,
                 false,  // canOverrideExistingModule
-                false,  // needsEagerInit
-                true,  // hasConstants
+                /** default value is true, but we should initialize it as quick as possible*/
+                true,  // needsEagerInit
                 false,  // isCxxModule
                 isTurboModule // isTurboModule
             )

--- a/packages/repack/android/src/newarch/ScriptManagerSpec.kt
+++ b/packages/repack/android/src/newarch/ScriptManagerSpec.kt
@@ -1,0 +1,7 @@
+package com.callstack.repack
+
+import com.facebook.react.bridge.ReactApplicationContext
+
+abstract class ScriptManagerSpec internal constructor(context: ReactApplicationContext) :
+  NativeRepackSpec(context) {
+}

--- a/packages/repack/android/src/newarch/ScriptManagerSpec.kt
+++ b/packages/repack/android/src/newarch/ScriptManagerSpec.kt
@@ -1,7 +1,7 @@
 package com.callstack.repack
 
+import com.facebook.fbreact.specs.NativeScriptManagerSpec
 import com.facebook.react.bridge.ReactApplicationContext
 
-abstract class ScriptManagerSpec internal constructor(context: ReactApplicationContext) :
-  NativeRepackSpec(context) {
+abstract class ScriptManagerSpec internal constructor(context: ReactApplicationContext): NativeScriptManagerSpec(context) {
 }

--- a/packages/repack/android/src/oldarch/ScriptManagerSpec.kt
+++ b/packages/repack/android/src/oldarch/ScriptManagerSpec.kt
@@ -1,0 +1,14 @@
+package com.callstack.repack
+
+import com.facebook.react.bridge.ReactApplicationContext
+import com.facebook.react.bridge.ReactContextBaseJavaModule
+import com.facebook.react.bridge.Promise
+import com.facebook.react.bridge.ReadableArray
+import com.facebook.react.bridge.ReadableMap
+
+abstract class ScriptManagerSpec internal constructor(context: ReactApplicationContext) :
+    ReactContextBaseJavaModule(context) {
+    abstract fun loadScript(scriptId: String, configMap: ReadableMap, promise: Promise)
+    abstract fun prefetchScript(scriptId: String, configMap: ReadableMap, promise: Promise)
+    abstract fun invalidateScripts(scriptIds: ReadableArray, promise: Promise)
+}

--- a/packages/repack/callstack-repack.podspec
+++ b/packages/repack/callstack-repack.podspec
@@ -20,4 +20,27 @@ Pod::Spec.new do |s|
   s.dependency "React-Core"
   s.dependency 'JWTDecode', '~> 3.0.0'
   s.dependency 'SwiftyRSA', '~> 1.7'
+
+    # Use install_modules_dependencies helper to install the dependencies if React Native version >=0.71.0.
+  # See https://github.com/facebook/react-native/blob/febf6b7f33fdb4904669f99d795eba4c0f95d7bf/scripts/cocoapods/new_architecture.rb#L79.
+  if respond_to?(:install_modules_dependencies, true)
+    install_modules_dependencies(s)
+  else
+  s.dependency "React-Core"
+
+  # Don't install the dependencies when we run `pod install` in the old architecture.
+  if ENV['RCT_NEW_ARCH_ENABLED'] == '1' then
+    s.compiler_flags = folly_compiler_flags + " -DRCT_NEW_ARCH_ENABLED=1"
+    s.pod_target_xcconfig    = {
+        "HEADER_SEARCH_PATHS" => "\"$(PODS_ROOT)/boost\"",
+        "OTHER_CPLUSPLUSFLAGS" => "-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1",
+        "CLANG_CXX_LANGUAGE_STANDARD" => "c++17"
+    }
+    s.dependency "React-Codegen"
+    s.dependency "RCT-Folly"
+    s.dependency "RCTRequired"
+    s.dependency "RCTTypeSafety"
+    s.dependency "ReactCommon/turbomodule/core"
+   end
+  end 
 end

--- a/packages/repack/ios/ScriptManager.h
+++ b/packages/repack/ios/ScriptManager.h
@@ -1,10 +1,11 @@
-#ifndef ScriptManager_h
-#define ScriptManager_h
+#ifdef RCT_NEW_ARCH_ENABLED
+#import "RNScriptManagerSpec.h"
 
+@interface ScriptManager : NSObject <NativeScriptManagerSpec>
+#else
 #import <React/RCTBridgeModule.h>
 
 @interface ScriptManager : NSObject <RCTBridgeModule>
+#endif
 
 @end
-
-#endif /* ScriptManager_h */

--- a/packages/repack/package.json
+++ b/packages/repack/package.json
@@ -112,5 +112,10 @@
     "typescript": "^5.2.2",
     "webpack": "^5.75.0",
     "webpack-virtual-modules": "^0.4.4"
+  },
+  "codegenConfig": {
+    "name": "RNScriptManagerSpec",
+    "type": "modules",
+    "jsSrcsDir": "src"
   }
 }

--- a/packages/repack/src/modules/ScriptManager/NativeScriptManager.ts
+++ b/packages/repack/src/modules/ScriptManager/NativeScriptManager.ts
@@ -1,0 +1,11 @@
+import type { TurboModule } from 'react-native';
+import { TurboModuleRegistry } from 'react-native';
+
+// TODO FIX TYPES https://github.com/callstack/repack/issues/494
+export interface Spec extends TurboModule {
+  loadScript(scriptId: string, config: Object): Promise<Object>;
+  prefetchScript(scriptId: string, config: Object): Promise<Object>;
+  invalidateScripts(scripts: Array<string>): Promise<string>;
+}
+
+export default TurboModuleRegistry.get<Spec>('ScriptManager') as Spec;

--- a/packages/repack/src/modules/ScriptManager/ScriptManager.ts
+++ b/packages/repack/src/modules/ScriptManager/ScriptManager.ts
@@ -1,6 +1,5 @@
 /* globals __DEV__, __webpack_require__ */
 import EventEmitter from 'events';
-import { NativeModules } from 'react-native';
 import { getWebpackContext } from './getWebpackContext';
 import { Script } from './Script';
 import type {
@@ -8,6 +7,7 @@ import type {
   ScriptLocatorResolver,
   StorageApi,
 } from './types';
+import NativeScriptManager from './NativeScriptManager';
 
 type Cache = Record<
   string,
@@ -100,9 +100,7 @@ export class ScriptManager extends EventEmitter {
    *
    * @internal
    */
-  protected constructor(
-    private nativeScriptManager = NativeModules.ScriptManager
-  ) {
+  protected constructor(private nativeScriptManager = NativeScriptManager) {
     super();
 
     if (!nativeScriptManager) {

--- a/packages/repack/src/modules/ScriptManager/__tests__/ScriptManager.test.ts
+++ b/packages/repack/src/modules/ScriptManager/__tests__/ScriptManager.test.ts
@@ -1,10 +1,13 @@
 /* eslint-disable require-await */
 /* globals globalThis */
-import * as ReactNative from 'react-native';
 import { Script } from '../Script';
 import { ScriptManager } from '../ScriptManager';
 
-jest.mock('react-native', () => ({ NativeModules: { ScriptManager: {} } }));
+jest.mock('../NativeScriptManager', () => ({
+  loadScript: jest.fn(),
+  prefetchScript: jest.fn(),
+  invalidateScripts: jest.fn(),
+}));
 
 // @ts-ignore
 globalThis.__webpack_require__ = {
@@ -30,8 +33,6 @@ class FakeCache {
 }
 
 beforeEach(() => {
-  ReactNative.NativeModules.ScriptManager = {};
-
   try {
     ScriptManager.shared.__destroy();
   } catch {
@@ -41,9 +42,9 @@ beforeEach(() => {
 
 describe('ScriptManagerAPI', () => {
   it('throw error if ScriptManager NativeModule was not found', async () => {
-    ReactNative.NativeModules.ScriptManager = undefined;
-
-    await expect(() => ScriptManager.shared).toThrow(/module was not found/);
+    await expect(() => new ScriptManager(null).shared).toThrow(
+      /repack react-native module was not found/
+    );
   });
 
   it('throw error if there are no resolvers', async () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -27619,16 +27619,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-native-svg@npm:^13.7.0":
-  version: 13.8.0
-  resolution: "react-native-svg@npm:13.8.0"
+"react-native-svg@npm:14.1.0":
+  version: 14.1.0
+  resolution: "react-native-svg@npm:14.1.0"
   dependencies:
     css-select: "npm:^5.1.0"
     css-tree: "npm:^1.1.3"
   peerDependencies:
     react: "*"
     react-native: "*"
-  checksum: 6a43dd4e16bcd227faa6ced43da82881a8abcec02808b20aaadf1effe873423b4bdb5484baaa7f8d9b06d0e18c02294253adb15872fc342e3c2d9dd3d4929cbc
+  checksum: 2322cba59542ae552c25d222b6311024ea17daf2431c5ed9029d3682e61d2f8bc5428f496b237e81a6d1c6bdf29abeab0ed005cfbb48420f34e1cdffdc40823b
   languageName: node
   linkType: hard
 
@@ -31161,7 +31161,7 @@ __metadata:
     react: "npm:18.2.0"
     react-native: "npm:0.73.2"
     react-native-event-source: "npm:^1.1.0"
-    react-native-svg: "npm:^13.7.0"
+    react-native-svg: "npm:14.1.0"
     terser-webpack-plugin: "npm:^5.3.3"
     typescript: "npm:^5.2.2"
     vitest: "npm:^0.15.1"


### PR DESCRIPTION
### Summary
This PR aims to add a turbo module with backward compatibility. Re.Pack current implementation directly uses RN native modules, but with this change, there is a `SPEC` implementation that allows for more efficient communication between native and JavaScript. This change allows for both old and new architecture. All implementation follows the official react native bob builder template. 

### Test plan

- Make sure you are currently using the newArch and the setup conforms to [React Native Doc directives](https://reactnative.dev/docs/next/new-architecture-app-intro) which also means you're on **`RN>=0.68.0`**

NOTE: TesterApp currently meets this requirement if you're using repack TesterApp.

 #### For Android
- You will only need to update your `android/gradle.properties` file as follows:
**`newArchEnabled=true`**

-  and then **`yarn TesterApp:start`**


#### For iOS
- Run pod install with the flags: 
**`RCT_NEW_ARCH_ENABLED=1 pod install`**

-  and then  **`yarn TesterApp:start`**
