### PR TITLE
fix: throw an error when bundle download was unsuccessful on iOS

### DIFF
--- a/.changeset/loud-falcons-prove.md
+++ b/.changeset/loud-falcons-prove.md
@@ -1,0 +1,5 @@
+---
+'@callstack/repack': patch
+---
+
+Fix download bundle error not threw on iOS issue

--- a/packages/repack/ios/ScriptManager.mm
+++ b/packages/repack/ios/ScriptManager.mm
@@ -218,8 +218,18 @@ RCT_EXPORT_METHOD(invalidateScripts
   NSURLSessionDataTask *task = [[NSURLSession sharedSession]
       dataTaskWithRequest:request
         completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
+          NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *)response;
+          NSInteger statusCode = [httpResponse statusCode];
           if (error != nil) {
             callback(error);
+          } else if (statusCode < 200 || statusCode >= 300) {
+            NSDictionary *userInfo = @{
+              NSLocalizedFailureReasonErrorKey : [NSString
+                  stringWithFormat:@"Request should have returned with 200 HTTP status, but instead it received %ld",
+                                   (long)statusCode]
+            };
+            NSError *httpError = [NSError errorWithDomain:NSURLErrorDomain code:statusCode userInfo:userInfo];
+            callback(httpError);
           } else {
             @try {
               NSDictionary<NSString *, id> *result = [CodeSigningUtils extractBundleAndTokenWithFileContent:data];


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->
On iOS ,if download bundle was not successful, throw an error.

### Test plan

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
