### PR TITLE
feat: add `--config` cli option to commands

### DIFF
--- a/.changeset/clever-timers-decide.md
+++ b/.changeset/clever-timers-decide.md
@@ -1,0 +1,5 @@
+---
+"@callstack/repack": minor
+---
+
+Add `--config` option to commands, deprecate `--webpackConfig` option

--- a/apps/tester-federation-v2/package.json
+++ b/apps/tester-federation-v2/package.json
@@ -5,8 +5,8 @@
   "scripts": {
     "android": "react-native run-android",
     "ios": "react-native run-ios",
-    "start:hostapp": "react-native webpack-start --webpackConfig rspack.config.host-app.mjs",
-    "start:miniapp": "react-native webpack-start --webpackConfig rspack.config.mini-app.mjs --port 8082"
+    "start:hostapp": "react-native webpack-start --config rspack.config.host-app.mjs",
+    "start:miniapp": "react-native webpack-start --config rspack.config.mini-app.mjs --port 8082"
   },
   "dependencies": {
     "@callstack/repack": "workspace:*",

--- a/apps/tester-federation/package.json
+++ b/apps/tester-federation/package.json
@@ -5,15 +5,15 @@
   "scripts": {
     "android": "react-native run-android",
     "ios": "react-native run-ios",
-    "start:hostapp": "react-native webpack-start --webpackConfig rspack.config.host-app.mjs",
-    "start:miniapp": "react-native webpack-start --webpackConfig rspack.config.mini-app.mjs --port 8082",
+    "start:hostapp": "react-native webpack-start --config rspack.config.host-app.mjs",
+    "start:miniapp": "react-native webpack-start --config rspack.config.mini-app.mjs --port 8082",
     "bundle": "pnpm run \"/^bundle:(hostapp|miniapp)$/\"",
     "bundle:hostapp": "pnpm run \"/^bundle:hostapp:(ios|android)$/\"",
     "bundle:miniapp": "pnpm run \"/^bundle:miniapp:(ios|android)$/\"",
-    "bundle:hostapp:android": "react-native webpack-bundle --webpackConfig rspack.config.host-app.mjs --platform android --entry-file index.js --dev=false --bundle-output build/host-app/android/output-local/index.android.bundle --assets-dest build/host-app/android/output-local/res",
-    "bundle:hostapp:ios": "react-native webpack-bundle --webpackConfig rspack.config.host-app.mjs --platform ios --entry-file index.js --dev=false --bundle-output build/host-app/ios/output-local/main.jsbundle --assets-dest build/host-app/ios/output-local",
-    "bundle:miniapp:android": "react-native webpack-bundle --webpackConfig rspack.config.mini-app.mjs --platform android --entry-file index.js --dev=false --bundle-output build/mini-app/android/output-local/index.android.bundle --assets-dest build/mini-app/android/output-local/res",
-    "bundle:miniapp:ios": "react-native webpack-bundle --webpackConfig rspack.config.mini-app.mjs --platform ios --entry-file index.js --dev=false --bundle-output build/mini-app/ios/output-local/main.jsbundle --assets-dest build/mini-app/ios/output-local"
+    "bundle:hostapp:android": "react-native webpack-bundle --config rspack.config.host-app.mjs --platform android --entry-file index.js --dev=false --bundle-output build/host-app/android/output-local/index.android.bundle --assets-dest build/host-app/android/output-local/res",
+    "bundle:hostapp:ios": "react-native webpack-bundle --config rspack.config.host-app.mjs --platform ios --entry-file index.js --dev=false --bundle-output build/host-app/ios/output-local/main.jsbundle --assets-dest build/host-app/ios/output-local",
+    "bundle:miniapp:android": "react-native webpack-bundle --config rspack.config.mini-app.mjs --platform android --entry-file index.js --dev=false --bundle-output build/mini-app/android/output-local/index.android.bundle --assets-dest build/mini-app/android/output-local/res",
+    "bundle:miniapp:ios": "react-native webpack-bundle --config rspack.config.mini-app.mjs --platform ios --entry-file index.js --dev=false --bundle-output build/mini-app/ios/output-local/main.jsbundle --assets-dest build/mini-app/ios/output-local"
   },
   "dependencies": {
     "@callstack/repack": "workspace:*",

--- a/packages/repack/src/commands/options.ts
+++ b/packages/repack/src/commands/options.ts
@@ -158,7 +158,8 @@ export const bundleCommandOptions = [
   },
   {
     name: '--webpackConfig <path>',
-    description: 'Path to a bundler config file, e.g webpack.config.js',
+    description:
+      '[DEPRECATED] Path to a bundler config file, e.g webpack.config.js. Please use --config instead.',
     parse: (val: string) => path.resolve(val),
   },
 ];

--- a/packages/repack/src/commands/options.ts
+++ b/packages/repack/src/commands/options.ts
@@ -68,8 +68,13 @@ export const startCommandOptions = [
     description: 'Enables verbose logging',
   },
   {
+    name: '--config <path>',
+    description: 'Path to a bundler config file, e.g webpack.config.js',
+    parse: (val: string) => path.resolve(val),
+  },
+  {
     name: '--webpackConfig <path>',
-    description: 'Path to a Webpack config',
+    description: 'Path to a bundler config file, e.g webpack.config.js',
     parse: (val: string) => path.resolve(val),
   },
 ];
