### PR TITLE
fix: use appId for launching android TesterApp

### DIFF
--- a/packages/TesterApp/package.json
+++ b/packages/TesterApp/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.7",
   "private": true,
   "scripts": {
-    "android": "react-native run-android",
+    "android": "react-native run-android --appId com.testerapp",
     "android:release": "node ./scripts/release.js android",
     "ios": "react-native run-ios",
     "ios:release": "node ./scripts/release.js ios",


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

the fix for this is present in the CLI but our RN version is using older version of CLI.

### Test plan

n/a
