### PR TITLE
fix: bundle caching after invalidating scripts

### DIFF
--- a/.changeset/blue-dolls-know.md
+++ b/.changeset/blue-dolls-know.md
@@ -1,0 +1,5 @@
+---
+"@callstack/repack": minor
+---
+
+fix bundle caching after invalidating scripts

--- a/apps/tester-federation/app.json
+++ b/apps/tester-federation/app.json
@@ -23,5 +23,9 @@
   },
   "ios": {
     "bundleIdentifier": "com.tester.federation"
+  },
+  "resources": {
+    "android": [],
+    "ios": []
   }
 }

--- a/apps/tester-federation/index.js
+++ b/apps/tester-federation/index.js
@@ -1,8 +1,11 @@
 import { AppRegistry, Platform } from 'react-native';
 import { ScriptManager, Federated } from '@callstack/repack/client';
+import AsyncStorage from '@react-native-async-storage/async-storage';
 
 import App from './src/host/App';
 import { components } from './app.json';
+
+ScriptManager.shared.setStorage(AsyncStorage);
 
 const resolveURL = Federated.createURLResolver({
   containers: { MiniApp: 'http://localhost:8082/[name][ext]' },
@@ -12,6 +15,7 @@ ScriptManager.shared.addResolver(async (scriptId, caller) => {
   return {
     url: resolveURL(scriptId, caller),
     query: { platform: Platform.OS },
+    cache: process.env.MF_CACHE,
   };
 });
 

--- a/apps/tester-federation/ios/Podfile.lock
+++ b/apps/tester-federation/ios/Podfile.lock
@@ -1280,6 +1280,27 @@ PODS:
   - ReactTestApp-DevSupport (3.8.9):
     - React-Core
     - React-jsi
+  - RNCAsyncStorage (1.23.1):
+    - DoubleConversion
+    - glog
+    - hermes-engine
+    - RCT-Folly (= 2024.01.01.00)
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Codegen
+    - React-Core
+    - React-debug
+    - React-Fabric
+    - React-featureflags
+    - React-graphics
+    - React-ImageManager
+    - React-NativeModulesApple
+    - React-RCTFabric
+    - React-rendererdebug
+    - React-utils
+    - ReactCommon/turbomodule/bridging
+    - ReactCommon/turbomodule/core
+    - Yoga
   - RNScreens (3.32.0):
     - DoubleConversion
     - glog
@@ -1391,6 +1412,7 @@ DEPENDENCIES:
   - ReactCommon/turbomodule/core (from `../node_modules/react-native/ReactCommon`)
   - "ReactNativeHost (from `../../../node_modules/.pnpm/react-native-test-app@3.8.9_react-native@0.74.3_@babel+core@7.24.0_@babel+preset-env@7.24.0_@_mf2ppxx6gl3lpvmnun7q4fqj7u/node_modules/@rnx-kit/react-native-host`)"
   - ReactTestApp-DevSupport (from `../node_modules/react-native-test-app`)
+  - "RNCAsyncStorage (from `../node_modules/@react-native-async-storage/async-storage`)"
   - RNScreens (from `../node_modules/react-native-screens`)
   - Yoga (from `../node_modules/react-native/ReactCommon/yoga`)
 
@@ -1516,6 +1538,8 @@ EXTERNAL SOURCES:
     :path: "../../../node_modules/.pnpm/react-native-test-app@3.8.9_react-native@0.74.3_@babel+core@7.24.0_@babel+preset-env@7.24.0_@_mf2ppxx6gl3lpvmnun7q4fqj7u/node_modules/@rnx-kit/react-native-host"
   ReactTestApp-DevSupport:
     :path: "../node_modules/react-native-test-app"
+  RNCAsyncStorage:
+    :path: "../node_modules/@react-native-async-storage/async-storage"
   RNScreens:
     :path: "../node_modules/react-native-screens"
   Yoga:
@@ -1580,6 +1604,7 @@ SPEC CHECKSUMS:
   ReactCommon: f00e436b3925a7ae44dfa294b43ef360fbd8ccc4
   ReactNativeHost: 35df5fb9d51dc99eaec21e993642f1232ec8b380
   ReactTestApp-DevSupport: 874fb27318647f43f4243c5f3a47a246db9cec12
+  RNCAsyncStorage: f2add1326156dc313df59d855c11f459059e4ffd
   RNScreens: d3d50aa84db4541eee00fbb1f32151030f56c510
   SocketRocket: abac6f5de4d4d62d24e11868d7a2f427e0ef940d
   SwiftyRSA: 8c6dd1ea7db1b8dc4fb517a202f88bb1354bc2c6

--- a/apps/tester-federation/package.json
+++ b/apps/tester-federation/package.json
@@ -9,13 +9,14 @@
     "start:miniapp": "react-native webpack-start --webpackConfig webpack.config.mini-app.mjs --port 8082"
   },
   "dependencies": {
-    "react": "18.2.0",
-    "react-native": "0.74.3",
+    "@callstack/repack": "workspace:*",
+    "@react-native-async-storage/async-storage": "^1.23.1",
     "@react-navigation/native": "^6.1.18",
     "@react-navigation/native-stack": "^6.10.1",
+    "react": "18.2.0",
+    "react-native": "0.74.3",
     "react-native-safe-area-context": "^4.10.8",
-    "react-native-screens": "^3.32.0",
-    "@callstack/repack": "workspace:*"
+    "react-native-screens": "^3.32.0"
   },
   "devDependencies": {
     "@babel/core": "^7.23.9",
@@ -30,8 +31,8 @@
     "get-port": "^6.1.2",
     "globby": "^13.1.2",
     "http-server": "^14.1.1",
-    "react-native-test-app": "^3.8.9",
     "prettier": "^3.2.4",
+    "react-native-test-app": "^3.8.9",
     "terser-webpack-plugin": "^5.3.3",
     "typescript": "^5.5.3",
     "webpack": "^5.91.0"

--- a/apps/tester-federation/webpack.config.host-app.mjs
+++ b/apps/tester-federation/webpack.config.host-app.mjs
@@ -1,5 +1,6 @@
 import { createRequire } from 'node:module';
 import path from 'node:path';
+import webpack from 'webpack';
 import * as Repack from '@callstack/repack';
 
 const dirname = Repack.getDirname(import.meta.url);
@@ -142,6 +143,7 @@ export default (env) => {
           },
         },
       }),