@@ -147,8 +152,13 @@ export const bundleCommandOptions = [
     description: 'Watch for file changes',
   },
   {
+    name: '--config <path>',
+    description: 'Path to a bundler config file, e.g webpack.config.js',
+    parse: (val: string) => path.resolve(val),
+  },
+  {
     name: '--webpackConfig <path>',
-    description: 'Path to a Webpack config',
+    description: 'Path to a bundler config file, e.g webpack.config.js',
     parse: (val: string) => path.resolve(val),
   },
 ];

--- a/packages/repack/src/commands/rspack/bundle.ts
+++ b/packages/repack/src/commands/rspack/bundle.ts
@@ -30,7 +30,7 @@ export async function bundle(
 ) {
   const rspackConfigPath = getRspackConfigFilePath(
     cliConfig.root,
-    args.webpackConfig
+    args.config ?? args.webpackConfig
   );
 
   const cliOptions: BundleCliOptions = {

--- a/packages/repack/src/commands/rspack/start.ts
+++ b/packages/repack/src/commands/rspack/start.ts
@@ -38,7 +38,7 @@ export async function start(
 ) {
   const rspackConfigPath = getRspackConfigFilePath(
     cliConfig.root,
-    args.webpackConfig
+    args.config ?? args.webpackConfig
   );
   const { reversePort: reversePortArg, ...restArgs } = args;
   const cliOptions: StartCliOptions = {

--- a/packages/repack/src/commands/types.ts
+++ b/packages/repack/src/commands/types.ts
@@ -10,6 +10,7 @@ export interface BundleArguments {
   stats?: string;
   verbose?: boolean;
   watch?: boolean;
+  config?: string;
   webpackConfig?: string;
 }
 
@@ -28,6 +29,7 @@ export interface StartArguments {
   reversePort?: boolean;
   silent?: boolean;
   verbose?: boolean;
+  config?: string;
   webpackConfig?: string;
 }
 

--- a/packages/repack/src/commands/webpack/bundle.ts
+++ b/packages/repack/src/commands/webpack/bundle.ts
@@ -29,7 +29,7 @@ export async function bundle(
 ) {
   const webpackConfigPath = getWebpackConfigFilePath(
     cliConfig.root,
-    args.webpackConfig
+    args.config ?? args.webpackConfig
   );
 
   const cliOptions: BundleCliOptions = {

--- a/packages/repack/src/commands/webpack/start.ts
+++ b/packages/repack/src/commands/webpack/start.ts
@@ -37,7 +37,7 @@ import type { HMRMessageBody } from './types';
 export async function start(_: string[], config: Config, args: StartArguments) {
   const webpackConfigPath = getWebpackConfigFilePath(
     config.root,
-    args.webpackConfig
+    args.config ?? args.webpackConfig
   );
   const { reversePort: reversePortArg, ...restArgs } = args;
   const cliOptions: StartCliOptions = {


### PR DESCRIPTION
### Summary

- [x] - add `--config` option
- [x] - deprecate `--webpackConfig` option
- [x] - use `--config` in testers 

### Test plan

n/a
