### PR TITLE
fix: keep track of last compilation stats by platform

### DIFF
--- a/.changeset/fluffy-insects-prove.md
+++ b/.changeset/fluffy-insects-prove.md
@@ -1,0 +1,5 @@
+---
+"@callstack/repack": patch
+---
+
+keep separate logs for compilation stats specific to each platform

--- a/packages/repack/src/commands/start.ts
+++ b/packages/repack/src/commands/start.ts
@@ -85,7 +85,7 @@ export async function start(_: string[], config: Config, args: StartArguments) {
         void runAdbReverse(ctx, args.port);
       }
 
-      let lastStats: webpack.StatsCompilation | undefined;
+      const lastStats: Record<string, webpack.StatsCompilation> = {};
 
       compiler.on('watchRun', ({ platform }) => {
         ctx.notifyBuildStart(platform);
@@ -109,7 +109,7 @@ export async function start(_: string[], config: Config, args: StartArguments) {
           stats: webpack.StatsCompilation;
         }) => {
           ctx.notifyBuildEnd(platform);
-          lastStats = stats;
+          lastStats[platform] = stats;
           ctx.broadcastToHmrClients(
             { action: 'built', body: createHmrBody(stats) },
             platform
@@ -154,7 +154,7 @@ export async function start(_: string[], config: Config, args: StartArguments) {
           getUriPath: () => '/__hmr',
           onClientConnected: (platform, clientId) => {
             ctx.broadcastToHmrClients(
-              { action: 'sync', body: createHmrBody(lastStats) },
+              { action: 'sync', body: createHmrBody(lastStats[platform]) },
               platform,
               [clientId]
             );


### PR DESCRIPTION
### Summary

Last compilation stats can origin from any platform, and when a new client connects, it will look for a last HMR update. Last stats will provide it with the name of the file, but it might be from another platform, and it will cause the file to not be found. This in turn will cause a full app reload, which would restart this flow, and cause and infinite loop. This PR addresses this problem by using separate slots for last stats for each platform.

This unblocks #567 

### Test plan

- [x] - tested locally on a setup of 3 iOS sims & 2 android emulators
