### PR TITLE
refactor(repack): use `done` hook inside of `OutputPlugin`

### DIFF
--- a/.changeset/shiny-planes-hope.md
+++ b/.changeset/shiny-planes-hope.md
@@ -1,0 +1,5 @@
+---
+"@callstack/repack": patch
+---
+
+Use `done` hook inside of `OutputPlugin`

--- a/packages/repack/src/webpack/plugins/OutputPlugin.ts
+++ b/packages/repack/src/webpack/plugins/OutputPlugin.ts
@@ -183,6 +183,11 @@ export class OutputPlugin implements WebpackPlugin {
       return;
     }
 
+    const outputPath = compiler.options.output?.path;
+    if (!outputPath) {
+      throw new Error('Cannot infer output path from compilation');
+    }
+
     const logger = compiler.getInfrastructureLogger('RepackOutputPlugin');
 
     const extraAssets = (this.config.extraChunks ?? []).map((spec) =>
@@ -295,11 +300,6 @@ export class OutputPlugin implements WebpackPlugin {
     compiler.hooks.afterEmit.tapPromise(
       'RepackOutputPlugin',
       async (compilation) => {
-        const outputPath = compilation.outputOptions.path;
-        if (!outputPath) {
-          throw new Error('Cannot infer output path from compilation');
-        }
-
         let localAssetsCopyProcessor;
 
         let { bundleFilename, sourceMapFilename, assetsPath } =

--- a/packages/repack/src/webpack/plugins/OutputPlugin.ts
+++ b/packages/repack/src/webpack/plugins/OutputPlugin.ts
@@ -243,7 +243,7 @@ export class OutputPlugin implements WebpackPlugin {
         chunkRelations: true,
         ids: true,
       });
-      const chunks = new Map(
+      const statsChunkMap = new Map(
         compilationStats.chunks!.map((chunk) => [chunk.id!, chunk])
       );
       const entryChunkName = this.config.entryName ?? 'main';
@@ -252,7 +252,7 @@ export class OutputPlugin implements WebpackPlugin {
       const sharedChunks = new Set<webpack.StatsChunk>();
       const auxiliaryAssets: Set<string> = new Set();
 
-      const entryChunk = compilationStats?.chunks?.find((chunk) => {
+      const entryChunk = compilationStats.chunks!.find((chunk) => {
         return chunk.initial && chunk.names?.includes(entryChunkName);
       });
 
@@ -262,7 +262,7 @@ export class OutputPlugin implements WebpackPlugin {
           continue;
         }
 
-        getAllInitialChunks(chunk, chunks)
+        getAllInitialChunks(chunk, statsChunkMap)
           .filter((sharedChunk) => sharedChunk !== chunk)
           .forEach((sharedChunk) => {
             sharedChunks.add(sharedChunk);
@@ -281,7 +281,7 @@ export class OutputPlugin implements WebpackPlugin {
       // Process shared chunks to add them either as local or remote chunk.
       for (const sharedChunk of sharedChunks) {
         const isUsedByLocalChunk = localChunks.some((localChunk) =>
-          getAllInitialChunks(localChunk, chunks).includes(sharedChunk)
+          getAllInitialChunks(localChunk, statsChunkMap).includes(sharedChunk)
         );
         if (
           isUsedByLocalChunk ||

--- a/packages/repack/src/webpack/plugins/OutputPlugin.ts
+++ b/packages/repack/src/webpack/plugins/OutputPlugin.ts
@@ -298,7 +298,6 @@ export class OutputPlugin implements WebpackPlugin {
     });
 
     compiler.hooks.done.tapPromise('RepackOutputPlugin', async (stats) => {
-      const compilation = stats.compilation;
       const stats1 = stats.toJson({ all: true });
 
       let localAssetsCopyProcessor;
@@ -333,7 +332,6 @@ export class OutputPlugin implements WebpackPlugin {
 
         localAssetsCopyProcessor = new AssetsCopyProcessor({
           platform: this.config.platform,
-          compilation,
           outputPath,
           bundleOutput: bundleFilename,
           bundleOutputDir: bundlePath,
@@ -350,6 +348,7 @@ export class OutputPlugin implements WebpackPlugin {
         // Process entry chunk
         localAssetsCopyProcessor?.enqueueChunk(chunk, {
           isEntry: entryChunk === chunk,
+          sourceMapFile: '', // TODO: use source map from stats.chunks
         });
       }
 
@@ -370,7 +369,6 @@ export class OutputPlugin implements WebpackPlugin {
             remoteAssetsCopyProcessors[spec.outputPath] =
               new AssetsCopyProcessor({
                 platform: this.config.platform,
-                compilation,
                 outputPath,
                 bundleOutput: '',
                 bundleOutputDir: spec.outputPath,
@@ -382,6 +380,7 @@ export class OutputPlugin implements WebpackPlugin {
 
           remoteAssetsCopyProcessors[spec.outputPath].enqueueChunk(chunk, {
             isEntry: false,
+            sourceMapFile: '', // TODO: use source map from stats.chunks
           });
         }
       }

--- a/packages/repack/src/webpack/plugins/utils/AssetsCopyProcessor.ts
+++ b/packages/repack/src/webpack/plugins/utils/AssetsCopyProcessor.ts
@@ -9,7 +9,6 @@ export class AssetsCopyProcessor {
   constructor(
     public readonly config: {
       platform: string;
-      compilation: webpack.Compilation;
       outputPath: string;
       bundleOutput: string;
       bundleOutputDir: string;
@@ -29,9 +28,11 @@ export class AssetsCopyProcessor {
     await this.filesystem.copyFile(from, to);
   }
 
-  enqueueChunk(chunk: webpack.Chunk, { isEntry }: { isEntry: boolean }) {
+  enqueueChunk(
+    chunk: webpack.Chunk,
+    { isEntry, sourceMapFile }: { isEntry: boolean; sourceMapFile?: string }
+  ) {
     const {
-      compilation,
       outputPath,
       bundleOutput,
       sourcemapOutput,
@@ -52,13 +53,6 @@ export class AssetsCopyProcessor {
     if (!chunkFile) {
       return;
     }
-
-    const relatedSourceMap =
-      compilation.assetsInfo.get(chunkFile)?.related?.sourceMap;
-    // Source map for the chunk e.g: `index.bundle.map`, `src_App_js.chunk.bundle.map`
-    const sourceMapFile = Array.isArray(relatedSourceMap)
-      ? relatedSourceMap[0]
-      : relatedSourceMap;
 
     // Target file path where to save the bundle.
     const bundleDestination = isEntry

--- a/packages/repack/src/webpack/plugins/utils/AssetsCopyProcessor.ts
+++ b/packages/repack/src/webpack/plugins/utils/AssetsCopyProcessor.ts
@@ -29,7 +29,7 @@ export class AssetsCopyProcessor {
   }
 
   enqueueChunk(
-    chunk: webpack.Chunk,
+    chunk: webpack.StatsChunk,
     { isEntry, sourceMapFile }: { isEntry: boolean; sourceMapFile?: string }
   ) {
     const {
@@ -45,11 +45,15 @@ export class AssetsCopyProcessor {
       : bundleOutputDir;
 
     // Chunk bundle e.g: `index.bundle`, `src_App_js.chunk.bundle`
-    const [chunkFile] = [...chunk.files];
+    // There might be more than 1 file associated with the chunk -
+    // this happens e.g. on web when importing CSS files into JS.
+    // TBD whether this can ever occur in React Native.
+    const chunkFile = chunk.files?.[0];
 
     // Sometimes there are no files associated with the chunk and the OutputPlugin fails
     // Skipping such chunks is a temporary workaround resulting in proper behaviour
-    // TODO: determine the real cause of this issue
+    // This can happen when Module Federation is used and some chunks are not emitted
+    // and are only used as temporary during compilation.
     if (!chunkFile) {
       return;
     }

--- a/packages/repack/src/webpack/plugins/utils/AssetsCopyProcessor.ts
+++ b/packages/repack/src/webpack/plugins/utils/AssetsCopyProcessor.ts
@@ -133,7 +133,7 @@ export class AssetsCopyProcessor {
     }
 
     // Copy regular assets
-    const mediaAssets = [...chunk.auxiliaryFiles]
+    const mediaAssets = [...chunk.auxiliaryFiles!]
       .filter((file) => !/\.(map|bundle\.json)$/.test(file))
       .filter((file) => !/^remote-assets/.test(file));
 
@@ -148,7 +148,7 @@ export class AssetsCopyProcessor {
     );
 
     // Manifest file name e.g: `index.bundle.json`, src_App_js.chunk.bundle.json`
-    const [manifest] = [...chunk.auxiliaryFiles].filter((file) =>
+    const [manifest] = [...chunk.auxiliaryFiles!].filter((file) =>
       /\.bundle\.json$/.test(file)
     );
     if (manifest) {

--- a/packages/repack/src/webpack/plugins/utils/__tests__/AssetsCopyProcessor.test.ts
+++ b/packages/repack/src/webpack/plugins/utils/__tests__/AssetsCopyProcessor.test.ts
@@ -9,26 +9,6 @@ describe('AssetsCopyProcessor', () => {
   describe('for ios', () => {
     const acpConfigStub = {
       platform: 'ios',
-      compilation: {
-        assetsInfo: new Map([
-          [
-            'index.bundle',
-            {
-              related: {
-                sourceMap: 'index.bundle.map',
-              },
-            },
-          ],
-          [
-            'src_Async_js.chunk.bundle',
-            {
-              related: {
-                sourceMap: 'src_Async_js.chunk.bundle.map',
-              },
-            },
-          ],
-        ]),
-      } as unknown as webpack.Compilation,
       outputPath: '/dist',
       bundleOutput: '/target/ios/build/Release-iphonesimulator/main.jsbundle',
       bundleOutputDir: '/target/ios/build/Release-iphonesimulator',
@@ -64,8 +44,8 @@ describe('AssetsCopyProcessor', () => {
             'assets/node_modules/react-native/libraries/newappscreen/components/logo.png',
             'index.bundle.map',
           ],
-        } as unknown as webpack.Chunk,
-        { isEntry: true }
+        } as unknown as webpack.StatsChunk,
+        { isEntry: true, sourceMapFile: 'index.bundle.map' }
       );
       await Promise.all(acp.execute());
       expect(1).toBe(1);
@@ -110,8 +90,8 @@ describe('AssetsCopyProcessor', () => {
             'src_Async_js.chunk.bundle.map',
             'src_Async_js.chunk.bundle.json',
           ],
-        } as unknown as webpack.Chunk,
-        { isEntry: false }
+        } as unknown as webpack.StatsChunk,
+        { isEntry: false, sourceMapFile: 'src_Async_js.chunk.bundle.map' }
       );
       await Promise.all(acp.execute());
 
@@ -136,26 +116,6 @@ describe('AssetsCopyProcessor', () => {
   describe('for android', () => {
     const acpConfigStub = {
       platform: 'android',
-      compilation: {
-        assetsInfo: new Map([
-          [
-            'index.bundle',
-            {
-              related: {
-                sourceMap: 'index.bundle.map',
-              },
-            },
-          ],
-          [
-            'src_Async_js.chunk.bundle',
-            {
-              related: {
-                sourceMap: 'src_Async_js.chunk.bundle.map',
-              },
-            },
-          ],
-        ]),
-      } as unknown as webpack.Compilation,
       outputPath: '/dist',
       bundleOutput:
         '/target/generated/assets/react/release/index.android.bundle',
@@ -190,8 +150,8 @@ describe('AssetsCopyProcessor', () => {
             'drawable-mdpi/node_modules_reactnative_libraries_newappscreen_components_logo.png',
             'index.bundle.map',
           ],
-        } as unknown as webpack.Chunk,
-        { isEntry: true }
+        } as unknown as webpack.StatsChunk,
+        { isEntry: true, sourceMapFile: 'index.bundle.map' }
       );
       await Promise.all(acp.execute());
 
@@ -235,8 +195,8 @@ describe('AssetsCopyProcessor', () => {
             'src_Async_js.chunk.bundle.map',
             'src_Async_js.chunk.bundle.json',
           ],
-        } as unknown as webpack.Chunk,
-        { isEntry: false }
+        } as unknown as webpack.StatsChunk,
+        { isEntry: false, sourceMapFile: 'src_Async_js.chunk.bundle.map' }
       );
       await Promise.all(acp.execute());
 


### PR DESCRIPTION
### Summary

Migrated `OutputPlugin` to run only inside of `done` hook - this enables usage of `OutputPlugin` with `rspack` as previous approach utilised features not available in `rspack` yet(?)

### Test plan

- [x] - updated tests pass
- [x] - output is the same as before
