### PR TITLE
fix: disable package imports by default

### DIFF
--- a/.changeset/lucky-paws-shop.md
+++ b/.changeset/lucky-paws-shop.md
@@ -1,0 +1,5 @@
+---
+'@callstack/repack': patch
+---
+
+Disable package imports by default

--- a/packages/repack/src/utils/getResolveOptions.ts
+++ b/packages/repack/src/utils/getResolveOptions.ts
@@ -55,6 +55,7 @@ export function getResolveOptions(platform: string, options?: ResolveOptions) {
 
   let conditionNames: string[];
   let exportsFields: string[];
+  let importsFields: string[];
 
   if (enablePackageExports) {
     /**
@@ -78,6 +79,11 @@ export function getResolveOptions(platform: string, options?: ResolveOptions) {
       }
     });
   }
+
+  /**
+   * Disable importsFields completely since it's not supported by metro at all.
+   */
+  importsFields = [];
 
   /**
    * Match what React Native uses from metro-config.
@@ -125,5 +131,9 @@ export function getResolveOptions(platform: string, options?: ResolveOptions) {
      * Reference: Webpack's [configuration.resolve.extensionAlias](https://webpack.js.org/configuration/resolve/#resolveextensionalias)
      */
     extensionAlias: extensionAlias,
+    /**
+     * Reference: Webpack's [configuration.resolve.importsFields](https://webpack.js.org/configuration/resolve/#resolveimportsfields)
+     */
+    importsFields: importsFields,
   };
 }


### PR DESCRIPTION
### Summary

metro doesn't support import fields at all, aligning for compat.

if a user wants to allow for importsFields, they can do so through `resolve.importsFields` and restoring the default value of `['imports']`

### Test plan

n/a
