### PR TITLE
chore(init): proper TS setup

### DIFF
--- a/packages/init/tsconfig.json
+++ b/packages/init/tsconfig.json
@@ -2,14 +2,19 @@
   "compilerOptions": {
     "target": "ES2020",
     "lib": ["ES2020"],
-    "module": "ES2020",
-    "moduleResolution": "node",
+    "module": "node16",
+    "moduleResolution": "node16",
     "outDir": "build",
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,
     "resolveJsonModule": true,
     "skipLibCheck": true,
-    "strict": true
+    "strict": true,
+    "paths": {
+      "detect-package-manager": [
+        "../../node_modules/detect-package-manager/dist/index.d.ts"
+      ]
+    }
   },
   "include": ["src/**/*.ts"]
 }


### PR DESCRIPTION
### Summary

Modified `tsconfig.json` inside of `packages/init` to properly track imports within the package. 

This change is fully internal and does not require a new release of `@callstack/repack-init`

Thanks @Q1w1N for spotting this!

### Test plan

not needed
