### PR TITLE
fix: include `NativeScriptManager.ts` in published files for codegen

### DIFF
--- a/.changeset/friendly-insects-dream.md
+++ b/.changeset/friendly-insects-dream.md
@@ -1,0 +1,5 @@
+---
+"@callstack/repack": patch
+---
+
+Fix: include `NativeScriptManger.ts` for codegen

--- a/packages/repack/package.json
+++ b/packages/repack/package.json
@@ -18,6 +18,7 @@
     "client.d.ts",
     "assets-loader.js",
     "callstack-repack.podspec",
+    "src/modules/ScriptManager/NativeScriptManager.ts",
     "CHANGELOG.md"
   ],
   "homepage": "https://github.com/callstack/repack",


### PR DESCRIPTION
### Summary
we were not including any `src` files, yet `codegenConfig` points to src dir for specs

### Test plan
- [x] - used `archive` script to verify that the file gets included
