### PR TITLE
chore: hoist workspace packages

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,2 @@
 auto-install-peers=false
+hoist-workspace-packages=true

--- a/packages/TesterApp/webpack.config.mjs
+++ b/packages/TesterApp/webpack.config.mjs
@@ -93,17 +93,6 @@ export default (env) => {
       alias: {
         'react-native': reactNativePath,
       },
-      /**
-       * Because Re.Pack is symlinked from it's workspace, we need to provide a fallback for
-       * `react-native-event-source` package used for lazyCompilation. This is not needed in
-       * normal projects.
-       */
-      fallback: {
-        'react-native-event-source': path.join(
-          dirname,
-          'node_modules/react-native-event-source'
-        ),
-      },
     },
     /**
      * Configures output.


### PR DESCRIPTION
### Summary

makes workspace packages available in the virtual store

thanks to that, we can remove the weird fallback in `TesterApp` and avoid an issue where codegen will fail to find a package because it's symlinked to workspace and not present in the store.

### Test plan

n/a
