### PR TITLE
fix: compile-time check for RN version

### DIFF
--- a/.changeset/fuzzy-bags-walk.md
+++ b/.changeset/fuzzy-bags-walk.md
@@ -1,0 +1,5 @@
+---
+'@callstack/repack': patch
+---
+
+Fix: use compile-time check to determine React-Native version in HMRClient

--- a/packages/repack/src/modules/WebpackHMRClient.ts
+++ b/packages/repack/src/modules/WebpackHMRClient.ts
@@ -1,5 +1,5 @@
 /* eslint-env browser */
-/* globals __webpack_hash__, __DEV__, __PLATFORM__, __PUBLIC_PORT__ */
+/* globals __webpack_hash__, __DEV__, __PLATFORM__, __PUBLIC_PORT__, __REACT_NATIVE_MINOR_VERSION__ */
 
 import type { HMRMessage, HMRMessageBody } from '../types';
 import { getDevServerLocation } from './getDevServerLocation';
@@ -174,10 +174,10 @@ if (__DEV__ && module.hot) {
     hide: () => {},
   };
 
-  try {
-    LoadingView = require('react-native/Libraries/Utilities/LoadingView');
-  } catch (error) {
+  if (__REACT_NATIVE_MINOR_VERSION__ >= 75) {
     LoadingView = require('react-native/Libraries/Utilities/DevLoadingView');
+  } else {
+    LoadingView = require('react-native/Libraries/Utilities/LoadingView');
   }
 
   const reload = () => DevSettings.reload();

--- a/packages/repack/src/modules/runtime-globals.d.ts
+++ b/packages/repack/src/modules/runtime-globals.d.ts
@@ -21,6 +21,9 @@ declare interface RepackRuntime {
 declare var __DEV__: boolean;
 declare var __PUBLIC_PORT__: number;
 declare var __PLATFORM__: string;
+declare var __REACT_NATIVE_MAJOR_VERSION__: number;
+declare var __REACT_NATIVE_MINOR_VERSION__: number;
+declare var __REACT_NATIVE_PATCH_VERSION__: number;
 declare var __webpack_public_path__: string;
 declare var __webpack_hash__: string;
 declare var __repack__: RepackRuntime;

--- a/packages/repack/src/webpack/plugins/DevelopmentPlugin.ts
+++ b/packages/repack/src/webpack/plugins/DevelopmentPlugin.ts
@@ -50,14 +50,14 @@ export class DevelopmentPlugin implements WebpackPlugin {
 
     const reactNativePackageJson: PackageJSON = require('react-native/package.json');
     const [majorVersion, minorVersion, patchVersion] =
-      reactNativePackageJson.version.split('.');
+      reactNativePackageJson.version.split('-')[0].split('.');
 
     new webpack.DefinePlugin({
-      __PUBLIC_PORT__: JSON.stringify(this.config.devServer.port),
       __PLATFORM__: JSON.stringify(this.config.platform),
-      __REACT_NATIVE_MAJOR_VERSION__: JSON.stringify(majorVersion),
-      __REACT_NATIVE_MINOR_VERSION__: JSON.stringify(minorVersion),
-      __REACT_NATIVE_PATCH_VERSION__: JSON.stringify(patchVersion),
+      __PUBLIC_PORT__: Number(this.config.devServer.port),
+      __REACT_NATIVE_MAJOR_VERSION__: Number(majorVersion),
+      __REACT_NATIVE_MINOR_VERSION__: Number(minorVersion),
+      __REACT_NATIVE_PATCH_VERSION__: Number(patchVersion),
     }).apply(compiler);
 
     if (this.config?.devServer.hmr) {

--- a/packages/repack/src/webpack/plugins/DevelopmentPlugin.ts
+++ b/packages/repack/src/webpack/plugins/DevelopmentPlugin.ts
@@ -12,6 +12,8 @@ type EntryStaticNormalized =
   ExtractEntryStaticNormalized<webpack.EntryNormalized>;
 
 type ModuleDependency = webpack.dependencies.ModuleDependency;
+
+type PackageJSON = { version: string };
 /**
  * {@link DevelopmentPlugin} configuration options.
  */
@@ -46,9 +48,16 @@ export class DevelopmentPlugin implements WebpackPlugin {
       return;
     }
 
+    const reactNativePackageJson: PackageJSON = require('react-native/package.json');
+    const [majorVersion, minorVersion, patchVersion] =
+      reactNativePackageJson.version.split('.');
+
     new webpack.DefinePlugin({
       __PUBLIC_PORT__: JSON.stringify(this.config.devServer.port),
       __PLATFORM__: JSON.stringify(this.config.platform),
+      __REACT_NATIVE_MAJOR_VERSION__: JSON.stringify(majorVersion),
+      __REACT_NATIVE_MINOR_VERSION__: JSON.stringify(minorVersion),
+      __REACT_NATIVE_PATCH_VERSION__: JSON.stringify(patchVersion),
     }).apply(compiler);
 
     if (this.config?.devServer.hmr) {


### PR DESCRIPTION
### Summary

- [x] - check RN version in compile time through `DefinePlugin`

### Test plan

- [x] - tested locally on TesterApp
