### PR TITLE
fix: native build config for Android

### DIFF
--- a/.changeset/proud-shrimps-share.md
+++ b/.changeset/proud-shrimps-share.md
@@ -1,0 +1,5 @@
+---
+"@callstack/repack": patch
+---
+
+Fix android native module configuration

--- a/packages/repack/android/CMakeLists.txt
+++ b/packages/repack/android/CMakeLists.txt
@@ -10,7 +10,8 @@ set(CMAKE_CXX_STANDARD 17)
 add_library(
         ${PACKAGE_NAME}
         SHARED
-        src/main/cpp
+        src/main/cpp/OnLoad.cpp
+        src/main/cpp/NativeScriptLoader.cpp
 )
 
 # Configure C++ 17
@@ -29,6 +30,7 @@ find_package(ReactAndroid REQUIRED CONFIG)
 target_include_directories(
         ${PACKAGE_NAME}
         PRIVATE
+        "src/main/cpp"
         "${REACT_NATIVE_DIR}/ReactCommon"
         "${REACT_NATIVE_DIR}/ReactCommon/callinvoker"
         "${REACT_NATIVE_DIR}/ReactAndroid/src/main/jni/react/turbomodule"

--- a/packages/repack/android/build.gradle
+++ b/packages/repack/android/build.gradle
@@ -84,7 +84,6 @@ android {
     }
 
     compileSdkVersion getExtOrIntegerDefault('compileSdkVersion')
-    buildToolsVersion getExtOrDefault('buildToolsVersion')
 
     if (rootProject.hasProperty("ndkPath")) {
         ndkPath rootProject.ext.ndkPath

--- a/packages/repack/android/gradle.properties
+++ b/packages/repack/android/gradle.properties
@@ -1,5 +1,4 @@
 RePack_kotlinVersion=1.7.0
 RePack_compileSdkVersion=29
-RePack_buildToolsVersion=29.0.2
 RePack_targetSdkVersion=29
 RePack_minSdkVersion=21


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

- [x] fixed CMake config
- [x] removed buildTools version from config - was causing a warning and other libs don't use this field anymore

### Test plan

- [x] - TesterApp android builds
