### PR TITLE
fix: handle cjs, mjs, mts, cts files in the nested rules

### DIFF
--- a/.changeset/heavy-drinks-heal.md
+++ b/.changeset/heavy-drinks-heal.md
@@ -1,0 +1,5 @@
+---
+"@callstack/repack": patch
+---
+
+Fix handling of cjs,mjs,cts,mts files when transpiling node modules with swc

--- a/packages/repack/src/rules/nodeModulesLoadingRules.ts
+++ b/packages/repack/src/rules/nodeModulesLoadingRules.ts
@@ -21,7 +21,7 @@ export const NODE_MODULES_LOADING_RULES: RuleSetRule = {
   ]),
   rules: [
     {
-      test: /\.jsx?$/,
+      test: /jsx?$/,
       use: [
         {
           loader: 'builtin:swc-loader',
@@ -47,7 +47,7 @@ export const NODE_MODULES_LOADING_RULES: RuleSetRule = {
       ],
     },
     {
-      test: /\.tsx?$/,
+      test: /tsx?$/,
       use: [
         {
           loader: 'builtin:swc-loader',


### PR DESCRIPTION
### Summary

- [x] ensure cjs, mjs, mts, cts files get picked up in node module rules

### Test plan

n/a
