### PR TITLE
fix: CLI commands alignment

### DIFF
--- a/.changeset/loud-hounds-clean.md
+++ b/.changeset/loud-hounds-clean.md
@@ -1,0 +1,5 @@
+---
+"@callstack/repack": patch
+---
+
+Align CLI options for `start` and `bundle` commands with `@react-native/community-cli-plugin`.

--- a/packages/repack/commands.js
+++ b/packages/repack/commands.js
@@ -185,17 +185,6 @@ const webpackConfigOption = {
   name: '--webpackConfig <path>',
   description: 'Path to a Webpack config',
   parse: (val) => path.resolve(val),
-  default: (config) => {
-    const {
-      getWebpackConfigPath,
-    } = require('./dist/commands/utils/getWebpackConfigPath');
-
-    try {
-      return getWebpackConfigPath(config.root);
-    } catch {
-      return '';
-    }
-  },
 };
 
 const commands = [

--- a/packages/repack/commands.js
+++ b/packages/repack/commands.js
@@ -100,6 +100,10 @@ const startCommandOptions = [
     name: '--silent',
     description: 'Silents all logs to the console/stdout',
   },
+  {
+    name: '--verbose',
+    description: 'Enables verbose logging',
+  },
 ];
 
 const bundleCommandOptions = [
@@ -165,6 +169,10 @@ const bundleCommandOptions = [
       "'verbose' - output everything\n" +
       "'detailed' - output everything except chunkModules and chunkRootModules\n" +
       "'summary' - output webpack version, warnings count and errors count",
+  },
+  {
+    name: '--verbose',
+    description: 'Enables verbose logging',
   },
 ];
 

