### PR TITLE
chore: add snapshot config for changesets

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://unpkg.com/@changesets/config@2.0.0/schema.json",
+  "$schema": "https://unpkg.com/@changesets/config@3.0.0/schema.json",
   "changelog": ["@changesets/changelog-github", { "repo": "callstack/repack" }],
   "commit": false,
   "fixed": [
@@ -13,5 +13,8 @@
   "access": "restricted",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
-  "ignore": ["metro-compat-test", "testerapp", "website"]
+  "ignore": ["metro-compat-test", "testerapp", "website"],
+  "snapshot": {
+    "useCalculatedVersion": true
+  }
 }


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

we need to `useCalculatedVersion` when doing snapshot releases because Cocoapods can't cope with version set to `0.0.0`

### Test plan

n/a
