### PR TITLE
fix: correctly parse platform from file URL

### DIFF
--- a/.changeset/fuzzy-lions-think.md
+++ b/.changeset/fuzzy-lions-think.md
@@ -1,0 +1,5 @@
+---
+"@callstack/repack": patch
+---
+
+fix: correctly parse platform from file URL

--- a/packages/repack/src/commands/start.ts
+++ b/packages/repack/src/commands/start.ts
@@ -255,8 +255,20 @@ async function runAdbReverse(ctx: Server.DelegateContext, port: number) {
 }
 
 function parseFileUrl(fileUrl: string) {
-  const { pathname: filename, searchParams } = new URL(fileUrl);
+  const { pathname, searchParams } = new URL(fileUrl);
   let platform = searchParams.get('platform');
+  let filename = pathname;
+
+  if (!platform) {
+    const pathArray = pathname.split('/');
+    const platformFromPath = pathArray[1];
+
+    if (platformFromPath === 'ios' || platformFromPath === 'android') {
+      platform = platformFromPath;
+      filename = pathArray.slice(2).join('/');
+    }
+  }
+
   if (!platform) {
     const [, platformOrName, name] = filename.split('.').reverse();
     if (name !== undefined) {


### PR DESCRIPTION
### Summary
https://github.com/callstack/repack/issues/644

Some cases like "http://localhost:8081/ios/src_app2_tsx-node_modules_react-native-reanimated_src_reanimated2_sync_recursive.chunk.bundle" can't parse the platform and filename correctly.

### Test plan






