### PR TITLE
[BREAKING] feat: make resolver preset follow Metro defaults closely

### DIFF
--- a/.changeset/kind-scissors-kick.md
+++ b/.changeset/kind-scissors-kick.md
@@ -9,6 +9,7 @@ BREAKING CHANGE:
 1. `getResolveOptions` now accepts a second optional parameter called options with the following properties:
    - `enablePackageExports` - defaults to `false`
    - `preferNativePlatform` - defaults to `true`
-2. Resolution via Package Exports (`exports` field in package.json) is now optional and disabled by default.
+2. Order of extensions was changed to match the order from `@react-native/metro-config`.
+3. Resolution via Package Exports (`exports` field in package.json) is now optional and disabled by default.
    It can now be enabled via `getResolveOptions` options parameter. This change was introduced to match `metro` defaults.
-3. Default `conditionNames` are now: `['require', 'import', 'react-native']` and match `@react-native/metro-config` defaults.
+4. Default `conditionNames` are now: `['require', 'import', 'react-native']` and match `@react-native/metro-config` defaults.

--- a/.changeset/kind-scissors-kick.md
+++ b/.changeset/kind-scissors-kick.md
@@ -1,0 +1,14 @@
+---
+"@callstack/repack": major
+---
+
+BREAKING CHANGE:
+
+`getResolveOptions` is now way more compatible with `metro-resolver` and `@react-native/metro-config`
+
+1. `getResolveOptions` now accepts a second optional parameter called options with the following properties:
+   - `enablePackageExports` - defaults to `false`
+   - `preferNativePlatform` - defaults to `true`
+2. Resolution via Package Exports (`exports` field in package.json) is now optional and disabled by default.
+   It can now be enabled via `getResolveOptions` options parameter. This change was introduced to match `metro` defaults.
+3. Default `conditionNames` are now: `['require', 'import', 'react-native']` and match `@react-native/metro-config` defaults.

--- a/metro-compat-test/jest.setup.js
+++ b/metro-compat-test/jest.setup.js
@@ -9,23 +9,38 @@ const testsToSkip = {
     '[nonstrict] should fall back to "main" field resolution when "exports" is an invalid subpath',
     '[nonstrict] should fall back to "browser" spec resolution and log inaccessible import warning',
     '[nonstrict] should fall back and log warning for an invalid "exports" target value',
-    '[nonstrict] should fall back to "browser" spec resolution and log inaccessible import warning',
-    '[nonstrict] should fall back to "browser" spec resolution and log inaccessible import warning',
     // Assets are handled differently in webpack
     'should resolve assets using "exports" field and calling `resolveAsset`',
     // Resolving fails as expected but error messages are different
     'should use most specific pattern base',
     'should throw FailedToResolvePathError when no conditions are matched',
+    // Root shorthand - pending fix in metro
+    'should expand array of strings as subpath mapping (root shorthand)',
+    // Restricted imports - pending fix in metro
+    'should resolve subpath patterns in "exports" matching import specifier',
+  ]),
+};
+
+const testsToSkipOnce = {
+  describe: new Set(),
+  test: new Set([
+    // sourceExts are expanded, platform-specific extensions are not
+    'without expanding `sourceExts`',
+    'without expanding platform-specific extensions',
   ]),
 };
 
 // alias it to test
 Object.defineProperty(testsToSkip, 'it', testsToSkip.test);
