### PR TITLE
feat: use `localhost` as defined default hostname for the dev-server

### DIFF
--- a/.changeset/fair-experts-wave.md
+++ b/.changeset/fair-experts-wave.md
@@ -1,0 +1,5 @@
+---
+"@callstack/repack": minor
+---
+
+use `localhost` as a defined default for the dev-server

--- a/packages/repack/src/commands/start.ts
+++ b/packages/repack/src/commands/start.ts
@@ -5,7 +5,7 @@ import execa from 'execa';
 import { Config } from '@react-native-community/cli-types';
 import type { Server } from '@callstack/repack-dev-server';
 import { CliOptions, HMRMessageBody, StartArguments } from '../types';
-import { DEFAULT_PORT } from '../env';
+import { DEFAULT_HOSTNAME, DEFAULT_PORT } from '../env';
 import {
   composeReporters,
   ConsoleReporter,
@@ -67,7 +67,7 @@ export async function start(_: string[], config: Config, args: StartArguments) {
   const { start, stop } = await createServer({
     options: {
       rootDir: cliOptions.config.root,
-      host: args.host,
+      host: args.host || DEFAULT_HOSTNAME,
       port: args.port ?? DEFAULT_PORT,
       https: args.https
         ? {

--- a/packages/repack/src/env.ts
+++ b/packages/repack/src/env.ts
@@ -2,6 +2,9 @@ export const WORKER_ENV_KEY = 'REPACK_WORKER';
 
 export const VERBOSE_ENV_KEY = 'REPACK_VERBOSE';
 
+/** Default development server hostname. */
+export const DEFAULT_HOSTNAME = 'localhost';
+
 /** Default development server port. */
 export const DEFAULT_PORT = 8081;
 

--- a/packages/repack/src/env.ts
+++ b/packages/repack/src/env.ts
@@ -2,7 +2,10 @@ export const WORKER_ENV_KEY = 'REPACK_WORKER';
 
 export const VERBOSE_ENV_KEY = 'REPACK_VERBOSE';
 
-/** Default development server hostname. */
+/**
+ * Default development server hostname.
+ * Allows for listening for connections from all network interfaces.
+ */
 export const DEFAULT_HOSTNAME = 'localhost';
 
 /** Default development server port. */

--- a/packages/repack/src/types.ts
+++ b/packages/repack/src/types.ts
@@ -108,16 +108,22 @@ export interface CliOptions {
 export interface DevServerOptions {
   /**
    * Hostname or IP address under which to run the development server.
-   * When left unspecified, it will listen on all available network interfaces, similarly to listening on '0.0.0.0'.
+   *
+   * See: {@link DEFAULT_HOSTNAME}.
    */
   host?: string;
 
-  /** Port under which to run the development server. See: {@link DEFAULT_PORT}. */
+  /**
+   * Port under which to run the development server.
+   *
+   * See: {@link DEFAULT_PORT}.
+   */
   port: number;
 
-  /** HTTPS options.
+  /**
+   * HTTPS options.
    * If specified, the server will use HTTPS, otherwise HTTP.
-   */
+   * */
   https?: {
     /** Path to certificate when running server on HTTPS. */
     cert?: string;

--- a/packages/repack/src/types.ts
+++ b/packages/repack/src/types.ts
@@ -123,7 +123,7 @@ export interface DevServerOptions {
   /**
    * HTTPS options.
    * If specified, the server will use HTTPS, otherwise HTTP.
-   * */
+   */
   https?: {
     /** Path to certificate when running server on HTTPS. */
     cert?: string;

--- a/packages/repack/src/webpack/utils/__tests__/getWebpackEnvOptions.test.ts
+++ b/packages/repack/src/webpack/utils/__tests__/getWebpackEnvOptions.test.ts
@@ -79,6 +79,7 @@ describe('getWebpackEnvOptions', () => {
       devServer: {
         hmr: true,
         port: 8081,
+        host: 'localhost',
       },
       bundleFilename: '',
     });

--- a/packages/repack/src/webpack/utils/getWebpackEnvOptions.ts
+++ b/packages/repack/src/webpack/utils/getWebpackEnvOptions.ts
@@ -1,6 +1,6 @@
 import path from 'path';
 import type { CliOptions, WebpackEnvOptions } from '../../types';
-import { DEFAULT_PORT } from '../../env';
+import { DEFAULT_HOSTNAME, DEFAULT_PORT } from '../../env';
 
 export function getWebpackEnvOptions(
   cliOptions: CliOptions
@@ -30,7 +30,7 @@ export function getWebpackEnvOptions(
     env.platform = cliOptions.arguments.start.platform || undefined;
     env.devServer = {
       port: cliOptions.arguments.start.port ?? DEFAULT_PORT,
-      host: cliOptions.arguments.start.host,
+      host: cliOptions.arguments.start.host || DEFAULT_HOSTNAME,
       https: cliOptions.arguments.start.https
         ? {
             cert: cliOptions.arguments.start.cert,


### PR DESCRIPTION
### Summary

- RN CLI defaults to `''` as a default hostname.
- Fastify treats `''` as `localhost` but doesn't inform the user that it's listening on both interfaces at once.

Using a defined default allows for displaying both interfaces when starting the server:
```
ℹ [11:38:23.495Z][DevServer] Server listening at http://[::1]:8081
ℹ [11:38:23.499Z][DevServer] Server listening at http://127.0.0.1:8081
```

### Test plan
n/a

### Notes

cherry-picked from #508 