### PR TITLE
fix: query object been encoded again on iOS side

### DIFF
--- a/.changeset/proud-ants-protect.md
+++ b/.changeset/proud-ants-protect.md
@@ -1,0 +1,5 @@
+---
+'@callstack/repack': patch
+---
+
+Fix url encoded twice issue on iOS side

--- a/packages/repack/ios/ScriptConfig.mm
+++ b/packages/repack/ios/ScriptConfig.mm
@@ -20,9 +20,16 @@
                 withScriptId:(nonnull NSString *)scriptId
 {
   NSDictionary *_Nullable headers = (NSDictionary *)config.headers();
-  NSURLComponents *urlComponents = [NSURLComponents componentsWithString:config.url()];
-  urlComponents.query = config.query();
-  NSURL *url = urlComponents.URL;
+
+  NSString *urlString = config[@"url"];
+  NSString *query = config[@"query"];
+  NSString *finalURLString;
+  if (query != nil) {
+      finalURLString = [NSString stringWithFormat:@"%@?%@", urlString, query];
+  } else {
+      finalURLString = urlString;
+  }
+  NSURL *url = [NSURL URLWithString:finalURLString];
 
   return [[ScriptConfig alloc] initWithScript:scriptId
                                       withURL:url

--- a/packages/repack/ios/ScriptConfig.mm
+++ b/packages/repack/ios/ScriptConfig.mm
@@ -20,16 +20,11 @@
                 withScriptId:(nonnull NSString *)scriptId
 {
   NSDictionary *_Nullable headers = (NSDictionary *)config.headers();
-
-  NSString *urlString = config[@"url"];
-  NSString *query = config[@"query"];
-  NSString *finalURLString;
-  if (query != nil) {
-      finalURLString = [NSString stringWithFormat:@"%@?%@", urlString, query];
-  } else {
-      finalURLString = urlString;
+  NSURLComponents *urlComponents = [NSURLComponents componentsWithString:config.url()];
+  if (config.query() != nil) {
+    urlComponents.percentEncodedQuery = config.query();
   }
-  NSURL *url = [NSURL URLWithString:finalURLString];
+  NSURL *url = urlComponents.URL;
 
   return [[ScriptConfig alloc] initWithScript:scriptId
                                       withURL:url
@@ -47,7 +42,9 @@
 + (ScriptConfig *)fromConfig:(NSDictionary *)config withScriptId:(nonnull NSString *)scriptId
 {
   NSURLComponents *urlComponents = [NSURLComponents componentsWithString:config[@"url"]];
-  urlComponents.query = config[@"query"];
+  if (config[@"query"] != nil) {
+    urlComponents.percentEncodedQuery = config[@"query"];
+  }
   NSURL *url = urlComponents.URL;
 
   return [[ScriptConfig alloc] initWithScript:scriptId

--- a/packages/repack/ios/ScriptManager.mm
+++ b/packages/repack/ios/ScriptManager.mm
@@ -218,18 +218,8 @@ RCT_EXPORT_METHOD(invalidateScripts
   NSURLSessionDataTask *task = [[NSURLSession sharedSession]
       dataTaskWithRequest:request
         completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
-          NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *) response;
-          NSInteger statusCode = [httpResponse statusCode];
           if (error != nil) {
             callback(error);
-          }else if(statusCode < 200 || statusCode >= 300){
-            NSDictionary *userInfo = @{
-                                          NSLocalizedFailureReasonErrorKey: [NSString stringWithFormat:@"Request should have returned with 200 HTTP status, but instead it received %ld", (long)statusCode]
-                                      };
-            NSError *httpError = [NSError errorWithDomain:NSURLErrorDomain
-                                                          code:statusCode
-                                                          userInfo:userInfo];
-            callback(httpError);
           } else {
             @try {
               NSDictionary<NSString *, id> *result = [CodeSigningUtils extractBundleAndTokenWithFileContent:data];

--- a/packages/repack/ios/ScriptManager.mm
+++ b/packages/repack/ios/ScriptManager.mm
@@ -218,8 +218,18 @@ RCT_EXPORT_METHOD(invalidateScripts
   NSURLSessionDataTask *task = [[NSURLSession sharedSession]
       dataTaskWithRequest:request
         completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
+          NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *) response;
+          NSInteger statusCode = [httpResponse statusCode];
           if (error != nil) {
             callback(error);
+          }else if(statusCode < 200 || statusCode >= 300){
+            NSDictionary *userInfo = @{
+                                          NSLocalizedFailureReasonErrorKey: [NSString stringWithFormat:@"Request should have returned with 200 HTTP status, but instead it received %ld", (long)statusCode]
+                                      };
+            NSError *httpError = [NSError errorWithDomain:NSURLErrorDomain
+                                                          code:statusCode
+                                                          userInfo:userInfo];
+            callback(httpError);
           } else {
             @try {
               NSDictionary<NSString *, id> *result = [CodeSigningUtils extractBundleAndTokenWithFileContent:data];


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->
The query object return by ScriptManager's resolver will be encoded in Script.from().
But on iOS side, the query will be encoded again.
This pr will fix this behavior.

### Test plan

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