--- a/packages/repack/commands.js
+++ b/packages/repack/commands.js
@@ -52,8 +52,9 @@ function getCommands() {
 
 const startCommandOptions = [
   {
-    name: '--cert <path>',
-    description: 'Path to custom SSL cert',
+    name: '--port <number>',
+    description: 'The port number that runs the server on',
+    parse: Number,
   },
   {
     name: '--host <string>',
@@ -69,81 +70,84 @@ const startCommandOptions = [
     description: 'Path to custom SSL key',
   },
   {
-    name: '--port <number>',
-    description: 'The port number that runs the server on',
+    name: '--cert <path>',
+    description: 'Path to custom SSL cert',
   },
   {
     name: '--no-interactive',
     description: 'Disables interactive mode',
   },
   {
-    name: '--silent',
-    description: 'Silents all logs to the console/stdout',
-  },
-  {
     name: '--experimental-debugger',
     description:
       '[Experimental] Enable the new debugger experience. Connection reliability and some basic features are unstable in this release.',
   },
-  {
-    name: '--silent',
-    description: 'Silents all logs to the console/stdout',
-  },
+  // options specific to Re.Pack
   {
     name: '--json',
     description: 'Log all messages to the console/stdout in JSON format',
+  },
+  {
+    name: '--log-file <path>',
+    description: 'Enables file logging to specified file',
+    parse: (val) => path.resolve(val),
   },
   {
     name: '--reverse-port',
     description: 'ADB reverse port on starting devServers only for Android',
   },
   {
-    name: '--log-file <path>',
-    description: 'Enables file logging to specified file',
+    name: '--silent',
+    description: 'Silents all logs to the console/stdout',
   },
 ];
 
 const bundleCommandOptions = [
-  {
-    name: '--assets-dest <path>',
-    description:
-      'Directory name where to store assets referenced in the bundle',
-  },
   {
     name: '--entry-file <path>',
     description:
       'Path to the root JS file, either absolute or relative to JS root',
   },
   {
-    name: '--minify',
-    description:
-      'Allows overriding whether bundle is minified. This defaults to false if dev is true, and true if dev is false. Disabling minification can be useful for speeding up production builds for testing purposes.',
+    name: '--platform <string>',
+    description: 'Either "ios" or "android"',
+    default: 'ios',
   },
   {
     name: '--dev [boolean]',
     description:
       'Enables development warnings and disables production optimisations',
+    parse: (val) => val !== 'false',
     default: true,
   },
   {
-    name: '--bundle-output <path>',
+    name: '--minify [boolean]',
+    description:
+      'Allows overriding whether bundle is minified. This defaults to ' +
+      'false if dev is true, and true if dev is false. Disabling minification ' +
+      'can be useful for speeding up production builds for testing purposes.',
+    parse: (val) => val !== 'false',
+  },
+  {
+    name: '--bundle-output <string>',
     description:
       'File name where to store the resulting bundle, ex. /tmp/groups.bundle',
   },
-
   {
-    name: '--sourcemap-output <path>',
+    name: '--sourcemap-output <string>',
     description:
       'File name where to store the sourcemap file for resulting bundle, ex. /tmp/groups.map',
   },
   {
-    name: '--platform <path>',
-    description: 'Either "ios" or "android" (default: "ios")',
+    name: '--assets-dest <string>',
+    description:
+      'Directory name where to store assets referenced in the bundle',
   },
   {
     name: '--reset-cache',
     description: 'Removes cached files (default: false)',
   },
+  // options specific to Re.Pack
   {
     name: '--json <statsFile>',
     description: 'Stores stats in a file.',

--- a/packages/repack/commands.js
+++ b/packages/repack/commands.js
@@ -147,10 +147,6 @@ const bundleCommandOptions = [
     description:
       'Directory name where to store assets referenced in the bundle',
   },
-  {
-    name: '--reset-cache',
-    description: 'Removes cached files (default: false)',
-  },
   // options specific to Re.Pack
   {
     name: '--json <statsFile>',

--- a/packages/repack/src/commands/bundle.ts
+++ b/packages/repack/src/commands/bundle.ts
@@ -41,6 +41,10 @@ export async function bundle(
     },
   } as CliOptions;
 
+  if (!args.entryFile) {
+    throw new Error("Option '--entry-file <path>' argument is missing");
+  }
+
   if (args.verbose ?? process.argv.includes('--verbose')) {
     process.env[VERBOSE_ENV_KEY] = '1';
   }

--- a/packages/repack/src/commands/start.ts
+++ b/packages/repack/src/commands/start.ts
@@ -41,10 +41,7 @@ export async function start(_: string[], config: Config, args: StartArguments) {
       webpackConfigPath,
     },
     command: 'start',
-    arguments: {
-      // `platform` is empty, since it will be filled in later by `DevServerProxy`
-      start: { ...restArgs, platform: '' },
-    },
+    arguments: { start: { ...restArgs } },
   };
 
   const reversePort = reversePortArg ?? process.argv.includes('--reverse-port');

--- a/packages/repack/src/types.ts
+++ b/packages/repack/src/types.ts
@@ -33,7 +33,7 @@ export interface WebpackPlugin {
  * @internal
  */
 export interface BundleArguments {
-  entryFile?: string;
+  entryFile: string;
   platform: string;
   dev: boolean;
   minify?: boolean;

--- a/packages/repack/src/types.ts
+++ b/packages/repack/src/types.ts
@@ -89,6 +89,11 @@ export interface CliOptions {
       };
 }
 
+export interface WebpackWorkerOptions {
+  cliOptions: CliOptions;
+  platform: string;
+}
+
 /**
  * Development server configuration options.
  */

--- a/packages/repack/src/types.ts
+++ b/packages/repack/src/types.ts
@@ -40,7 +40,6 @@ export interface BundleArguments {
   bundleOutput?: string;
   sourcemapOutput?: string;
   assetsDest?: string;
-  resetCache?: boolean;
   json?: string;
   stats?: string;
   verbose?: boolean;

--- a/packages/repack/src/types.ts
+++ b/packages/repack/src/types.ts
@@ -28,38 +28,23 @@ export interface WebpackPlugin {
 }
 
 /**
- * Common CLI arguments that are used across all commands.
- *
- * @internal
- */
-export interface CommonArguments {
-  /** Target application platform. */
-  platform: string;
-  /** Whether to clean any persistent cache. */
-  resetCache?: boolean;
-  /** Whether to log additional debug messages. */
-  verbose?: boolean;
-  /** Custom path to Webpack config. */
-  webpackConfig?: string;
-}
-
-/**
  * CLI arguments passed from React Native CLI when running bundle command.
  *
  * @internal
  */
-export interface BundleArguments extends CommonArguments {
-  assetsDest?: string;
-  entryFile: string;
-  json?: string;
-  minify?: boolean;
+export interface BundleArguments {
+  entryFile?: string;
+  platform: string;
   dev: boolean;
-  bundleOutput: string;
-  // bundleEncoding?: string;
+  minify?: boolean;
+  bundleOutput?: string;
   sourcemapOutput?: string;
-  // sourcemapSourcesRoot?: string;
-  // sourcemapUseAbsolutePath: boolean;
+  assetsDest?: string;
+  resetCache?: boolean;
+  json?: string;
   stats?: string;
+  verbose?: boolean;
+  webpackConfig?: string;
 }
 
 /**
@@ -67,19 +52,20 @@ export interface BundleArguments extends CommonArguments {
  *
  * @internal
  */
-export interface StartArguments extends CommonArguments {
-  cert?: string;
-  host?: string;
+export interface StartArguments {
+  port?: number;
+  host: string;
   https?: boolean;
   key?: string;
-  port?: number;
+  cert?: string;
   interactive?: boolean;
+  experimentalDebugger?: boolean;
+  json?: boolean;
+  logFile?: string;
+  reversePort?: boolean;
   silent?: boolean;
   verbose?: boolean;
-  json?: boolean;
-  reversePort?: boolean;
-  logFile?: string;
-  experimentalDebugger?: boolean;
+  webpackConfig?: string;
 }
 
 /**

--- a/packages/repack/src/webpack/Compiler.ts
+++ b/packages/repack/src/webpack/Compiler.ts
@@ -5,7 +5,7 @@ import EventEmitter from 'events';
 import webpack from 'webpack';
 import mimeTypes from 'mime-types';
 import { SendProgress } from '@callstack/repack-dev-server';
-import type { CliOptions, StartArguments } from '../types';
+import type { CliOptions, WebpackWorkerOptions } from '../types';
 import type { LogType, Reporter } from '../logging';
 import { VERBOSE_ENV_KEY, WORKER_ENV_KEY } from '../env';
 import { adaptFilenameToPlatform } from './utils';
@@ -36,14 +36,9 @@ export class Compiler extends EventEmitter {
   private spawnWorker(platform: string) {
     this.isCompilationInProgress[platform] = true;
 
-    const workerData = {
-      ...this.cliOptions,
-      arguments: {
-        start: {
-          ...(this.cliOptions.arguments as { start: StartArguments }).start,
-          platform,
-        },
-      },
+    const workerData: WebpackWorkerOptions = {
+      cliOptions: this.cliOptions,
+      platform,
     };
 
     process.env[WORKER_ENV_KEY] = '1';

--- a/packages/repack/src/webpack/utils/getWebpackEnvOptions.ts
+++ b/packages/repack/src/webpack/utils/getWebpackEnvOptions.ts
@@ -27,7 +27,6 @@ export function getWebpackEnvOptions(
     env.assetsPath = cliOptions.arguments.bundle.assetsDest;
   } else {
     env.mode = 'development';
-    env.platform = cliOptions.arguments.start.platform || undefined;
     env.devServer = {
       port: cliOptions.arguments.start.port ?? DEFAULT_PORT,
       host: cliOptions.arguments.start.host || DEFAULT_HOSTNAME,

--- a/packages/repack/src/webpack/webpackWorker.ts
+++ b/packages/repack/src/webpack/webpackWorker.ts
@@ -1,16 +1,16 @@
-import { workerData, parentPort } from 'worker_threads';
-import path from 'path';
-import webpack from 'webpack';
+import path from 'node:path';
+import { workerData, parentPort } from 'node:worker_threads';
 import memfs from 'memfs';
-import type { CliOptions } from '../types';
-import { getWebpackEnvOptions } from './utils';
+import webpack from 'webpack';
+import type { WebpackWorkerOptions } from '../types';
 import { loadWebpackConfig } from './loadWebpackConfig';
+import { getWebpackEnvOptions } from './utils';
 
-async function main(cliOptions: CliOptions) {
+async function main({ cliOptions, platform }: WebpackWorkerOptions) {
   const webpackEnvOptions = getWebpackEnvOptions(cliOptions);
   const webpackConfig = await loadWebpackConfig(
     cliOptions.config.webpackConfigPath,
-    webpackEnvOptions
+    { ...webpackEnvOptions, platform }
   );
   const watchOptions = webpackConfig.watchOptions ?? {};
 

--- a/website/src/4.x/docs/cli-commands/bundle.md
+++ b/website/src/4.x/docs/cli-commands/bundle.md
@@ -1,4 +1,3 @@
-
 # bundle
 
 `bundle` or `webpack-bundle` is a command-line tool that builds the bundle for the provided project.
@@ -13,30 +12,18 @@ react-native bundle [options]
 
 ## Options
 
-### --verbose
-
-- Type: `boolean`
-
-Increase logging verbosity.
-
-### --assets-dest <path>
-
-- Type: `string`
-
-Directory name where to store assets referenced in the bundle.
-
 ### --entry-file <path>
 
 - Type: `string`
 
 Path to the root JS file, either absolute or relative to JS root.
 
-### --minify
+### --platform <string>
 
-- Type: `boolean`
-- Default: `false`
+- Type: `string`
+- Default: `"ios"`
 
-Allows overriding whether bundle is minified. This defaults to false if dev is true, and true if dev is false. Disabling minification can be useful for speeding up production builds for testing purposes.
+Either "ios" or "android".
 
 ### --dev [boolean]
 
@@ -45,31 +32,29 @@ Allows overriding whether bundle is minified. This defaults to false if dev is t
 
 Enables development warnings and disables production optimizations.
 
-### --bundle-output <path>
+### --minify [boolean]
+
+- Type: `boolean`
+
+Allows overriding whether bundle is minified. This defaults to false if dev is true, and true if dev is false. Disabling minification can be useful for speeding up production builds for testing purposes.
+
+### --bundle-output <string>
 
 - Type: `string`
 
 File name where to store the resulting bundle, ex. /tmp/groups.bundle.
 
-### --sourcemap-output <path>
+### --sourcemap-output <string>
 
 - Type: `string`
 
 File name where to store the sourcemap file for resulting bundle, ex. /tmp/groups.map.
 
-### --platform <path>
+### --assets-dest <string>
 
 - Type: `string`
-- Default: `"ios"`
 
-Either "ios" or "android".
-
-### --reset-cache
-
-- Type: `boolean`
-- Default: `false`
-
-Removes cached files.
+Directory name where to store assets referenced in the bundle.
 
 ### --json <statsFile>
 
@@ -94,10 +79,15 @@ Instructs Webpack on how to treat the stats:
 
 More details: [Webpack documentation](https://webpack.js.org/configuration/stats/)
 
+### --verbose
+
+- Type: `boolean`
+
+Enables verbose logging.
+
 ### --webpackConfig <path>
 
 - Type: `string`
-- Default: `"[project_root]/webpack.config.mjs"`
 
 Path to a Webpack config file.
 

--- a/website/src/4.x/docs/cli-commands/start.md
+++ b/website/src/4.x/docs/cli-commands/start.md
@@ -1,4 +1,3 @@
-
 # start
 
 `start` or `webpack-start` is a command-line tool that starts the React Native development server with Webpack integration.
@@ -13,18 +12,11 @@ react-native start [options]
 
 ## Options
 
-### --verbose
+### --port <number>
 
-- Type: `boolean`
-- Default: `false`
+- Type: `number`
 
-Increase logging verbosity.
-
-### --cert <path>
-
-- Type: `string`
-
-Path to custom SSL certificate.
+The port number that runs the server on.
 
 ### --host <string>
 
@@ -36,7 +28,6 @@ Set the server host.
 ### --https
 
 - Type: `boolean`
-- Default: `false`
 
 Enables HTTPS connections to the server.
 
@@ -46,11 +37,11 @@ Enables HTTPS connections to the server.
 
 Path to custom SSL key.
 
-### --port <number>
+### --cert <path>
 
-- Type: `number`
+- Type: `string`
 
-The port number that runs the server on.
+Path to custom SSL certificate.
 
 ### --no-interactive
 
@@ -58,33 +49,17 @@ The port number that runs the server on.
 
 Disables interactive mode.
 
-### --silent
-
-- Type: `boolean`
-- Default: `false`
-
-Silences all logs to the console/stdout.
-
 ### --experimental-debugger
 
 - Type: `boolean`
-- Default: `false`
 
 Enable the new debugger experience. Connection reliability and some basic features are unstable in this release.
 
 ### --json
 
 - Type: `boolean`
-- Default: `false`
 
 Log all messages to the console/stdout in JSON format.
-
-### --reverse-port
-
-- Type: `boolean`
-- Default: `false`
-
-ADB reverse port on starting devServers only for Android.
 
 ### --log-file <path>
 
@@ -92,10 +67,27 @@ ADB reverse port on starting devServers only for Android.
 
 Enables file logging to specified file.
 
+### --reverse-port
+
+- Type: `boolean`
+
+ADB reverse port on starting devServers only for Android.
+
+### --silent
+
+- Type: `boolean`
+
+Silences all logs to the console/stdout.
+
+### --verbose
+
+- Type: `boolean`
+
+Enables verbose logging.
+
 ### --webpackConfig <path>
 
 - Type: `string`
-- Default: `"[project_root]/webpack.config.mjs"`
 
 Path to a Webpack config file.
 


### PR DESCRIPTION
### Summary

Aligned both CLI command options to match the ones defined in [@react-native/community-cli-plugin](https://github.com/facebook/react-native/tree/main/packages/community-cli-plugin/src/commands)

- [x] - parsing is now the same for every command that is present in the `community-cli-plugin`
- [x] - added explicit check for `entryFile` option in `bundle` command, making the error message meaningful
- [x] - removed redundant default value for `webpackConfigPath`
- [x] - added back missing `--verbose` option to both `start` and `bundle` commands
- [x] - reordered options in `commands.js` to match the order in `community-cli-plugin`
- [x] - removed non-existing `--reset-cache` option for `bundle command`
- [x] - updated docs

Closes #695 
Closes #690

### Test plan

- [x] - tested locally on both tester apps
