### PR TITLE
fix(TesterApp): don't load DevSettings native module in release builds

### DIFF
--- a/packages/TesterApp/src/deprecatedRemoteDebugger/DeprecatedRemoteDebuggerContainer.tsx
+++ b/packages/TesterApp/src/deprecatedRemoteDebugger/DeprecatedRemoteDebuggerContainer.tsx
@@ -1,13 +1,30 @@
-import { Button } from '../ui/Button'
-// @ts-ignore
-import NativeDevSettings from 'react-native/Libraries/NativeModules/specs/NativeDevSettings';
+import React from 'react';
+import { Button } from '../ui/Button';
 
+let enableRemoteDebugger = () => {};
+let disableRemoteDebugger = () => {};
 
-export default function DeprecatedRemoteDebuggerContainer () {
+if (__DEV__) {
+  const {
+    default: NativeDevSettings,
+  } = require('react-native/Libraries/NativeModules/specs/NativeDevSettings');
+  enableRemoteDebugger = () => NativeDevSettings.setIsDebuggingRemotely(true);
+  disableRemoteDebugger = () => NativeDevSettings.setIsDebuggingRemotely(false);
+}
+
+export default function DeprecatedRemoteDebuggerContainer() {
   return (
     <>
-      <Button title={'Open remote debugger'} onPress={() => NativeDevSettings.setIsDebuggingRemotely(true)} />
-      <Button title={'Close remote debugger'} onPress={() => NativeDevSettings.setIsDebuggingRemotely(false)} />
+      <Button
+        disabled={!__DEV__}
+        title={'Open remote debugger'}
+        onPress={enableRemoteDebugger}
+      />
+      <Button
+        disabled={!__DEV__}
+        title={'Close remote debugger'}
+        onPress={disableRemoteDebugger}
+      />
     </>
-  )
+  );
 }


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

conditionally require `NativeDevSettings` module for Remote Debugger so that it doesn't crash when running a prod build.

### Test plan

n/a
