### PR TITLE
fix(dev-server): should traversal all connected devices when sending event

### DIFF
--- a/.changeset/hmr-client-prove.md
+++ b/.changeset/hmr-client-prove.md
@@ -1,0 +1,7 @@
+---
+"@callstack/repack-dev-server": patch
+---
+
+should traversal all connected devices when sending event.
+
+delete device don't work when disconnected.

--- a/packages/dev-server/src/plugins/wss/servers/WebSocketHMRServer.ts
+++ b/packages/dev-server/src/plugins/wss/servers/WebSocketHMRServer.ts
@@ -80,17 +80,22 @@ export class WebSocketHMRServer extends WebSocketServer {
     }
 
     const clientId = `client#${this.nextClientId++}`;
-    this.clients.set({ clientId, platform }, socket);
 
-    this.fastify.log.info({ msg: 'HMR client connected', clientId, platform });
+    const client = {
+      clientId,
+      platform,
+    };
+
+    this.clients.set(client, socket);
+
+    this.fastify.log.info({ msg: 'HMR client connected', ...client });
 
     const onClose = () => {
       this.fastify.log.info({
         msg: 'HMR client disconnected',
-        clientId,
-        platform,
+        ...client,
       });
-      this.clients.delete({ clientId, platform });
+      this.clients.delete(client);
     };
 
     socket.addEventListener('error', onClose);

--- a/packages/dev-server/src/plugins/wss/servers/WebSocketHMRServer.ts
+++ b/packages/dev-server/src/plugins/wss/servers/WebSocketHMRServer.ts
@@ -46,7 +46,7 @@ export class WebSocketHMRServer extends WebSocketServer {
         key.platform !== platform ||
         !(clientIds ?? [key.clientId]).includes(key.clientId)
       ) {
-        return;
+        continue;
       }
 
       try {


### PR DESCRIPTION

<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

- When more than two devices are connected, one Android and one iOS, the second connected device will never receive the hot update notification, because the second device is different from the first connected device during traversal, and the loop will be exited directly.  We should continue to traversal next device when the platform of current device is different from  target device.

- Fix delete device don't work when disconnected

### Test plan

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
