### PR TITLE
feat: OutputPlugin support for empty object as entry

### DIFF
--- a/.changeset/early-radios-grow.md
+++ b/.changeset/early-radios-grow.md
@@ -1,0 +1,5 @@
+---
+"@callstack/repack": minor
+---
+
+OutputPlugin now supports configuration with empty object as compilation entry.

--- a/packages/repack/src/webpack/plugins/OutputPlugin.ts
+++ b/packages/repack/src/webpack/plugins/OutputPlugin.ts
@@ -293,12 +293,6 @@ export class OutputPlugin implements WebpackPlugin {
         }
       }
 
-      if (!entryChunk) {
-        throw new Error(
-          'Cannot infer entry chunk - this should have not happened.'
-        );
-      }
-
       const assets = compilationStats.assets!;
       // Collect auxiliary assets (only remote-assets for now)
       assets


### PR DESCRIPTION
### Summary

Closes #361
 
When supplied with empty object as entry, `OutputPlugin` would fail because we didn't allow for such scenario. Since this scenario is a valid webpack use case (documented [here](https://webpack.js.org/concepts/entry-points/#object-syntax)), the constraint of `entryChunk` being present was removed. 

This feature is especially useful when using `ModuleFederation` - if we only care about the federated container + chunks, then all of our entrypoints declarations come from the `ModuleFederationPlugin`. 

### Test plan

- [x] - TesterApp tests suite pass
- [x] - tested locally with super-app-showcase
