### PR TITLE
fix: hermes plugin node version

### DIFF
--- a/.changeset/silent-tigers-kiss.md
+++ b/.changeset/silent-tigers-kiss.md
@@ -1,0 +1,5 @@
+---
+"@callstack/repack": patch
+---
+
+Use the current Node when composing Hermes sourcemaps

--- a/packages/repack/src/webpack/plugins/ChunksToHermesBytecodePlugin/utils/composeSourceMaps.ts
+++ b/packages/repack/src/webpack/plugins/ChunksToHermesBytecodePlugin/utils/composeSourceMaps.ts
@@ -34,7 +34,7 @@ export const composeSourceMaps = async ({
 
   try {
     await execa.node(
-      path.join(reactNativePath, 'scripts/compose-source-maps.js'),
+      path.join(reactNativePath, 'scripts', 'compose-source-maps.js'),
       [packagerMapPath, compilerMapPath, '-o', composedSourceMapPath]
     );
 

--- a/packages/repack/src/webpack/plugins/ChunksToHermesBytecodePlugin/utils/composeSourceMaps.ts
+++ b/packages/repack/src/webpack/plugins/ChunksToHermesBytecodePlugin/utils/composeSourceMaps.ts
@@ -1,4 +1,4 @@
-import path from 'path';
+import path from 'node:path';
 import fs from 'fs-extra';
 import execa from 'execa';
 
@@ -33,13 +33,10 @@ export const composeSourceMaps = async ({
   const composedSourceMapPath = packagerMapPath + '.composed';
 
   try {
-    await execa('node', [
+    await execa.node(
       path.join(reactNativePath, 'scripts/compose-source-maps.js'),
-      packagerMapPath,
-      compilerMapPath,
-      '-o',
-      composedSourceMapPath,
-    ]);
+      [packagerMapPath, compilerMapPath, '-o', composedSourceMapPath]
+    );
 
     // Remove intermediate files
     await fs.unlink(packagerMapPath);

--- a/packages/repack/src/webpack/plugins/__tests__/ChunksToHermesBytecodePlugin.test.ts
+++ b/packages/repack/src/webpack/plugins/__tests__/ChunksToHermesBytecodePlugin.test.ts
@@ -84,15 +84,19 @@ describe('ChunksToHermesBytecodePlugin', () => {
         );
         pluginInstance.apply(compilerMock as unknown as webpack.Compiler);
       });
-
       const execaMock = execa as jest.MockedFunction<typeof execa>;
+      const execaNodeMock = execa.node as jest.MockedFunction<
+        typeof execa.node
+      >;
 
       expect(compilerMock.hooks.assetEmitted.tapPromise).toHaveBeenCalledTimes(
         1
       );
-      expect(execaMock).toHaveBeenCalledTimes(2);
+      expect(execaMock).toHaveBeenCalledTimes(1);
       expect(execaMock.mock.calls[0][0]).toEqual('path/to/hermesc');
-      expect(execaMock.mock.calls[1][1]?.[0]).toEqual(
+
+      expect(execaNodeMock).toHaveBeenCalledTimes(1);
+      expect(execaNodeMock.mock.calls[0][0]).toEqual(
         'path/to/react-native/scripts/compose-source-maps.js'
       );
     });


### PR DESCRIPTION
### Summary

use `execa.node` to reuse the node version from env instead of calling `node` - this mitigates the issue where sometimes node can't be found when building through Xcode

### Test plan

- [x] - iOS builds
- [x] - Android builds 
