### PR TITLE
fix: remove duplicated React-Core dependency from podspec

### DIFF
--- a/packages/repack/callstack-repack.podspec
+++ b/packages/repack/callstack-repack.podspec
@@ -17,11 +17,10 @@ Pod::Spec.new do |s|
 
   s.pod_target_xcconfig = { "DEFINES_MODULE" => "YES" }
   
-  s.dependency "React-Core"
   s.dependency 'JWTDecode', '~> 3.0.0'
   s.dependency 'SwiftyRSA', '~> 1.7'
 
-    # Use install_modules_dependencies helper to install the dependencies if React Native version >=0.71.0.
+  # Use install_modules_dependencies helper to install the dependencies if React Native version >=0.71.0.
   # See https://github.com/facebook/react-native/blob/febf6b7f33fdb4904669f99d795eba4c0f95d7bf/scripts/cocoapods/new_architecture.rb#L79.
   if respond_to?(:install_modules_dependencies, true)
     install_modules_dependencies(s)


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

This small PR removes duplicated `React-Core` dependency from `.podspec` file.

It is included either in `install_modules_dependencies` function or in `L28`

### Test plan

Make sure that `TesterApp` builds and runs successfully on both architectures
