### PR TITLE
fix: support non-classic paths to HMRClient from react-native

### DIFF
--- a/.changeset/dry-trains-join.md
+++ b/.changeset/dry-trains-join.md
@@ -1,0 +1,5 @@
+---
+"@callstack/repack": patch
+---
+
+Support non-classic(pnpm) paths to HMRClient from react-native

--- a/packages/repack/src/webpack/plugins/RepackTargetPlugin/RepackTargetPlugin.ts
+++ b/packages/repack/src/webpack/plugins/RepackTargetPlugin/RepackTargetPlugin.ts
@@ -50,7 +50,7 @@ export class RepackTargetPlugin implements WebpackPlugin {
 
     // Replace React Native's HMRClient.js with custom Webpack-powered DevServerClient.
     new webpack.NormalModuleReplacementPlugin(
-      /react-native([/\\]+)Libraries([/\\]+)Utilities([/\\]+)HMRClient\.js$/,
+      /react-native.*?([/\\]+)Libraries([/\\]+)Utilities([/\\]+)HMRClient\.js$/,
       function (resource) {
         const request = require.resolve('../../../modules/DevServerClient');
         const context = path.dirname(request);


### PR DESCRIPTION
### Summary

When using `pnpm` or `yarn` with `pnpm` linker, the path to `react-native` can be different:

#### yarn (with pnpm linker):
`react-native-virtual-38652004f3/package/Libraries/Utilities/HMRClient.js`
#### pnpm:
`react-native@0.71.8_@babel+core@7.23.0_@babel+preset-env@7.22.20_react@18.2.0/node_modules/react-native/Libraries/Utilities/HMRClient.js`

This change allows to match these additional cases as well and include `DevServerClient` from 'Re.Pack' properly.

Pretty sure we don't need to make it any more stricter than this, the chance of collision with something else is close to 0
### Test plan

- [x] - tested on TesterApp with pnpm
