### PR TITLE
chore: fix ts setup

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -1,7 +1,11 @@
 {
   "$schema": "./node_modules/nx/schemas/nx-schema.json",
   "namedInputs": {
-    "default": ["{projectRoot}/src/**/*"]
+    "default": [
+      "{projectRoot}/**/*",
+      "!{projectRoot}/jest.config.js",
+      "!{projectRoot}/jest.setup.js"
+    ]
   },
   "workspaceLayout": {
     "appsDir": "apps",

--- a/packages/dev-server/tsconfig.json
+++ b/packages/dev-server/tsconfig.json
@@ -13,7 +13,6 @@
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
     "preserveWatchOutput": true,
-    "composite": true,
     "paths": {
       "@react-native/dev-middleware": [
         "./node_modules/@react-native/dev-middleware/dist"

--- a/packages/repack/tsconfig.build.json
+++ b/packages/repack/tsconfig.build.json
@@ -4,7 +4,7 @@
   "exclude": ["**/__tests__/**"],
   "compilerOptions": {
     "outDir": "dist",
-    "rootDir": "src"
-  },
-  "references": [{ "path": "../dev-server" }]
+    "rootDir": "src",
+    "paths": {}
+  }
 }

--- a/packages/repack/tsconfig.json
+++ b/packages/repack/tsconfig.json
@@ -11,7 +11,6 @@
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
     "resolveJsonModule": true,
-    "composite": true,
     "rootDirs": ["src", "../dev-server/src"],
     "paths": {
       "@callstack/repack-dev-server": ["../dev-server/src/index.ts"],


### PR DESCRIPTION
### Summary

removed use of project references for now, `tsconfig.tsbuildinfo` was causing a lot of issues when changing branches (not invalidating properly).

### Test plan

n/a
