### PR TITLE
fix(TesterApp): resolving symlinks in `resolveNodePackage.gradle` on Windows

### DIFF
--- a/packages/TesterApp/android/resolveNodePackage.gradle
+++ b/packages/TesterApp/android/resolveNodePackage.gradle
@@ -2,10 +2,20 @@
 // TODO remove in the future when this lands in RN
 
 ext.resolveNodePackage = { String packageName, File startDir ->
-    def candidate = new File(startDir, "node_modules/$packageName")
+    def candidate
+
+    def osName = System.getProperty("os.name").toLowerCase()
+    if (osName.contains("win")) {
+        // for Windows OS
+        candidate = new File(startDir, "node_modules\\$packageName")
+    } else {
+        // for Unix-likely OS (MacOS/Linux)
+        candidate = new File(startDir, "node_modules/$packageName")
+    }
 
     if (candidate.exists()) {
-        return candidate.canonicalFile
+        // workaround for `candidate.canonicalPath` because it doesn't resolve final path to symlink on Windows
+        return new File(candidate.toPath().toRealPath().toString())
     }
 
     def parentDir = startDir.parentFile


### PR DESCRIPTION

<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

When I was trying to run `TesterApp` on Windows I saw that paths to symlinked packages weren't resolve correctly, for some reason `.canonicalPath` on Windows doesn't resolve symlink. In this Pull Request I've replace `.canonicalPath` with workaround functions that seems to work on both platforms. 

### Test plan

1. Clone repository
3. Go to `packages/TesterApp`
4. Try running `pnpm android` on Windows 