### PR TITLE
fix: LoadingView import

### DIFF
--- a/.changeset/metal-kiwis-yell.md
+++ b/.changeset/metal-kiwis-yell.md
@@ -1,0 +1,5 @@
+---
+"@callstack/repack": patch
+---
+
+fix: `LoadingView` import in `HMRClient` for React Native >=0.75

--- a/packages/repack/src/modules/WebpackHMRClient.ts
+++ b/packages/repack/src/modules/WebpackHMRClient.ts
@@ -4,6 +4,11 @@
 import type { HMRMessage, HMRMessageBody } from '../types';
 import { getDevServerLocation } from './getDevServerLocation';
 
+type LoadingViewUtil = {
+  showMessage(text: string, type: 'load' | 'refresh'): void;
+  hide(): void;
+};
+
 class HMRClient {
   url: string;
   socket: WebSocket;
@@ -13,10 +18,7 @@ class HMRClient {
     private app: {
       reload: () => void;
       dismissErrors: () => void;
-      LoadingView: {
-        showMessage(text: string, type: 'load' | 'refresh'): void;
-        hide(): void;
-      };
+      LoadingView: LoadingViewUtil;
     }
   ) {
     this.url = `ws://${
@@ -167,7 +169,16 @@ class HMRClient {
 
 if (__DEV__ && module.hot) {
   const { DevSettings, Platform } = require('react-native');
-  const LoadingView = require('react-native/Libraries/Utilities/LoadingView');
+  let LoadingView: LoadingViewUtil = {
+    showMessage: () => {},
+    hide: () => {},
+  };
+
+  try {
+    LoadingView = require('react-native/Libraries/Utilities/LoadingView');
+  } catch (error) {
+    LoadingView = require('react-native/Libraries/Utilities/DevLoadingView');
+  }
 
   const reload = () => DevSettings.reload();
   const dismissErrors = () => {


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

Due to the changes introduced in PR [facebook/react-native#43992](https://github.com/facebook/react-native/pull/43992), the `LoadingView.js `file has been renamed to `DevLoadingView.js`.

### Test plan

When using React Native version 75.x.x in your project, you may encounter the following error:
`Error: Can't resolve 'react-native/Libraries/Utilities/LoadingView' in ...`
This is because the `LoadingView.js` file has been renamed and needs to be updated accordingly in your codebase.

