### PR TITLE
chore: pnpm chores

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,24 +42,5 @@
     "prettier": "^3.2.4",
     "typescript": "^5.2.2"
   },
-  "packageManager": "pnpm@8.15.4+sha256.cea6d0bdf2de3a0549582da3983c70c92ffc577ff4410cbf190817ddc35137c2",
-  "pnpm": {
-    "packageExtensions": {
-      "@react-native/dev-middleware@*": {
-        "dependencies": {
-          "ws": "*"
-        }
-      },
-      "@react-native/codegen@*": {
-        "dependencies": {
-          "invariant": "^2.2.4"
-        }
-      },
-      "@react-native-community/cli-tools@*": {
-        "dependencies": {
-          "execa": "^5.0.0"
-        }
-      }
-    }
-  }
+  "packageManager": "pnpm@8.15.4+sha256.cea6d0bdf2de3a0549582da3983c70c92ffc577ff4410cbf190817ddc35137c2"
 }

--- a/package.json
+++ b/package.json
@@ -42,5 +42,5 @@
     "prettier": "^3.2.4",
     "typescript": "^5.2.2"
   },
-  "packageManager": "pnpm@8.15.4+sha256.cea6d0bdf2de3a0549582da3983c70c92ffc577ff4410cbf190817ddc35137c2"
+  "packageManager": "pnpm@8.15.6"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,8 +4,6 @@ settings:
   autoInstallPeers: false
   excludeLinksFromLockfile: false
 
-packageExtensionsChecksum: 7765c0b8bb934187be06f95467f438bc
-
 importers:
 
   .:


### PR DESCRIPTION
### Summary

- [x] - bump `pnpm` to `8.15.6`
- [x] - remove now irrelevant `packageExtensions` since they were fixed upstream 

### Test plan

n/a
