### PR TITLE
[BREAKING] feat: override start & bundle commands

### DIFF
--- a/packages/repack/commands.d.ts
+++ b/packages/repack/commands.d.ts
@@ -1,5 +1,17 @@
 const commands: [
   {
+    name: 'bundle';
+    description: string;
+    options: Array<any>;
+    func: typeof import('./dist/commands/bundle').bundle;
+  },
+  {
+    name: 'start';
+    description: string;
+    options: Array<any>;
+    func: typeof import('./dist/commands/start').start;
+  },
+  {
     name: 'webpack-bundle';
     description: string;
     options: Array<any>;
@@ -10,6 +22,6 @@ const commands: [
     description: string;
     options: Array<any>;
     func: typeof import('./dist/commands/start').start;
-  }
+  },
 ];
 export default commands;

--- a/packages/repack/commands.js
+++ b/packages/repack/commands.js
@@ -72,9 +72,9 @@ const webpackConfigOption = {
   },
 };
 
-module.exports = [
+const commands = [
   {
-    name: 'webpack-bundle',
+    name: 'bundle',
     description: bundleCommand.description,
     options: bundleCommand.options.concat(
       {
@@ -96,7 +96,7 @@ module.exports = [
     func: require('./dist/commands/bundle').bundle,
   },
   {
-    name: 'webpack-start',
+    name: 'start',
     options: startCommand.options.concat(
       {
         name: '--verbose',
@@ -124,3 +124,10 @@ module.exports = [
     func: require('./dist/commands/start').start,
   },
 ];
+
+const webpackCommands = commands.map((command) => ({
+  ...command,
+  name: `webpack-${command.name}`,
+}));
+
+module.exports = [...commands, ...webpackCommands];


### PR DESCRIPTION
### Summary

Closes #93
Closes #487

Override `start` & `bundle` commands from CLI.

For maximum compatibility, instead of replacing `webpack-start` and `webpack-bundle` commands, the overrides were added on top of old commands. This results in following behaviour:

- for React-Native <0.74 (CLI <13)  - CLI won't apply overrides, webpack commands will work just as before
- for React-Native >=0.74 (CLI >=13) - both overrides and webpack commands work

It's possible to opt out of overrides by simply filtering out commands in `react-native.config.js`:
```js
const commands = require('@callstack/repack/commands');

module.exports = {
  commands: commands.filter((command) => command.name.startsWith('webpack')),
};
```

This also solves the issue with launching metro dev server when running `react-native run-ios` or `react-native run-android` - Re.Pack dev server will be launched instead

### Test plan

- [x] - tested locally
- [ ] - add integration tests to TesterApp suite
