### PR TITLE
fix: make iOS native module compatible with `use_frameworks!`

### DIFF
--- a/.changeset/big-spiders-guess.md
+++ b/.changeset/big-spiders-guess.md
@@ -1,0 +1,5 @@
+---
+"@callstack/repack": patch
+---
+
+Fix: make `callstack-repack` pod compatible with use_frameworks!

--- a/packages/repack/callstack-repack.podspec
+++ b/packages/repack/callstack-repack.podspec
@@ -14,6 +14,7 @@ Pod::Spec.new do |s|
   s.platforms            = { :ios => "12.0" }
   s.source               = { :git => "https://github.com/callstack/repack.git", :tag => "#{s.version}" }
   s.source_files         = "ios/**/*.{h,m,mm,swift}"
+  s.static_framework     = true
 
   s.pod_target_xcconfig = { "DEFINES_MODULE" => "YES" }
 
@@ -30,11 +31,11 @@ Pod::Spec.new do |s|
     # Don't install the dependencies when we run `pod install` in the old architecture.
     if new_arch_enabled then
       s.compiler_flags = folly_compiler_flags + " -DRCT_NEW_ARCH_ENABLED=1"
-      s.pod_target_xcconfig = {
+      s.pod_target_xcconfig.update({
         "HEADER_SEARCH_PATHS" => "\"$(PODS_ROOT)/boost\"",
         "OTHER_CPLUSPLUSFLAGS" => "-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1",
         "CLANG_CXX_LANGUAGE_STANDARD" => "c++17"
-      }
+      })
       s.dependency "React-Codegen"
       s.dependency "RCT-Folly"
       s.dependency "RCTRequired"

--- a/packages/repack/callstack-repack.podspec
+++ b/packages/repack/callstack-repack.podspec
@@ -1,22 +1,22 @@
 require "json"
 
 package = JSON.parse(File.read(File.join(__dir__, "package.json")))
+folly_compiler_flags = '-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1 -Wno-comma -Wno-shorten-64-to-32'
+new_arch_enabled = ENV['RCT_NEW_ARCH_ENABLED'] == '1'
 
 Pod::Spec.new do |s|
-  s.name         = "callstack-repack"
-  s.version      = package["version"]
-  s.summary      = package["description"]
-  s.homepage     = package["homepage"]
-  s.license      = package["license"]
-  s.authors      = package["author"]
-
-  s.platforms    = { :ios => "12.0" }
-  s.source       = { :git => "https://github.com/callstack/repack.git", :tag => "#{s.version}" }
-
-  s.source_files = "ios/**/*.{h,m,mm,swift}"
+  s.name                 = "callstack-repack"
+  s.version              = package["version"]
+  s.summary              = package["description"]
+  s.homepage             = package["homepage"]
+  s.license              = package["license"]
+  s.authors              = package["author"]
+  s.platforms            = { :ios => "12.0" }
+  s.source               = { :git => "https://github.com/callstack/repack.git", :tag => "#{s.version}" }
+  s.source_files         = "ios/**/*.{h,m,mm,swift}"
 
   s.pod_target_xcconfig = { "DEFINES_MODULE" => "YES" }
-  
+
   s.dependency 'JWTDecode', '~> 3.0.0'
   s.dependency 'SwiftyRSA', '~> 1.7'
 
@@ -25,21 +25,21 @@ Pod::Spec.new do |s|
   if respond_to?(:install_modules_dependencies, true)
     install_modules_dependencies(s)
   else
-  s.dependency "React-Core"
+    s.dependency "React-Core"
 
-  # Don't install the dependencies when we run `pod install` in the old architecture.
-  if ENV['RCT_NEW_ARCH_ENABLED'] == '1' then
-    s.compiler_flags = folly_compiler_flags + " -DRCT_NEW_ARCH_ENABLED=1"
-    s.pod_target_xcconfig    = {
+    # Don't install the dependencies when we run `pod install` in the old architecture.
+    if new_arch_enabled then
+      s.compiler_flags = folly_compiler_flags + " -DRCT_NEW_ARCH_ENABLED=1"
+      s.pod_target_xcconfig = {
         "HEADER_SEARCH_PATHS" => "\"$(PODS_ROOT)/boost\"",
         "OTHER_CPLUSPLUSFLAGS" => "-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1",
         "CLANG_CXX_LANGUAGE_STANDARD" => "c++17"
-    }
-    s.dependency "React-Codegen"
-    s.dependency "RCT-Folly"
-    s.dependency "RCTRequired"
-    s.dependency "RCTTypeSafety"
-    s.dependency "ReactCommon/turbomodule/core"
-   end
-  end 
+      }
+      s.dependency "React-Codegen"
+      s.dependency "RCT-Folly"
+      s.dependency "RCTRequired"
+      s.dependency "RCTTypeSafety"
+      s.dependency "ReactCommon/turbomodule/core"
+    end
+  end
 end

--- a/packages/repack/ios/ScriptManager.mm
+++ b/packages/repack/ios/ScriptManager.mm
@@ -2,7 +2,11 @@
 #import "ScriptConfig.h"
 #import "ErrorCodes.h"
 
+#if __has_include(<callstack_repack/callstack_repack-Swift.h>)
+#import <callstack_repack/callstack_repack-Swift.h>
+#else
 #import "callstack_repack-Swift.h"
+#endif
 
 #import <React/RCTBridge.h>
 #import <React/RCTBundleURLProvider.h>


### PR DESCRIPTION
### Summary

copied what Expo does in their native modules, seems to do the trick when dealing with `use_frameworks!`, best we test it out in the field and potentially revert before stable release.

closes #498

### Test plan
- [x] - TesterApp new arch + `USE_FRAMEWORKS=static` (bridgeless disabled)
- [x] - TesterApp old arch + `USE_FRAMEWORKS=static`
- [x] - new RN 0.74 app new arch + `USE_FRAMEWORKS=static` (bridgeless disabled)
- [x] - new RN 0.74 app old arch + `USE_FRAMEWORKS=static`