+      new webpack.EnvironmentPlugin({ MF_CACHE: false }),
     ],
   };
 };

--- a/packages/repack/android/src/main/java/com/callstack/repack/RemoteScriptLoader.kt
+++ b/packages/repack/android/src/main/java/com/callstack/repack/RemoteScriptLoader.kt
@@ -95,10 +95,19 @@ class RemoteScriptLoader(reactContext: ReactContext) : NativeScriptLoader(reactC
     }
 
     fun execute(config: ScriptConfig, promise: Promise) {
+        val scriptPath = getScriptFilePath(config.id)
         try {
-            val path = File(reactContext.filesDir, getScriptFilePath(config.id))
-            val code: ByteArray = FileInputStream(path).use { it.readBytes() }
-            evaluate(code, path.toString(), promise)
+            val file = File(reactContext.filesDir, scriptPath)
+            if (!file.exists()) {
+                throw Exception("Script file does not exist: $file")
+            }
+            
+            val code = FileInputStream(file).use { it.readBytes() }
+            if (code.isEmpty()) {
+                throw Exception("Script file exists but could not be read: $file")
+            }
+
+            evaluate(code, scriptPath, promise)
         } catch (error: Exception) {
             promise.reject(
                     ScriptLoadingError.ScriptEvalFailure.code,

--- a/packages/repack/ios/ScriptManager.mm
+++ b/packages/repack/ios/ScriptManager.mm
@@ -149,14 +149,14 @@ RCT_EXPORT_METHOD(invalidateScripts
   @try {
     NSFileManager *manager = [NSFileManager defaultManager];
     if (![[NSFileManager defaultManager] fileExistsAtPath:scriptPath]) {
-        NSString *errorMessage = [NSString stringWithFormat:@"Script file does not exist at path: %@", scriptPath];
-        @throw [NSError errorWithDomain:errorMessage code:0 userInfo:nil];
+      NSString *errorMessage = [NSString stringWithFormat:@"Script file does not exist at path: %@", scriptPath];
+      @throw [NSError errorWithDomain:errorMessage code:0 userInfo:nil];
     }
 
     NSData *data = [manager contentsAtPath:scriptPath];
     if (!data) {
-        NSString *errorMessage = [NSString stringWithFormat:@"Script file exists but could not be read: %@", scriptPath];
-        @throw [NSError errorWithDomain:errorMessage code:0 userInfo:nil];
+      NSString *errorMessage = [NSString stringWithFormat:@"Script file exists but could not be read: %@", scriptPath];
+      @throw [NSError errorWithDomain:errorMessage code:0 userInfo:nil];
     }
 
     [self evaluateJavascript:data url:url resolve:resolve reject:reject];

--- a/packages/repack/ios/ScriptManager.mm
+++ b/packages/repack/ios/ScriptManager.mm
@@ -149,17 +149,19 @@ RCT_EXPORT_METHOD(invalidateScripts
   @try {
     NSFileManager *manager = [NSFileManager defaultManager];
     if (![[NSFileManager defaultManager] fileExistsAtPath:scriptPath]) {
-        @throw [NSError errorWithDomain:@"Script file does not exist" code:0 userInfo:nil];
+        NSString *errorMessage = [NSString stringWithFormat:@"Script file does not exist at path: %@", scriptPath];
+        @throw [NSError errorWithDomain:errorMessage code:0 userInfo:nil];
     }
 
     NSData *data = [manager contentsAtPath:scriptPath];
     if (!data) {
-        @throw [NSError errorWithDomain:@"Script file exists but could not be read" code:0 userInfo:nil];
+        NSString *errorMessage = [NSString stringWithFormat:@"Script file exists but could not be read: %@", scriptPath];
+        @throw [NSError errorWithDomain:errorMessage code:0 userInfo:nil];
     }
 
     [self evaluateJavascript:data url:url resolve:resolve reject:reject];
   } @catch (NSError *error) {
-    reject(CodeExecutionFailure, error.localizedDescription, nil);
+    reject(CodeExecutionFailure, error.domain, nil);
   }
 }
 

--- a/packages/repack/ios/ScriptManager.mm
+++ b/packages/repack/ios/ScriptManager.mm
@@ -148,7 +148,15 @@ RCT_EXPORT_METHOD(invalidateScripts
   NSString *scriptPath = [self getScriptFilePath:scriptId];
   @try {
     NSFileManager *manager = [NSFileManager defaultManager];
+    if (![[NSFileManager defaultManager] fileExistsAtPath:scriptPath]) {
+        @throw [NSError errorWithDomain:@"Script file does not exist" code:0 userInfo:nil];
+    }
+
     NSData *data = [manager contentsAtPath:scriptPath];
+    if (!data) {
+        @throw [NSError errorWithDomain:@"Script file exists but could not be read" code:0 userInfo:nil];
+    }
+
     [self evaluateJavascript:data url:url resolve:resolve reject:reject];
   } @catch (NSError *error) {
     reject(CodeExecutionFailure, error.localizedDescription, nil);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -171,6 +171,9 @@ importers:
       '@callstack/repack':
         specifier: workspace:*
         version: link:../../packages/repack
+      '@react-native-async-storage/async-storage':
+        specifier: ^1.23.1
+        version: 1.23.1(react-native@0.74.3(@babel/core@7.24.0)(@babel/preset-env@7.24.0(@babel/core@7.24.0))(@types/react@18.2.74)(react@18.2.0))
       '@react-navigation/native':
         specifier: ^6.1.18
         version: 6.1.18(react-native@0.74.3(@babel/core@7.24.0)(@babel/preset-env@7.24.0(@babel/core@7.24.0))(@types/react@18.2.74)(react@18.2.0))(react@18.2.0)
@@ -549,13 +552,13 @@ importers:
         version: 1.0.0(@rsbuild/core@0.7.8)
       rspress:
         specifier: 1.25.2
-        version: 1.25.2(webpack@5.91.0)
+        version: 1.25.2(@swc/helpers@0.5.3)(webpack@5.91.0)
       rspress-plugin-font-open-sans:
         specifier: ^1.0.0
         version: 1.0.0
       rspress-plugin-vercel-analytics:
         specifier: ^0.3.0
-        version: 0.3.0(react@18.2.0)(rspress@1.25.2(webpack@5.91.0))
+        version: 0.3.0(react@18.2.0)(rspress@1.25.2(@swc/helpers@0.5.3)(webpack@5.91.0))
     devDependencies:
       '@types/node':
         specifier: ^18
@@ -9632,17 +9635,17 @@ snapshots:
       '@rspack/core': 0.7.3(@swc/helpers@0.5.3)
       '@swc/helpers': 0.5.3
       core-js: 3.36.1
-      html-webpack-plugin: html-rspack-plugin@5.7.2(@rspack/core@0.7.3)
+      html-webpack-plugin: html-rspack-plugin@5.7.2(@rspack/core@0.7.3(@swc/helpers@0.5.3))
       postcss: 8.4.39
 
-  '@rsbuild/plugin-less@0.7.8(@rsbuild/core@0.7.8)':
+  '@rsbuild/plugin-less@0.7.8(@rsbuild/core@0.7.8)(@swc/helpers@0.5.3)':
     dependencies:
       '@rsbuild/core': 0.7.8
       '@rsbuild/shared': 0.7.8(@swc/helpers@0.5.3)
     transitivePeerDependencies:
       - '@swc/helpers'
 
-  '@rsbuild/plugin-react@0.7.8(@rsbuild/core@0.7.8)':
+  '@rsbuild/plugin-react@0.7.8(@rsbuild/core@0.7.8)(@swc/helpers@0.5.3)':
     dependencies:
       '@rsbuild/core': 0.7.8
       '@rsbuild/shared': 0.7.8(@swc/helpers@0.5.3)
@@ -9651,7 +9654,7 @@ snapshots:
     transitivePeerDependencies:
       - '@swc/helpers'
 
-  '@rsbuild/plugin-sass@0.7.8(@rsbuild/core@0.7.8)':
+  '@rsbuild/plugin-sass@0.7.8(@rsbuild/core@0.7.8)(@swc/helpers@0.5.3)':
     dependencies:
       '@rsbuild/core': 0.7.8
       '@rsbuild/shared': 0.7.8(@swc/helpers@0.5.3)
@@ -9665,7 +9668,7 @@ snapshots:
     dependencies:
       '@rspack/core': 0.7.3(@swc/helpers@0.5.3)
       caniuse-lite: 1.0.30001640
-      html-webpack-plugin: html-rspack-plugin@5.7.2(@rspack/core@0.7.3)
+      html-webpack-plugin: html-rspack-plugin@5.7.2(@rspack/core@0.7.3(@swc/helpers@0.5.3))
       postcss: 8.4.39
     optionalDependencies:
       fsevents: 2.3.3
@@ -9725,7 +9728,7 @@ snapshots:
     optionalDependencies:
       react-refresh: 0.14.2
 
-  '@rspress/core@1.25.2(webpack@5.91.0)':
+  '@rspress/core@1.25.2(@swc/helpers@0.5.3)(webpack@5.91.0)':
     dependencies:
       '@loadable/component': 5.16.4(react@18.2.0)
       '@mdx-js/loader': 2.3.0(webpack@5.91.0)
@@ -9733,9 +9736,9 @@ snapshots:
       '@mdx-js/react': 2.3.0(react@18.2.0)
       '@modern-js/utils': 2.54.5
       '@rsbuild/core': 0.7.8
-      '@rsbuild/plugin-less': 0.7.8(@rsbuild/core@0.7.8)
-      '@rsbuild/plugin-react': 0.7.8(@rsbuild/core@0.7.8)
-      '@rsbuild/plugin-sass': 0.7.8(@rsbuild/core@0.7.8)
+      '@rsbuild/plugin-less': 0.7.8(@rsbuild/core@0.7.8)(@swc/helpers@0.5.3)
+      '@rsbuild/plugin-react': 0.7.8(@rsbuild/core@0.7.8)(@swc/helpers@0.5.3)
+      '@rsbuild/plugin-sass': 0.7.8(@rsbuild/core@0.7.8)(@swc/helpers@0.5.3)
       '@rspress/mdx-rs': 0.5.7
       '@rspress/plugin-auto-nav-sidebar': 1.25.2
       '@rspress/plugin-container-syntax': 1.25.2
@@ -12363,7 +12366,7 @@ snapshots:
 
   html-escaper@2.0.2: {}
 
-  html-rspack-plugin@5.7.2(@rspack/core@0.7.3):
+  html-rspack-plugin@5.7.2(@rspack/core@0.7.3(@swc/helpers@0.5.3)):
     optionalDependencies:
       '@rspack/core': 0.7.3(@swc/helpers@0.5.3)
 
@@ -15106,7 +15109,7 @@ snapshots:
     dependencies:
       fs-extra: 11.2.0
 
-  rspress-plugin-devkit@0.3.0(rspress@1.25.2(webpack@5.91.0)):
+  rspress-plugin-devkit@0.3.0(rspress@1.25.2(@swc/helpers@0.5.3)(webpack@5.91.0)):
     dependencies:
       '@rspress/shared': 1.25.2
       '@types/estree-jsx': 1.0.5
@@ -15121,7 +15124,7 @@ snapshots:
       mdast-util-to-markdown: 1.5.0
       mdast-util-to-string: 4.0.0
       remark-mdc: 1.2.0
-      rspress: 1.25.2(webpack@5.91.0)
+      rspress: 1.25.2(@swc/helpers@0.5.3)(webpack@5.91.0)
       ts-morph: 22.0.0
       unified: 10.1.2
       unist-util-visit: 5.0.0
@@ -15134,21 +15137,21 @@ snapshots:
 
   rspress-plugin-font-open-sans@1.0.0: {}
 
-  rspress-plugin-vercel-analytics@0.3.0(react@18.2.0)(rspress@1.25.2(webpack@5.91.0)):
+  rspress-plugin-vercel-analytics@0.3.0(react@18.2.0)(rspress@1.25.2(@swc/helpers@0.5.3)(webpack@5.91.0)):
     dependencies:
       '@rspress/shared': 1.25.2
       '@vercel/analytics': 1.2.2(react@18.2.0)
-      rspress: 1.25.2(webpack@5.91.0)
-      rspress-plugin-devkit: 0.3.0(rspress@1.25.2(webpack@5.91.0))
+      rspress: 1.25.2(@swc/helpers@0.5.3)(webpack@5.91.0)
+      rspress-plugin-devkit: 0.3.0(rspress@1.25.2(@swc/helpers@0.5.3)(webpack@5.91.0))
     transitivePeerDependencies:
       - next
       - react
       - supports-color
 
-  rspress@1.25.2(webpack@5.91.0):
+  rspress@1.25.2(@swc/helpers@0.5.3)(webpack@5.91.0):
     dependencies:
       '@rsbuild/core': 0.7.8
-      '@rspress/core': 1.25.2(webpack@5.91.0)
+      '@rspress/core': 1.25.2(@swc/helpers@0.5.3)(webpack@5.91.0)
       '@rspress/shared': 1.25.2
       cac: 6.7.14
       chalk: 5.3.0


### PR DESCRIPTION
### Summary

Closes #553

- fixed `invalidateScripts` behaviour when trying to invalidate all scripts (when passing undefined or `[]` as argument)
- fixed hang in native ScriptManager on iOS when trying to execute file that doesn't exist
- aligned Android errors to match iOS when executing the same flow

### Test plan

- [x] - local test on `tester-federation`
- [x] - verify canary fixes linked issue 
