### PR TITLE
chore: add version to metro-compat-test

### DIFF
--- a/metro-compat-test/package.json
+++ b/metro-compat-test/package.json
@@ -1,5 +1,6 @@
 {
   "name": "metro-compat-test",
+  "version": "0.0.1",
   "description": "Metro compatibility tests",
   "author": "Jakub Romańczyk <jakub.romanczyk@callstack.com>",
   "license": "MIT",


### PR DESCRIPTION
### Summary

lack of version in `metro-compat-test` causes changesets prereleases to fail, added placeholder version to work around this issue. 

Reference: https://github.com/changesets/changesets/pull/847

### Test plan

n/a
