### PR TITLE
fix: crash when using node 22 for bundling in development

### DIFF
--- a/.changeset/plenty-kangaroos-whisper.md
+++ b/.changeset/plenty-kangaroos-whisper.md
@@ -1,0 +1,5 @@
+---
+"@callstack/repack": patch
+---
+
+fix crash when using Node 22 for bundling in development

--- a/packages/repack/src/webpack/webpackWorker.ts
+++ b/packages/repack/src/webpack/webpackWorker.ts
@@ -53,23 +53,20 @@ async function main(cliOptions: CliOptions) {
         info: asset.info,
       };
     });
-    parentPort?.postMessage(
-      {
-        event: 'done',
-        assets,
-        stats: stats.toJson({
-          all: false,
-          cached: true,
-          children: true,
-          modules: true,
-          timings: true,
-          hash: true,
-          errors: true,
-          warnings: false,
-        }),
-      },
-      assets.map((asset) => asset.data.buffer)
-    );
+    parentPort?.postMessage({
+      event: 'done',
+      assets,
+      stats: stats.toJson({
+        all: false,
+        cached: true,
+        children: true,
+        modules: true,
+        timings: true,
+        hash: true,
+        errors: true,
+        warnings: false,
+      }),
+    });
   });
 
   compiler.watch(watchOptions, (error) => {


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

Removed unnecessary assets from transferList when using `MessagePort` inside of `webpackWorker`. In previous versions this wasn't considered an error, since Node 21 it is (see related PR below).

Related PR: https://github.com/nodejs/node/pull/47604 

Closes #595 

### Test plan

- [x] - tests pass (node 18 & node 20)
- [x] - locally tested on node 22
