### PR TITLE
fix: finding path to `webpack.config.mjs` on Windows

### DIFF
--- a/.changeset/friendly-melons-argue.md
+++ b/.changeset/friendly-melons-argue.md
@@ -1,0 +1,5 @@
+---
+'@callstack/repack': patch
+---
+
+Fix reading `webpack.config.mjs` on Windows

--- a/packages/repack/src/commands/utils/getWebpackConfigPath.ts
+++ b/packages/repack/src/commands/utils/getWebpackConfigPath.ts
@@ -24,8 +24,8 @@ export function getWebpackConfigPath(root: string, customPath?: string) {
       : path.join(root, candidate);
     if (fs.existsSync(filename)) {
       if (
-        path.isAbsolute(candidate) &&
-        candidate.endsWith('.mjs') &&
+        path.isAbsolute(filename) &&
+        filename.endsWith('.mjs') &&
         Os.platform() === 'win32'
       ) {
         return `file:\\${filename}`;

--- a/packages/repack/src/commands/utils/getWebpackConfigPath.ts
+++ b/packages/repack/src/commands/utils/getWebpackConfigPath.ts
@@ -1,6 +1,7 @@
-import path from 'path';
-import fs from 'fs';
-import Os from 'os';
+import path from 'node:path';
+import fs from 'node:fs';
+import os from 'node:os';
+import url from 'node:url';
 
 // Supports the same files as Webpack CLI.
 const DEFAULT_WEBPACK_CONFIG_LOCATIONS = [
@@ -22,13 +23,10 @@ export function getWebpackConfigPath(root: string, customPath?: string) {
     const filename = path.isAbsolute(candidate)
       ? candidate
       : path.join(root, candidate);
+
     if (fs.existsSync(filename)) {
-      if (
-        path.isAbsolute(filename) &&
-        filename.endsWith('.mjs') &&
-        Os.platform() === 'win32'
-      ) {
-        return `file:\\${filename}`;
+      if (path.extname(filename) === '.mjs' && os.platform() === 'win32') {
+        return url.pathToFileURL(filename).href;
       } else {
         return filename;
       }


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

Closes https://github.com/callstack/repack/issues/721

### Test plan

- tested the fix in the issue's repro on a Windows PC
