### PR TITLE
Fixing issue where entry chunk is not added to local chunks if another chunk is processed first.

### DIFF
--- a/packages/repack/src/webpack/plugins/OutputPlugin.ts
+++ b/packages/repack/src/webpack/plugins/OutputPlugin.ts
@@ -263,6 +263,7 @@ export class OutputPlugin implements WebpackPlugin {
       const entryChunk = compilationStats.chunks!.find((chunk) => {
         return chunk.initial && chunk.names?.includes(entryChunkName);
       });
+      localChunks.push(entryChunk!);
 
       for (const chunk of compilationStats.chunks!) {
         // Do not process shared chunks right now.
@@ -276,12 +277,9 @@ export class OutputPlugin implements WebpackPlugin {
             sharedChunks.add(sharedChunk);
           });
 
-        // Entry chunk
-        if (entryChunk === chunk) {
+        if (isLocalChunk(chunk.name ?? chunk.id?.toString())) {
           localChunks.push(chunk);
-        } else if (isLocalChunk(chunk.name ?? chunk.id?.toString())) {
-          localChunks.push(chunk);
-        } else {
+        } else if (entryChunk !== chunk) {
           remoteChunks.push(chunk);
         }
       }


### PR DESCRIPTION
### Summary

After upgrading to repack 4, I noticed that after webpack generated and built my app, despite webpack completing successfully android builds were no longer copying the main javascript bundle to `android/app/build/generated/assets/`. I believe this is the same symptom as #654. 

After digging into the code, it turns out that when the OutputPlugin was processing chunks, on android it would just so happen to process one of my remote chunks first that had a dependency on the entry chunk. Since that dependency existed, the entryChunk would get added to `sharedChunks` before it had a chance to be added to `localChunks`, preventing it from being copied to the output folder properly.

### Test plan

- [ ] Have an app with remote chunks that reference the main entry chunk.
- [ ] Run `webpack-bundle` on android to build an android release build.
- [ ] Ensure the destination android folder (`android/app/build/generated/assets/` in my case) contains the main javascript bundle.
- [ ] (Verify other configurations continue to work)
