### PR TITLE
fix: verbose flag in start command

### DIFF
--- a/.changeset/odd-cars-yawn.md
+++ b/.changeset/odd-cars-yawn.md
@@ -1,0 +1,5 @@
+---
+"@callstack/repack": patch
+---
+
+More intuitive behaviour of `--verbose` flag in start command

--- a/apps/tester-app/ios/Podfile.lock
+++ b/apps/tester-app/ios/Podfile.lock
@@ -1,6 +1,6 @@
 PODS:
   - boost (1.84.0)
-  - callstack-repack (5.0.0-alpha.0):
+  - callstack-repack (5.0.0-rc.0):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -1852,7 +1852,7 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   boost: 1dca942403ed9342f98334bf4c3621f011aa7946
-  callstack-repack: 101158626fc46ba3d24c4b56d81188c12427b49b
+  callstack-repack: 75464b0e26467fc4a7236373399bc0fc2281f495
   DoubleConversion: f16ae600a246532c4020132d54af21d0ddb2a385
   FBLazyVector: 319d66555ce769137a84559a19fb8197733a68e1
   fmt: 10c6e61f4be25dc963c36bd73fc7b1705fe975be

--- a/apps/tester-federation-v2/ios/Podfile.lock
+++ b/apps/tester-federation-v2/ios/Podfile.lock
@@ -1,6 +1,6 @@
 PODS:
   - boost (1.84.0)
-  - callstack-repack (5.0.0-alpha.0):
+  - callstack-repack (5.0.0-rc.0):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -1895,7 +1895,7 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   boost: 1dca942403ed9342f98334bf4c3621f011aa7946
-  callstack-repack: 101158626fc46ba3d24c4b56d81188c12427b49b
+  callstack-repack: 75464b0e26467fc4a7236373399bc0fc2281f495
   DoubleConversion: f16ae600a246532c4020132d54af21d0ddb2a385
   FBLazyVector: 319d66555ce769137a84559a19fb8197733a68e1
   fmt: 10c6e61f4be25dc963c36bd73fc7b1705fe975be

--- a/apps/tester-federation/ios/Podfile.lock
+++ b/apps/tester-federation/ios/Podfile.lock
@@ -1,6 +1,6 @@
 PODS:
   - boost (1.84.0)
-  - callstack-repack (5.0.0-alpha.0):
+  - callstack-repack (5.0.0-rc.0):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -1919,7 +1919,7 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   boost: 1dca942403ed9342f98334bf4c3621f011aa7946
-  callstack-repack: 101158626fc46ba3d24c4b56d81188c12427b49b
+  callstack-repack: 75464b0e26467fc4a7236373399bc0fc2281f495
   DoubleConversion: f16ae600a246532c4020132d54af21d0ddb2a385
   FBLazyVector: 319d66555ce769137a84559a19fb8197733a68e1
   fmt: 10c6e61f4be25dc963c36bd73fc7b1705fe975be

--- a/packages/repack/src/commands/rspack/start.ts
+++ b/packages/repack/src/commands/rspack/start.ts
@@ -57,14 +57,12 @@ export async function start(
   }
 
   const reversePort = reversePortArg ?? process.argv.includes('--reverse-port');
+
   const isSilent = args.silent;
-  const isVerbose = isSilent
-    ? false
-    : // TODO fix (jbroma)
-      // biome-ignore format: fix in a separate PR
-      args.verbose ?? process.argv.includes('--verbose');
+  const isVerbose = args.verbose;
 
   const showHttpRequests = isVerbose || args.logRequests;
+
   const reporter = composeReporters(
     [
       new ConsoleReporter({

--- a/packages/repack/src/commands/rspack/start.ts
+++ b/packages/repack/src/commands/rspack/start.ts
@@ -61,7 +61,7 @@ export async function start(
   const isSilent = args.silent;
   const isVerbose = args.verbose;
 
-  const showHttpRequests = isVerbose || args.logRequests;
+  const showHttpRequests = isSilent ? false : isVerbose || args.logRequests;
 
   const reporter = composeReporters(
     [

--- a/packages/repack/src/commands/webpack/start.ts
+++ b/packages/repack/src/commands/webpack/start.ts
@@ -56,14 +56,12 @@ export async function start(_: string[], config: Config, args: StartArguments) {
   }
 
   const reversePort = reversePortArg ?? process.argv.includes('--reverse-port');
+
   const isSilent = args.silent;
-  const isVerbose = isSilent
-    ? false
-    : // TODO fix in a separate PR (jbroma)
-      // biome-ignore format: fix in a separate PR
-      args.verbose ?? process.argv.includes('--verbose');
+  const isVerbose = args.verbose;
 
   const showHttpRequests = isVerbose || args.logRequests;
+
   const reporter = composeReporters(
     [
       new ConsoleReporter({

--- a/packages/repack/src/commands/webpack/start.ts
+++ b/packages/repack/src/commands/webpack/start.ts
@@ -60,7 +60,7 @@ export async function start(_: string[], config: Config, args: StartArguments) {
   const isSilent = args.silent;
   const isVerbose = args.verbose;
 
-  const showHttpRequests = isVerbose || args.logRequests;
+  const showHttpRequests = isSilent ? false : isVerbose || args.logRequests;
 
   const reporter = composeReporters(
     [


### PR DESCRIPTION
### Summary

addressed the TODO in start commands for the verbose flag:
- [x] - rely only on RNC CLI parsed arg
- [x] - cleaned up logic when interacting with `--silent` flag 

### Test plan

n/a
