### PR TITLE
chore: update templates

### DIFF
--- a/.changeset/fluffy-moons-tie.md
+++ b/.changeset/fluffy-moons-tie.md
@@ -1,0 +1,5 @@
+---
+"@callstack/repack": patch
+---
+
+Update templates to include `.cjs` and `.mjs` extensions

--- a/packages/TesterApp/webpack.config.mjs
+++ b/packages/TesterApp/webpack.config.mjs
@@ -147,9 +147,8 @@ export default (env) => {
        */
       rules: [
         {
-          test: /\.[jt]sx?$/,
+          test: /\.[cm]?[jt]sx?$/,
           include: [
-            /node_modules(.*[/\\])+react\//,
             /node_modules(.*[/\\])+react-native/,
             /node_modules(.*[/\\])+@react-native/,
             /node_modules(.*[/\\])+@react-navigation/,

--- a/templates/webpack.config.cjs
+++ b/templates/webpack.config.cjs
@@ -146,7 +146,7 @@ module.exports = (env) => {
        */
       rules: [
         {
-          test: /\.[jt]sx?$/,
+          test: /\.[cm]?[jt]sx?$/,
           include: [
             /node_modules(.*[/\\])+react\//,
             /node_modules(.*[/\\])+react-native/,

--- a/templates/webpack.config.cjs
+++ b/templates/webpack.config.cjs
@@ -148,7 +148,6 @@ module.exports = (env) => {
         {
           test: /\.[cm]?[jt]sx?$/,
           include: [
-            /node_modules(.*[/\\])+react\//,
             /node_modules(.*[/\\])+react-native/,
             /node_modules(.*[/\\])+@react-native/,
             /node_modules(.*[/\\])+@react-navigation/,

--- a/templates/webpack.config.mjs
+++ b/templates/webpack.config.mjs
@@ -152,7 +152,6 @@ export default (env) => {
         {
           test: /\.[cm]?[jt]sx?$/,
           include: [
-            /node_modules(.*[/\\])+react\//,
             /node_modules(.*[/\\])+react-native/,
             /node_modules(.*[/\\])+@react-native/,
             /node_modules(.*[/\\])+@react-navigation/,

--- a/templates/webpack.config.mjs
+++ b/templates/webpack.config.mjs
@@ -150,7 +150,7 @@ export default (env) => {
        */
       rules: [
         {
-          test: /\.[jt]sx?$/,
+          test: /\.[cm]?[jt]sx?$/,
           include: [
             /node_modules(.*[/\\])+react\//,
             /node_modules(.*[/\\])+react-native/,


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

- [x] - expand the regex for transpiling node_modules, to include extensions like `.cjs[x]` and `.mjs[x]` (and also `ts` equivalents, although these are quite exotic and probably non existent in the ecosystem)
- [x] - removed `react` from transpiled dependencies - it was never needed in the first place, and the regex was not correct for the Windows platform

### Test plan

- [x] - TesterApp bundles and runs correctly after the changes
<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
