### PR TITLE
fix: prevent infinite recursion when looking for initial chunks

### DIFF
--- a/packages/repack/src/webpack/plugins/OutputPlugin.ts
+++ b/packages/repack/src/webpack/plugins/OutputPlugin.ts
@@ -229,7 +229,15 @@ export class OutputPlugin implements WebpackPlugin {
       chunk: webpack.StatsChunk,
       chunks: Map<string | number, webpack.StatsChunk>
     ): Array<webpack.StatsChunk> => {
-      if (!chunk.parents?.length) return [chunk];
+      if (!chunk.parents?.length) {
+        return [chunk];
+      }
+
+      // Chunk might reference itself as a parent and/or child
+      if (chunk.parents.length === 1 && chunk.parents[0] === chunk.id) {
+        return [chunk];
+      }
+
       return chunk.parents.flatMap((parent) => {
         return getAllInitialChunks(chunks.get(parent)!, chunks);
       });


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

Fix infinite recursion bug in `OutputPlugin` which might happen when chunk references itself as parent and/or child. 

### Remarks

Reproduced in TesterApp by limiting the chunk count:
```js
new webpack.optimize.LimitChunkCountPlugin({
        maxChunks: 1,
}),
```

### Test plan

TBD, ideally a config case test
