### PR TITLE
fix: peer dep config in repack package

### DIFF
--- a/.changeset/big-wolves-tell.md
+++ b/.changeset/big-wolves-tell.md
@@ -1,0 +1,5 @@
+---
+"@callstack/repack": patch
+---
+
+Fix peer dependency config for @rspack/core in repack package

--- a/packages/repack/package.json
+++ b/packages/repack/package.json
@@ -83,7 +83,7 @@
     "@module-federation/enhanced": ">=0.6.10",
     "@react-native-community/cli": "*",
     "@react-native-community/cli-types": "*",
-    "@rspack/core": "=>1",
+    "@rspack/core": ">=1",
     "@rspack/plugin-react-refresh": ">=1",
     "react-native": ">=0.74",
     "webpack": ">=5.90"


### PR DESCRIPTION
### Summary

- [x] - fix bad specifier for version of `@rspack/core` in `@callstack/repack` package

### Test plan

n/a