+Object.defineProperty(testsToSkipOnce, 'it', testsToSkipOnce.test);
 
 // trap call & check if test should be skipped
 const handler = {
   apply(target, _, args) {
     if (testsToSkip[target.name].has(args[0])) {
+      return target.skip(...args);
+    } else if (testsToSkipOnce[target.name].has(args[0])) {
+      testsToSkipOnce[target.name].delete(args[0]);
       return target.skip(...args);
     } else return target(...args);
   },

--- a/metro-compat-test/resolver/resolve.ts
+++ b/metro-compat-test/resolver/resolve.ts
@@ -101,9 +101,12 @@ function transformContext(
     } as InputFileMap,
     options: {
       // repack uses whole separate config per platform
-      conditionNames: platform
-        ? context.unstable_conditionsByPlatform[platform]
-        : context.unstable_conditionNames,
+      conditionNames: Array.from(
+        new Set([
+          ...context.unstable_conditionNames,
+          ...(context.unstable_conditionsByPlatform[platform!] ?? []),
+        ])
+      ),
       fallback: context.extraNodeModules
         ? { ...context.extraNodeModules }
         : undefined,

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "build": "turbo run build",
     "lint": "turbo run lint --filter=!metro-compat-test",
     "typecheck": "turbo run typecheck --filter=!metro-compat-test",
-    "test": "turbo run test --filter=!metro-compat-test",
+    "test": "turbo run test",
     "release": "pnpm build && pnpm lint && pnpm test && pnpm changeset publish",
     "website:start": "turbo run docs && pnpm --filter website run start",
     "website:build": "turbo run docs && pnpm --filter website run export",

--- a/packages/repack/src/webpack/utils/getResolveOptions.ts
+++ b/packages/repack/src/webpack/utils/getResolveOptions.ts
@@ -49,21 +49,7 @@ export function getResolveOptions(platform: string, options?: ResolveOptions) {
   const preferNativePlatform = options?.preferNativePlatform ?? true;
   const enablePackageExports = options?.enablePackageExports ?? false;
 
-  let extensions = ['.ts', '.js', '.tsx', '.jsx', '.json'];
-
-  const platformExtensions = [
-    `.${platform}.ts`,
-    `.${platform}.js`,
-    `.${platform}.tsx`,
-    `.${platform}.jsx`,
-  ];
-
-  const nativeExtensions = [
-    '.native.ts',
-    '.native.js',
-    '.native.tsx',
-    '.native.jsx',
-  ];
+  let extensions = ['.js', '.jsx', '.json', '.ts', '.tsx'];
 
   let conditionNames: string[];
   let exportsFields: string[];
@@ -79,11 +65,16 @@ export function getResolveOptions(platform: string, options?: ResolveOptions) {
   } else {
     conditionNames = [];
     exportsFields = [];
-    extensions = [
-      platformExtensions,
-      preferNativePlatform ? nativeExtensions : [],
-      extensions,
-    ].flat();
+    extensions = extensions.flatMap((ext) => {
+      const platformExt = `.${platform}${ext}`;
+      const nativeExt = `.native${ext}`;
+
+      if (preferNativePlatform) {
+        return [platformExt, nativeExt, ext];
+      } else {
+        return [platformExt, ext];
+      }
+    });
   }
 
   /**

--- a/packages/repack/src/webpack/utils/getResolveOptions.ts
+++ b/packages/repack/src/webpack/utils/getResolveOptions.ts
@@ -1,5 +1,5 @@
 /**
- * {@link getResolveOptions} options.
+ * {@link getResolveOptions} additional options.
  */
 export interface ResolveOptions {
   /**
@@ -16,7 +16,8 @@ export interface ResolveOptions {
  * Get Webpack's resolve options to properly resolve JavaScript files:
  * - resolve platform extensions (e.g. `file.ios.js`)
  * - resolve native extensions (e.g. `file.native.js`)
- * - optionally use package exports (`exports` field in `package.json`) instead of main fields (e.g. `main` or `browser` or `react-native`)
+ * - optionally use package exports (`exports` field in `package.json`) instead of
+ *   main fields (e.g. `main` or `browser` or `react-native`)
  *
  * @param platform Target application platform.
  * @param options Additional options that can modify resolution behaviour.
@@ -25,6 +26,7 @@ export interface ResolveOptions {
  * @category Webpack util
  *
  * @example Usage in Webpack config:
+ *
  * ```ts
  * import * as Repack from '@callstack/repack';
  *
@@ -84,17 +86,32 @@ export function getResolveOptions(platform: string, options: ResolveOptions) {
     ].flat();
   }
 
+  /**
+   * Match what React Native uses in @react-native/metro-config.
+   * First entry takes precedence.
+   *
+   * Reference: https://github.com/facebook/react-native/blob/main/packages/metro-config/src/index.flow.js
+   */
   return {
     /**
-     * Match what React Native uses in @react-native/metro-config.
-     * First entry takes precedence.
-     *
-     * Reference: https://github.com/facebook/react-native/blob/main/packages/metro-config/src/index.flow.js
+     * Reference: Webpack's [configuration.resolve.mainFields](https://webpack.js.org/configuration/resolve/#resolvemainfields)
      */
     mainFields: ['react-native', 'browser', 'main'],
+    /**
+     * Reference: Webpack's [configuration.resolve.aliasFields](https://webpack.js.org/configuration/resolve/#resolvealiasfields)
+     */
     aliasFields: ['react-native', 'browser', 'main'],
-    conditionNames,
-    exportsFields,
-    extensions,
+    /**
+     * Reference: Webpack's [configuration.resolve.conditionNames](https://webpack.js.org/configuration/resolve/#resolveconditionnames)
+     */
+    conditionNames: conditionNames,
+    /**
+     * Reference: Webpack's [configuration.resolve.exportsFields](https://webpack.js.org/configuration/resolve/#resolveexportsfields)
+     */
+    exportsFields: exportsFields,
+    /**
+     * Reference: Webpack's [configuration.resolve.extensions](https://webpack.js.org/configuration/resolve/#resolveextensions)
+     */
+    extensions: extensions,
   };
 }

--- a/packages/repack/src/webpack/utils/getResolveOptions.ts
+++ b/packages/repack/src/webpack/utils/getResolveOptions.ts
@@ -23,7 +23,45 @@
  * };
  * ```
  */
-export function getResolveOptions(platform: string) {
+export function getResolveOptions({
+  platform,
+  enablePackageExports = false,
+  preferNativePlatform = true,
+}: {
+  platform: string;
+  enablePackageExports?: boolean;
+  preferNativePlatform?: boolean;
+}) {
+  let extensions = ['.ts', '.js', '.tsx', '.jsx', '.json'];
+  const platformExtensions = [
+    `.${platform}.ts`,
+    `.${platform}.js`,
+    `.${platform}.tsx`,
+    `.${platform}.jsx`,
+  ];
+  const nativeExtensions = [
+    '.native.ts',
+    '.native.js',
+    '.native.tsx',
+    '.native.jsx',
+  ];
+
+  let conditionNames: string[];
+  let exportsFields: string[];
+
+  if (enablePackageExports) {
+    conditionNames = ['require', 'import', 'react-native'];
+    exportsFields = ['exports'];
+  } else {
+    conditionNames = [];
+    exportsFields = [];
+    extensions = [
+      platformExtensions,
+      preferNativePlatform ? nativeExtensions : [],
+      extensions,
+    ].flat();
+  }
+
   return {
     /**
      * Match what React Native packager supports.
@@ -31,21 +69,8 @@ export function getResolveOptions(platform: string) {
      */
     mainFields: ['react-native', 'browser', 'main'],
     aliasFields: ['react-native', 'browser', 'main'],
-    conditionNames: ['default', 'require'],
-    extensions: [
-      `.${platform}.ts`,
-      `.${platform}.js`,
-      `.${platform}.tsx`,
-      `.${platform}.jsx`,
-      '.native.ts',
-      '.native.js',
-      '.native.tsx',
-      '.native.jsx',
-      '.ts',
-      '.js',
-      '.tsx',
-      '.jsx',
-      '.json',
-    ],
+    conditionNames,
+    exportsFields,
+    extensions,
   };
 }

--- a/packages/repack/src/webpack/utils/getResolveOptions.ts
+++ b/packages/repack/src/webpack/utils/getResolveOptions.ts
@@ -50,6 +50,12 @@ export function getResolveOptions({
   let exportsFields: string[];
 
   if (enablePackageExports) {
+    /**
+     * Match what React Native uses in @react-native/metro-config.
+     * Order of conditionNames doesn't matter.
+     *
+     * Source: https://github.com/facebook/react-native/blob/d53cc2b46dee5ed4d93ee76dea4aea9da42d0158/packages/metro-config/src/index.flow.js
+     */
     conditionNames = ['require', 'import', 'react-native'];
     exportsFields = ['exports'];
   } else {
@@ -66,6 +72,8 @@ export function getResolveOptions({
     /**
      * Match what React Native packager supports.
      * First entry takes precedence.
+     *
+     * Source: https://github.com/facebook/react-native/blob/d53cc2b46dee5ed4d93ee76dea4aea9da42d0158/packages/metro-config/src/index.flow.js
      */
     mainFields: ['react-native', 'browser', 'main'],
     aliasFields: ['react-native', 'browser', 'main'],

--- a/packages/repack/src/webpack/utils/getResolveOptions.ts
+++ b/packages/repack/src/webpack/utils/getResolveOptions.ts
@@ -45,9 +45,9 @@ export interface ResolveOptions {
  * ```
  */
 
-export function getResolveOptions(platform: string, options: ResolveOptions) {
-  const preferNativePlatform = options.preferNativePlatform ?? true;
-  const enablePackageExports = options.enablePackageExports ?? false;
+export function getResolveOptions(platform: string, options?: ResolveOptions) {
+  const preferNativePlatform = options?.preferNativePlatform ?? true;
+  const enablePackageExports = options?.enablePackageExports ?? false;
 
   let extensions = ['.ts', '.js', '.tsx', '.jsx', '.json'];
 


### PR DESCRIPTION
### Summary

BREAKING CHANGE:

`getResolveOptions` is now way more compatible with `metro-resolver` and `@react-native/metro-config`

1. `getResolveOptions` now accepts a second optional parameter called options with the following properties:
   - `enablePackageExports` - defaults to `false`
   - `preferNativePlatform` - defaults to `true`
2. Order of extensions was changed to match the order from `@react-native/metro-config`.
3. Resolution via Package Exports (`exports` field in package.json) is now optional and disabled by default.
   It can now be enabled via `getResolveOptions` options parameter. This change was introduced to match `metro` defaults.
4. Default `conditionNames` are now: `['require', 'import', 'react-native']` and match `@react-native/metro-config` defaults.

### Remarks

Implementation passes every `metro-compat` test with the following exceptions in `package-exports-test`:
- **_should resolve "exports" target directly > without expanding `sourceExts`_** - test should be marked as `[nonstrict]` as it relies on unsupported fallback mechanism
- **_should resolve "exports" target directly > without expanding platform-specific extensions_** - test should be marked as `[nonstrict]` as it relies on unsupported fallback mechanism
- **_subpath exports > should expand array of strings as subpath mapping (root shorthand)_** - this spec is not compliant with Node spec and should be fixed upstream as it's original purpose was to match Node spec.
- _**subpath patterns > should resolve subpath patterns in "exports" matching import specifier**_ - one of the examples in the test is bad - `Bar.js` should not be exposed by the package according to the Node spec, but instead fallback to using less specific specifier. This mechanism is used to restrict imports in packages and should be fixed upstream

### Checklist
- [x] - rework implementation of `getResolveOptions`
- [x] - adjust `JSDoc`
- [x] - ensure `TypeDoc` compiles and displays new descriptions properly
- [x] - add tests from Remarks to skipped ones 

### Test plan

- [x] - pass selected `metro-compat` tests
