### PR TITLE
feat: Add `retry` and `retryDelay` Properties to Enhance Download Method Reliability

### DIFF
--- a/.changeset/tidy-eels-clean.md
+++ b/.changeset/tidy-eels-clean.md
@@ -1,0 +1,5 @@
+---
+"@callstack/repack": minor
+---
+
+Add a mechanism for retrying downloads of scripts through `retry` and `retryDelay` properties

--- a/packages/repack/src/modules/ScriptManager/NativeScriptManager.ts
+++ b/packages/repack/src/modules/ScriptManager/NativeScriptManager.ts
@@ -18,8 +18,6 @@ export interface NormalizedScriptLocator {
   url: string;
   fetch: boolean;
   timeout: number;
-  retry: number | undefined;
-  retryDelay: number | undefined;
   absolute: boolean;
   query: string | undefined;
   headers: { [key: string]: string } | undefined;

--- a/packages/repack/src/modules/ScriptManager/NativeScriptManager.ts
+++ b/packages/repack/src/modules/ScriptManager/NativeScriptManager.ts
@@ -18,6 +18,8 @@ export interface NormalizedScriptLocator {
   url: string;
   fetch: boolean;
   timeout: number;
+  retry: number | undefined;
+  retryDelay: number | undefined;
   absolute: boolean;
   query: string | undefined;
   headers: { [key: string]: string } | undefined;

--- a/packages/repack/src/modules/ScriptManager/Script.ts
+++ b/packages/repack/src/modules/ScriptManager/Script.ts
@@ -152,7 +152,10 @@ export class Script {
   constructor(
     public readonly scriptId: string,
     public readonly caller: string | undefined,
-    public readonly locator: NormalizedScriptLocator,
+    public readonly locator: NormalizedScriptLocator & {
+      retry?: number;
+      retryDelay?: number;
+    },
     public readonly cache: boolean = true
   ) {}
 

--- a/packages/repack/src/modules/ScriptManager/Script.ts
+++ b/packages/repack/src/modules/ScriptManager/Script.ts
@@ -127,6 +127,8 @@ export class Script {
         url: locator.url,
         absolute: locator.absolute ?? false,
         timeout: locator.timeout ?? Script.DEFAULT_TIMEOUT,
+        retry: locator.retry,
+        retryDelay: locator.retryDelay,
         query: new URLSearchParams(locator.query).toString() || undefined,
         body,
         headers: Object.keys(headers).length ? headers : undefined,

--- a/packages/repack/src/modules/ScriptManager/ScriptManager.ts
+++ b/packages/repack/src/modules/ScriptManager/ScriptManager.ts
@@ -18,6 +18,14 @@ const CACHE_ENV = __DEV__ ? 'debug' : 'release';
 
 const CACHE_KEY = [CACHE_NAME, CACHE_VERSION, CACHE_ENV].join('.');
 
+const LOADING_ERROR_CODES = [
+  // android
+  'NetworkFailure',
+  'RequestFailure',
+  // ios
+  'ScriptDownloadFailure',
+];
+
 /* Options for resolver when adding it to a `ScriptManager`. */
 export interface ResolverOptions {
   /**
@@ -355,7 +363,8 @@ export class ScriptManager extends EventEmitter {
         return; // Successfully loaded the script, exit the loop
       } catch (error) {
         attempts--;
-        if (attempts > 0) {
+        const { code } = error as Error & { code: string };
+        if (attempts > 0 && LOADING_ERROR_CODES.includes(code)) {
           if (retryDelay > 0) {
             await new Promise((resolve) => setTimeout(resolve, retryDelay));
           }

--- a/packages/repack/src/modules/ScriptManager/ScriptManager.ts
+++ b/packages/repack/src/modules/ScriptManager/ScriptManager.ts
@@ -357,7 +357,7 @@ export class ScriptManager extends EventEmitter {
         attempts--;
         if (attempts > 0) {
           if (retryDelay > 0) {
-            await waitMs(retryDelay);
+            await new Promise((resolve) => setTimeout(resolve, retryDelay));
           }
         } else {
           throw error; // No more retries, throw the error
@@ -445,17 +445,4 @@ export class ScriptManager extends EventEmitter {
       scriptSourceUrl
     );
   }
-}
-
-/**
- * Waits for a specified number of milliseconds.
- *
- * This function returns a Promise that resolves after the specified delay.
- * It is useful for introducing delays in asynchronous code.
- *
- * @param {number} ms - The number of milliseconds to wait.
- * @returns {Promise} A promise that resolves after the specified delay.
- */
-async function waitMs(ms: number) {
-  return new Promise((resolve) => setTimeout(resolve, ms));
 }

--- a/packages/repack/src/modules/ScriptManager/ScriptManager.ts
+++ b/packages/repack/src/modules/ScriptManager/ScriptManager.ts
@@ -350,7 +350,7 @@ export class ScriptManager extends EventEmitter {
    * @param {number} [locator.retryDelay=0] - The delay in milliseconds between retries.
    * @throws {Error} Throws an error if all retry attempts fail.
    */
-  async loadScriptWithRetry(
+  protected async loadScriptWithRetry(
     scriptId: string,
     locator: NormalizedScriptLocator & { retryDelay?: number; retry?: number }
   ) {

--- a/packages/repack/src/modules/ScriptManager/ScriptManager.ts
+++ b/packages/repack/src/modules/ScriptManager/ScriptManager.ts
@@ -344,7 +344,7 @@ export class ScriptManager extends EventEmitter {
    */
   async loadScriptWithRetry(
     scriptId: string,
-    locator: NormalizedScriptLocator
+    locator: NormalizedScriptLocator & { retryDelay?: number; retry?: number }
   ) {
     const { retry = 0, retryDelay = 0 } = locator;
     let attempts = retry + 1; // Include the initial attempt

--- a/packages/repack/src/modules/ScriptManager/types.ts
+++ b/packages/repack/src/modules/ScriptManager/types.ts
@@ -69,6 +69,26 @@ export interface ScriptLocator {
   timeout?: number;
 
   /**
+   * Number of times to retry fetching the script in case of failure.
+   *
+   * If the script fails to download due to network issues or server errors,
+   * this field determines how many additional attempts should be made to fetch it.
+   * A value of `0` means no retries will be attempted.
+   * Defaults to `0` if not specified.
+   */
+  retry?: number;
+
+  /**
+   * Delay in milliseconds between each retry attempt.
+   *
+   * This field specifies the wait time between consecutive retry attempts
+   * if the script download fails. It helps to avoid immediate retries and allows
+   * the network or server to recover before trying again.
+   * Defaults to `0` if not specified.
+   */
+  retryDelay?: number;
+
+  /**
    * Flag indicating whether the URL is an absolute FileSystem URL on a target device.
    * Useful if you're using custom code to download the script and you want `ScriptManager` to
    * execute it only from a custom FileSystem path.


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

This PR introduces two new properties, `retry` and `retryDelay`, to the `ScriptConfig` within the download method. These properties aim to improve the download process by handling network failures more robustly. 

- **`retry`**: Specifies the number of attempts to retry the download in case of failure.
- **`retryDelay`**: Defines the delay (in milliseconds) between each retry attempt.

This feature aims to minimize the impact of transient network failures and improve the reliability of downloads in unstable network conditions.

<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->

### Test plan

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
