### PR TITLE
fix: windows favicon path

### DIFF
--- a/.changeset/modern-dryers-itch.md
+++ b/.changeset/modern-dryers-itch.md
@@ -1,0 +1,5 @@
+---
+"@callstack/repack-dev-server": patch
+---
+
+Fix path to favicon.ico on Windows

--- a/packages/dev-server/src/plugins/favicon/faviconPlugin.ts
+++ b/packages/dev-server/src/plugins/favicon/faviconPlugin.ts
@@ -1,12 +1,15 @@
+import path from 'path';
+import { fileURLToPath } from 'url';
 import fastifyFavicon from 'fastify-favicon';
 import type { FastifyInstance } from 'fastify';
 import fastifyPlugin from 'fastify-plugin';
 
 // @ts-ignore
-const pathToImg = new URL('../../img', import.meta.url).pathname;
+const dirname = path.dirname(fileURLToPath(import.meta.url));
+const pathToImgDir = path.join(dirname, '../../img');
 
 async function faviconPlugin(instance: FastifyInstance) {
-  instance.register(fastifyFavicon, { path: pathToImg });
+  instance.register(fastifyFavicon, { path: pathToImgDir });
 }
 
 export default fastifyPlugin(faviconPlugin, {


### PR DESCRIPTION
### Summary

closes #548

### Test plan

- [x] `favicon.ico` works on MacOS
- [x] `favicon.ico` works on Windows
