### PR TITLE
chore: update `webpack.config` templates

### DIFF
--- a/.changeset/sharp-stingrays-wave.md
+++ b/.changeset/sharp-stingrays-wave.md
@@ -1,0 +1,5 @@
+---
+"@callstack/repack": patch
+---
+
+Update webpack.config templates

--- a/packages/TesterApp/webpack.config.mjs
+++ b/packages/TesterApp/webpack.config.mjs
@@ -1,6 +1,10 @@
-import path from 'path';
+import { createRequire } from 'node:module';
+import path from 'node:path';
 import TerserPlugin from 'terser-webpack-plugin';
 import * as Repack from '@callstack/repack';
+
+const dirname = Repack.getDirname(import.meta.url);
+const { resolve } = createRequire(import.meta.url);
 
 /**
  * More documentation, installation, usage, motivation and differences with Metro is available at:
@@ -20,7 +24,7 @@ import * as Repack from '@callstack/repack';
 export default (env) => {
   const {
     mode = 'development',
-    context = Repack.getDirname(import.meta.url),
+    context = dirname,
     entry = './index.js',
     platform = process.env.PLATFORM,
     minimize = mode === 'production',
@@ -28,10 +32,8 @@ export default (env) => {
     bundleFilename = undefined,
     sourceMapFilename = undefined,
     assetsPath = undefined,
-    reactNativePath = new URL('./node_modules/react-native', import.meta.url)
-      .pathname,
+    reactNativePath = resolve('react-native'),
   } = env;
-  const dirname = context;
 
   if (!platform) {
     throw new Error('Missing platform');
@@ -156,7 +158,7 @@ export default (env) => {
             /node_modules(.*[/\\])+pretty-format/,
             /node_modules(.*[/\\])+metro/,
             /node_modules(.*[/\\])+abort-controller/,
-            /node_modules(.*[/\\])+@callstack\/repack/,
+            /node_modules(.*[/\\])+@callstack[/\\]repack/,
           ],
           use: 'babel-loader',
         },

--- a/packages/repack/src/webpack/utils/getInitializationEntries.ts
+++ b/packages/repack/src/webpack/utils/getInitializationEntries.ts
@@ -29,11 +29,12 @@ export interface InitializationEntriesOptions {
  * ```ts
  * import * as Repack from '@callstack/repack';
  *
+ * const { resolve } = createRequire(import.meta.url);
+ *
  * export default (env) => {
  *   const {
  *     devServer,
- *     reactNativePath = new URL('./node_modules/react-native', import.meta.url)
- *       .pathname,
+ *     reactNativePath = resolve('react-native'),
  *   } = env;
  *
  *   return {

--- a/templates/webpack.config.cjs
+++ b/templates/webpack.config.cjs
@@ -22,7 +22,7 @@ module.exports = (env) => {
     mode = 'development',
     context = __dirname,
     entry = './index.js',
-    platform,
+    platform = process.env.PLATFORM,
     minimize = mode === 'production',
     devServer = undefined,
     bundleFilename = undefined,

--- a/templates/webpack.config.cjs
+++ b/templates/webpack.config.cjs
@@ -157,7 +157,7 @@ module.exports = (env) => {
             /node_modules(.*[/\\])+pretty-format/,
             /node_modules(.*[/\\])+metro/,
             /node_modules(.*[/\\])+abort-controller/,
-            /node_modules(.*[/\\])+@callstack\/repack/,
+            /node_modules(.*[/\\])+@callstack[/\\]repack/,
           ],
           use: 'babel-loader',
         },

--- a/templates/webpack.config.mjs
+++ b/templates/webpack.config.mjs
@@ -3,7 +3,9 @@ import path from 'node:path';
 import TerserPlugin from 'terser-webpack-plugin';
 import * as Repack from '@callstack/repack';
 
+const dirname = Repack.getDirname(import.meta.url);
 const require = createRequire(import.meta.url);
+
 /**
  * More documentation, installation, usage, motivation and differences with Metro is available at:
  * https://github.com/callstack/repack/blob/main/README.md
@@ -22,7 +24,7 @@ const require = createRequire(import.meta.url);
 export default (env) => {
   const {
     mode = 'development',
-    context = Repack.getDirname(import.meta.url),
+    context = dirname,
     entry = './index.js',
     platform = process.env.PLATFORM,
     minimize = mode === 'production',
@@ -32,13 +34,12 @@ export default (env) => {
     assetsPath = undefined,
     reactNativePath = require.resolve('react-native'),
   } = env;
-  const dirname = Repack.getDirname(import.meta.url);
 
   if (!platform) {
     throw new Error('Missing platform');
   }
 
-    /**
+  /**
    * Using Module Federation might require disabling hmr.
    * Uncomment below to set `devServer.hmr` to `false`.
    *

--- a/templates/webpack.config.mjs
+++ b/templates/webpack.config.mjs
@@ -161,7 +161,7 @@ export default (env) => {
             /node_modules(.*[/\\])+pretty-format/,
             /node_modules(.*[/\\])+metro/,
             /node_modules(.*[/\\])+abort-controller/,
-            /node_modules(.*[/\\])+@callstack\/repack/,
+            /node_modules(.*[/\\])+@callstack[/\\]repack/,
           ],
           use: 'babel-loader',
         },

--- a/templates/webpack.config.mjs
+++ b/templates/webpack.config.mjs
@@ -1,7 +1,9 @@
-import path from 'path';
+import { createRequire } from 'node:module';
+import path from 'node:path';
 import TerserPlugin from 'terser-webpack-plugin';
 import * as Repack from '@callstack/repack';
 
+const require = createRequire(import.meta.url);
 /**
  * More documentation, installation, usage, motivation and differences with Metro is available at:
  * https://github.com/callstack/repack/blob/main/README.md
@@ -28,8 +30,7 @@ export default (env) => {
     bundleFilename = undefined,
     sourceMapFilename = undefined,
     assetsPath = undefined,
-    reactNativePath = new URL('./node_modules/react-native', import.meta.url)
-      .pathname,
+    reactNativePath = require.resolve('react-native'),
   } = env;
   const dirname = Repack.getDirname(import.meta.url);
 

--- a/templates/webpack.config.mjs
+++ b/templates/webpack.config.mjs
@@ -4,7 +4,7 @@ import TerserPlugin from 'terser-webpack-plugin';
 import * as Repack from '@callstack/repack';
 
 const dirname = Repack.getDirname(import.meta.url);
-const require = createRequire(import.meta.url);
+const { resolve } = createRequire(import.meta.url);
 
 /**
  * More documentation, installation, usage, motivation and differences with Metro is available at:
@@ -32,7 +32,7 @@ export default (env) => {
     bundleFilename = undefined,
     sourceMapFilename = undefined,
     assetsPath = undefined,
-    reactNativePath = require.resolve('react-native'),
+    reactNativePath = resolve('react-native'),
   } = env;
 
   if (!platform) {


### PR DESCRIPTION
### Summary

closes #501 

Updated templates to address following issues:
- [x] - `@callstack/repack` path in `module.rules` was not adjusted for Windows environment in both CJS & MJS templates
- [x] - added missing default for `platform` in CJS template
- [x] - use `createRequire` in MJS template to access `resolve` function and obtain path to RN instead of relying on `URL`. Destructuring `resolve` also helps with preventing accidental `require` usage in MJS.
- [x] - use `node:` prefix in MJS template for builtin modules
- [x] - aligned `webpack.config` in TesterApp to match current templates 

### Test plan

n/a
