### PR TITLE
fix: bundle naming collisions when using device filesystem cache

### DIFF
--- a/.changeset/brown-needles-pull.md
+++ b/.changeset/brown-needles-pull.md
@@ -1,0 +1,5 @@
+---
+"@callstack/repack": minor
+---
+
+Fix bundle naming collisions when using device filesystem cache

--- a/packages/repack/android/src/main/java/com/callstack/repack/RemoteScriptLoader.kt
+++ b/packages/repack/android/src/main/java/com/callstack/repack/RemoteScriptLoader.kt
@@ -17,8 +17,8 @@ class RemoteScriptLoader(reactContext: ReactContext) : NativeScriptLoader(reactC
     private val scriptsDirName = "scripts"
     private val client = OkHttpClient()
 
-    private fun getScriptFilePath(id: String): String {
-        return "${scriptsDirName}/$id.script.bundle"
+    private fun getScriptFilePath(scriptUniqueId: String): String {
+        return "${scriptsDirName}/$scriptUniqueId.script.bundle"
     }
 
     private fun createClientPerRequest(config: ScriptConfig): OkHttpClient {
@@ -30,7 +30,7 @@ class RemoteScriptLoader(reactContext: ReactContext) : NativeScriptLoader(reactC
     }
 
     private fun downloadAndCache(config: ScriptConfig, onSuccess: () -> Unit, onError: (code: String, message: String) -> Unit) {
-        val path = getScriptFilePath(config.id)
+        val path = getScriptFilePath(config.uniqueId)
         val file = File(reactContext.filesDir, path)
 
         val callback = object : Callback {
@@ -95,7 +95,7 @@ class RemoteScriptLoader(reactContext: ReactContext) : NativeScriptLoader(reactC
     }
 
     fun execute(config: ScriptConfig, promise: Promise) {
-        val scriptPath = getScriptFilePath(config.id)
+        val scriptPath = getScriptFilePath(config.uniqueId)
         try {
             val file = File(reactContext.filesDir, scriptPath)
             if (!file.exists()) {

--- a/packages/repack/android/src/main/java/com/callstack/repack/ScriptConfig.kt
+++ b/packages/repack/android/src/main/java/com/callstack/repack/ScriptConfig.kt
@@ -8,7 +8,7 @@ import okhttp3.RequestBody.Companion.toRequestBody
 import java.net.URL
 
 data class ScriptConfig(
-        val id: String,
+        val scriptId: String,
         val url: URL,
         val query: String?,
         val fetch: Boolean,
@@ -18,21 +18,20 @@ data class ScriptConfig(
         val timeout: Int,
         val headers: Headers,
         val verifyScriptSignature: String,
+        val uniqueId: String
 ) {
     companion object {
-        fun fromReadableMap(id: String, value: ReadableMap): ScriptConfig {
-            val urlString = value.getString("url")
-                    ?: throw Error("ScriptManagerModule.load ScriptMissing url")
-            val method = value.getString("method")
-                    ?: throw Error("ScriptManagerModule.load ScriptMissing method")
+        fun fromReadableMap(scriptId: String, value: ReadableMap): ScriptConfig {
+            val urlString = requireNotNull(value.getString("url"))
+            val method = requireNotNull(value.getString("method"))
             val fetch = value.getBoolean("fetch")
             val absolute = value.getBoolean("absolute")
             val query = value.getString("query")
             val bodyString = value.getString("body")
             val headersMap = value.getMap("headers")
             val timeout = value.getInt("timeout")
-            val verifyScriptSignature = value.getString("verifyScriptSignature")
-                    ?: throw Error("ScriptManagerModule.load ScriptMissing verifyScriptSignature")
+            val verifyScriptSignature = requireNotNull(value.getString("verifyScriptSignature"))
+            val uniqueId = requireNotNull(value.getString("uniqueId"))
 
             val url = URL(
                     if (query != null) {
@@ -56,7 +55,7 @@ data class ScriptConfig(
             val body = bodyString?.toRequestBody(contentType)
 
             return ScriptConfig(
-                    id,
+                    scriptId,
                     url,
                     query,
                     fetch,
@@ -65,7 +64,8 @@ data class ScriptConfig(
                     body,
                     timeout,
                     headers.build(),
-                    verifyScriptSignature
+                    verifyScriptSignature,
+                    uniqueId
             )
         }
     }

--- a/packages/repack/android/src/main/java/com/callstack/repack/ScriptManagerModule.kt
+++ b/packages/repack/android/src/main/java/com/callstack/repack/ScriptManagerModule.kt
@@ -24,9 +24,9 @@ class ScriptManagerModule(reactContext: ReactApplicationContext) : ScriptManager
 
     @ReactMethod
     override fun loadScript(scriptId: String, configMap: ReadableMap, promise: Promise) {
-        runInBackground {
-            val config = ScriptConfig.fromReadableMap(scriptId, configMap)
+        val config = ScriptConfig.fromReadableMap(scriptId, configMap)
 
+        runInBackground {
             // Currently, `loadScript` supports either `RemoteScriptLoader` or `FileSystemScriptLoader`
             // but not both at the same time - it will likely change in the future.
             when {

--- a/packages/repack/ios/ScriptConfig.h
+++ b/packages/repack/ios/ScriptConfig.h
@@ -19,6 +19,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (readonly, nullable) NSDictionary *headers;
 @property (readonly) NSNumber *timeout;
 @property (readonly) NSString *verifyScriptSignature;
+@property (readonly) NSString *uniqueId;
 
 #ifdef RCT_NEW_ARCH_ENABLED
 + (ScriptConfig *)fromConfig:(JS::NativeScriptManager::NormalizedScriptLocator &)config
@@ -36,7 +37,8 @@ NS_ASSUME_NONNULL_BEGIN
                      withHeaders:(nullable NSDictionary *)headers
                         withBody:(nullable NSData *)body
                      withTimeout:(NSNumber *)timeout
-       withVerifyScriptSignature:(NSString *)verifyScriptSignature;
+       withVerifyScriptSignature:(NSString *)verifyScriptSignature
+                    withUniqueId:(NSString *)uniqueId;
 
 NS_ASSUME_NONNULL_END
 

--- a/packages/repack/ios/ScriptConfig.mm
+++ b/packages/repack/ios/ScriptConfig.mm
@@ -87,6 +87,7 @@
   _headers = headers;
   _timeout = timeout;
   _verifyScriptSignature = verifyScriptSignature;
+  _uniqueId = uniqueId;
   return self;
 }
 

--- a/packages/repack/ios/ScriptConfig.mm
+++ b/packages/repack/ios/ScriptConfig.mm
@@ -13,6 +13,7 @@
 @synthesize headers = _headers;
 @synthesize timeout = _timeout;
 @synthesize verifyScriptSignature = _verifyScriptSignature;
+@synthesize uniqueId = _uniqueId;
 
 #ifdef RCT_NEW_ARCH_ENABLED
 + (ScriptConfig *)fromConfig:(JS::NativeScriptManager::NormalizedScriptLocator &)config
@@ -32,7 +33,8 @@
                                   withHeaders:headers
                                      withBody:[config.body() dataUsingEncoding:NSUTF8StringEncoding]
                                   withTimeout:[NSNumber numberWithDouble:config.timeout()]
-                    withVerifyScriptSignature:config.verifyScriptSignature()];
+                    withVerifyScriptSignature:config.verifyScriptSignature()
+                                 withUniqueId:config.uniqueId()];
 }
 #else
 + (ScriptConfig *)fromConfig:(NSDictionary *)config withScriptId:(nonnull NSString *)scriptId
@@ -50,7 +52,8 @@
                                   withHeaders:config[@"headers"]
                                      withBody:[config[@"body"] dataUsingEncoding:NSUTF8StringEncoding]
                                   withTimeout:config[@"timeout"]
-                    withVerifyScriptSignature:config[@"verifyScriptSignature"]];
+                    withVerifyScriptSignature:config[@"verifyScriptSignature"]
+                                 withUniqueId:config[@"uniqueId"]];
 }
 #endif
 
@@ -71,7 +74,8 @@
                      withHeaders:(nullable NSDictionary *)headers
                         withBody:(nullable NSData *)body
                      withTimeout:(nonnull NSNumber *)timeout
-       withVerifyScriptSignature:(NSString *)verifyScriptSignature;
+       withVerifyScriptSignature:(NSString *)verifyScriptSignature
+                    withUniqueId:(NSString *)uniqueId
 {
   _scriptId = scriptId;
   _url = url;

--- a/packages/repack/ios/ScriptManager.mm
+++ b/packages/repack/ios/ScriptManager.mm
@@ -156,9 +156,7 @@ RCT_EXPORT_METHOD(invalidateScripts
   }];
 }
 
-- (void)execute:(ScriptConfig *)config
-        resolve:(RCTPromiseResolveBlock)resolve
-         reject:(RCTPromiseRejectBlock)reject
+- (void)execute:(ScriptConfig *)config resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject
 {
   NSString *scriptPath = [self getScriptFilePath:config.uniqueId];
   @try {

--- a/packages/repack/ios/ScriptManager.mm
+++ b/packages/repack/ios/ScriptManager.mm
@@ -60,11 +60,11 @@ RCT_EXPORT_METHOD(loadScript
                if (error) {
                  reject(ScriptDownloadFailure, error.localizedFailureReason, nil);
                } else {
-                 [self execute:config.scriptId url:config.url resolve:resolve reject:reject];
+                 [self execute:config resolve:resolve reject:reject];
                }
              }];
       } else {
-        [self execute:scriptId url:config.url resolve:resolve reject:reject];
+        [self execute:config resolve:resolve reject:reject];
       }
 
     } else if ([[config.url scheme] isEqualToString:@"file"]) {
@@ -156,12 +156,11 @@ RCT_EXPORT_METHOD(invalidateScripts
   }];
 }
 
-- (void)execute:(NSString *)scriptId
-            url:(NSURL *)url
+- (void)execute:(ScriptConfig *)config
         resolve:(RCTPromiseResolveBlock)resolve
          reject:(RCTPromiseRejectBlock)reject
 {
-  NSString *scriptPath = [self getScriptFilePath:scriptId];
+  NSString *scriptPath = [self getScriptFilePath:config.uniqueId];
   @try {
     NSFileManager *manager = [NSFileManager defaultManager];
     if (![[NSFileManager defaultManager] fileExistsAtPath:scriptPath]) {
@@ -175,7 +174,7 @@ RCT_EXPORT_METHOD(invalidateScripts
       @throw [NSError errorWithDomain:errorMessage code:0 userInfo:nil];
     }
 
-    [self evaluateJavascript:data url:url resolve:resolve reject:reject];
+    [self evaluateJavascript:data url:config.url resolve:resolve reject:reject];
   } @catch (NSError *error) {
     reject(CodeExecutionFailure, error.domain, nil);
   }
@@ -189,15 +188,15 @@ RCT_EXPORT_METHOD(invalidateScripts
   return [rootDirectoryPath stringByAppendingPathComponent:@"scripts"];
 }
 
-- (NSString *)getScriptFilePath:(NSString *)scriptId
+- (NSString *)getScriptFilePath:(NSString *)scriptUniqueId
 {
-  NSString *scriptPath = [[self getScriptsDirectoryPath] stringByAppendingPathComponent:scriptId];
+  NSString *scriptPath = [[self getScriptsDirectoryPath] stringByAppendingPathComponent:scriptUniqueId];
   return [scriptPath stringByAppendingPathExtension:@"script.bundle"];
 }
 
 - (void)downloadAndCache:(ScriptConfig *)config completionHandler:(void (^)(NSError *error))callback
 {
-  NSString *scriptFilePath = [self getScriptFilePath:config.scriptId];
+  NSString *scriptFilePath = [self getScriptFilePath:config.uniqueId];
   NSString *scriptsDirectoryPath = [self getScriptsDirectoryPath];
 
   NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:config.url];

--- a/packages/repack/src/modules/ScriptManager/NativeScriptManager.ts
+++ b/packages/repack/src/modules/ScriptManager/NativeScriptManager.ts
@@ -13,6 +13,7 @@ export const enum NormalizedScriptLocatorSignatureVerificationMode {
 }
 
 export interface NormalizedScriptLocator {
+  uniqueId: string;
   method: NormalizedScriptLocatorHTTPMethod;
   url: string;
   fetch: boolean;

--- a/packages/repack/src/modules/ScriptManager/Script.ts
+++ b/packages/repack/src/modules/ScriptManager/Script.ts
@@ -67,7 +67,7 @@ export class Script {
    * @param caller Optional caller name to prefix the script id.
    */
   static getScriptUniqueId(scriptId: string, caller?: string) {
-    const prefix = caller ? caller + '::' : '';
+    const prefix = caller ? caller + '_' : '';
     return prefix + scriptId;
   }
 

--- a/packages/repack/src/modules/ScriptManager/Script.ts
+++ b/packages/repack/src/modules/ScriptManager/Script.ts
@@ -59,6 +59,19 @@ export class Script {
   }
 
   /**
+   * Get unique identifier for the script.
+   *
+   * Used to create unique identifier for the script, which serves as its key in the cache.
+   *
+   * @param scriptId Id of the script.
+   * @param caller Optional caller name to prefix the script id.
+   */
+  static getScriptUniqueId(scriptId: string, caller?: string) {
+    const prefix = caller ? caller + '::' : '';
+    return prefix + scriptId;
+  }
+
+  /**
    * Create new instance of `Script` from non-normalized script locator data.
    *
    * @param locator Non-normalized locator data.
@@ -75,6 +88,8 @@ export class Script {
     new Headers(locator.headers).forEach((value: string, key: string) => {
       headers[key.toLowerCase()] = value;
     });
+
+    const uniqueId = Script.getScriptUniqueId(key.scriptId, key.caller);
 
     let body: NormalizedScriptLocator['body'];
     if (locator.body instanceof FormData) {
@@ -105,6 +120,7 @@ export class Script {
       key.scriptId,
       key.caller,
       {
+        uniqueId,
         method:
           (locator.method as NormalizedScriptLocatorHTTPMethod) ??
           NormalizedScriptLocatorHTTPMethod.GET,

--- a/packages/repack/src/modules/ScriptManager/ScriptManager.ts
+++ b/packages/repack/src/modules/ScriptManager/ScriptManager.ts
@@ -12,9 +12,11 @@ type Cache = Record<
   Pick<NormalizedScriptLocator, 'method' | 'url' | 'query' | 'headers' | 'body'>
 >;
 
-const CACHE_KEY = `Repack.ScriptManager.Cache.v3.${
-  __DEV__ ? 'debug' : 'release'
-}`;
+const CACHE_NAME = 'Repack.ScriptManager.Cache';
+const CACHE_VERSION = 'v4';
+const CACHE_ENV = __DEV__ ? 'debug' : 'release';
+
+const CACHE_KEY = [CACHE_NAME, CACHE_VERSION, CACHE_ENV].join('.');
 
 /* Options for resolver when adding it to a `ScriptManager`. */
 export interface ResolverOptions {

--- a/packages/repack/src/modules/ScriptManager/ScriptManager.ts
+++ b/packages/repack/src/modules/ScriptManager/ScriptManager.ts
@@ -266,7 +266,7 @@ export class ScriptManager extends EventEmitter {
       }
 
       const script = Script.from({ scriptId, caller }, locator, false);
-      const cacheKey = `${scriptId}_${caller ?? 'unknown'}`;
+      const cacheKey = script.locator.uniqueId;
 
       // Check if user provided a custom shouldUpdateScript function
       if (locator.shouldUpdateScript) {

--- a/packages/repack/src/modules/ScriptManager/__tests__/ScriptManager.test.ts
+++ b/packages/repack/src/modules/ScriptManager/__tests__/ScriptManager.test.ts
@@ -81,6 +81,41 @@ describe('ScriptManagerAPI', () => {
     ).rejects.toThrow(/Error: No script resolvers were added/);
   });
 
+  it('should generate uniqueId', async () => {
+    const uniqueId = Script.getScriptUniqueId('src_App_js', 'main');
+    expect(uniqueId).toEqual('main_src_App_js');
+
+    ScriptManager.shared.addResolver(async (scriptId, caller) => {
+      expect(caller).toEqual('main');
+
+      return {
+        url: Script.getRemoteURL(`http://domain.ext/${scriptId}`),
+      };
+    });
+
+    const script = await ScriptManager.shared.resolveScript(
+      'src_App_js',
+      'main'
+    );
+    expect(script.locator.uniqueId).toEqual('main_src_App_js');
+  });
+
+  it('should generate uniqueId with undefined caller', async () => {
+    const uniqueId = Script.getScriptUniqueId('src_App_js', undefined);
+    expect(uniqueId).toEqual('src_App_js');
+
+    ScriptManager.shared.addResolver(async (scriptId, caller) => {
+      expect(caller).toEqual(undefined);
+
+      return {
+        url: Script.getRemoteURL(`http://domain.ext/${scriptId}`),
+      };
+    });
+
+    const script = await ScriptManager.shared.resolveScript('src_App_js');
+    expect(script.locator.uniqueId).toEqual('src_App_js');
+  });
+
   it('should resolve with url only', async () => {
     const cache = new FakeCache();
 
@@ -104,6 +139,7 @@ describe('ScriptManagerAPI', () => {
       method: 'GET',
       timeout: Script.DEFAULT_TIMEOUT,
       verifyScriptSignature: 'off',
+      uniqueId: 'main_src_App_js',
     });
 
     const {
@@ -132,6 +168,7 @@ describe('ScriptManagerAPI', () => {
       method: 'GET',
       timeout: Script.DEFAULT_TIMEOUT,
       verifyScriptSignature: 'off',
+      uniqueId: 'main_src_App_js',
     });
   });
 
@@ -159,6 +196,7 @@ describe('ScriptManagerAPI', () => {
       method: 'GET',
       timeout: Script.DEFAULT_TIMEOUT,
       verifyScriptSignature: 'off',
+      uniqueId: 'main_src_App_js',
     });
   });
 
@@ -186,6 +224,7 @@ describe('ScriptManagerAPI', () => {
       query: 'accessCode=1234&accessUid=asdf',
       timeout: Script.DEFAULT_TIMEOUT,
       verifyScriptSignature: 'off',
+      uniqueId: 'main_src_App_js',
     });
 
     ScriptManager.shared.removeAllResolvers();
@@ -226,6 +265,7 @@ describe('ScriptManagerAPI', () => {
       headers: { 'x-hello': 'world' },
       timeout: Script.DEFAULT_TIMEOUT,
       verifyScriptSignature: 'off',
+      uniqueId: 'main_src_App_js',
     });
 
     ScriptManager.shared.removeAllResolvers();
@@ -250,6 +290,7 @@ describe('ScriptManagerAPI', () => {
       headers: { 'x-hello': 'world', 'x-changed': 'true' },
       timeout: Script.DEFAULT_TIMEOUT,
       verifyScriptSignature: 'off',
+      uniqueId: 'main_src_App_js',
     });
   });
 
@@ -275,6 +316,7 @@ describe('ScriptManagerAPI', () => {
       body: 'hello_world',
       timeout: Script.DEFAULT_TIMEOUT,
       verifyScriptSignature: 'off',
+      uniqueId: 'main_src_App_js',
     });
 
     ScriptManager.shared.removeAllResolvers();
@@ -297,6 +339,7 @@ describe('ScriptManagerAPI', () => {
       body: 'message',
       timeout: Script.DEFAULT_TIMEOUT,
       verifyScriptSignature: 'off',
+      uniqueId: 'main_src_App_js',
     });
   });
 
@@ -325,6 +368,7 @@ describe('ScriptManagerAPI', () => {
       method: 'POST',
       timeout: Script.DEFAULT_TIMEOUT,
       verifyScriptSignature: 'off',
+      uniqueId: 'main_src_App_js',
     });
   });
 

--- a/packages/repack/src/modules/ScriptManager/types.ts
+++ b/packages/repack/src/modules/ScriptManager/types.ts
@@ -96,6 +96,7 @@ export interface ScriptLocator {
    * `off` means that the script's code-signature will not be verfied
    */
   verifyScriptSignature?: 'strict' | 'lax' | 'off';
+
   /**
    * Function called before loading or getting from the cache and after resolving the script locator.
    * It's an async function which should return a boolean indicating whether the script should be loaded or use default behaviour.


### PR DESCRIPTION
### Summary

Closes #660 

To prevent naming collisions on the device filesystem we're now using `uniqueId` as a filename.

`Script.locator.uniqueId` is generated by prepending `caller` to the `scriptId`.
If the `caller` is unknown, then `uniqueId` is equal to the `scriptId`.

### Notes

This PR changes the cache key from `v3` to `v4` so all previous cache won't be accessible with the next release that includes this PR

### Test plan

- [x] - local test on federation tester
- [x] - added unit tests to ScriptManager suite
- [x] - verify the change works in super app showcase scenario
- [x] - (optionally) verify canary release fixes the issue
