### PR TITLE
[BREAKING] refactor: remove `--silent` CLI flag

### DIFF
--- a/.changeset/bright-scissors-kiss.md
+++ b/.changeset/bright-scissors-kiss.md
@@ -1,0 +1,9 @@
+---
+"@callstack/repack": major
+---
+
+Removed `--silent` CLI flag for start command. 
+
+For silencing output, you can use shell redirection instead:
+- Unix/macOS: `npx react-native start > /dev/null 2>&1`
+- Windows: `npx react-native start > nul 2>&1`

--- a/apps/tester-app/__tests__/start.test.ts
+++ b/apps/tester-app/__tests__/start.test.ts
@@ -116,7 +116,6 @@ describe('start command', () => {
           const args = {
             port,
             platform,
-            silent: true,
             logFile: path.join(TMP_DIR, 'server.log'),
             webpackConfig: path.join(__dirname, 'configs', configFile),
           };

--- a/packages/repack/src/commands/common/__tests__/setupInteractions.test.ts
+++ b/packages/repack/src/commands/common/__tests__/setupInteractions.test.ts
@@ -46,7 +46,14 @@ describe('setupInteractions', () => {
   it('should log a warning if setRawMode is not available', () => {
     mockProcess.stdin.setRawMode = undefined as any;
 
-    setupInteractions({}, mockLogger, mockProcess, mockReadline);
+    setupInteractions(
+      {},
+      {
+        logger: mockLogger,
+        process: mockProcess,
+        readline: mockReadline,
+      }
+    );
 
     expect(mockLogger.warn).toHaveBeenCalledWith(
       'Interactive mode is not supported in this environment'
@@ -54,7 +61,14 @@ describe('setupInteractions', () => {
   });
 
   it('should set up keypress events and interactions', () => {
-    setupInteractions({}, mockLogger, mockProcess, mockReadline);
+    setupInteractions(
+      {},
+      {
+        logger: mockLogger,
+        process: mockProcess,
+        readline: mockReadline,
+      }
+    );
 
     expect(mockReadline.emitKeypressEvents).toHaveBeenCalledWith(
       mockProcess.stdin
@@ -67,7 +81,14 @@ describe('setupInteractions', () => {
   });
 
   it('should handle ctrl+c and ctrl+z keypresses', () => {
-    setupInteractions({}, mockLogger, mockProcess, mockReadline);
+    setupInteractions(
+      {},
+      {
+        logger: mockLogger,
+        process: mockProcess,
+        readline: mockReadline,
+      }
+    );
 
     const keypressHandler = (mockProcess.stdin.on as jest.Mock).mock
       .calls[0][1];
@@ -86,7 +107,11 @@ describe('setupInteractions', () => {
       onOpenDevTools: jest.fn(),
     };
 
-    setupInteractions(handlers, mockLogger, mockProcess, mockReadline);
+    setupInteractions(handlers, {
+      logger: mockLogger,
+      process: mockProcess,
+      readline: mockReadline,
+    });
 
     const keypressHandler = (mockProcess.stdin.on as jest.Mock).mock
       .calls[0][1];
@@ -109,7 +134,11 @@ describe('setupInteractions', () => {
       onReload: jest.fn(),
     };
 
-    setupInteractions(handlers, mockLogger, mockProcess, mockReadline);
+    setupInteractions(handlers, {
+      logger: mockLogger,
+      process: mockProcess,
+      readline: mockReadline,
+    });
 
     expect(mockProcess.stdout.write).toHaveBeenCalledWith(' r: Reload app\n');
     expect(mockProcess.stdout.write).toHaveBeenCalledWith(
@@ -132,7 +161,11 @@ describe('setupInteractions', () => {
       // onOpenDevMenu - unsupported
     };
 
-    setupInteractions(handlers, mockLogger, mockProcess, mockReadline);
+    setupInteractions(handlers, {
+      logger: mockLogger,
+      process: mockProcess,
+      readline: mockReadline,
+    });
 
     const keypressHandler = (mockProcess.stdin.on as jest.Mock).mock
       .calls[0][1];
@@ -164,7 +197,11 @@ describe('setupInteractions', () => {
       onOpenDevTools: jest.fn(),
     };
 
-    setupInteractions(handlers, mockLogger, mockProcess, mockReadline);
+    setupInteractions(handlers, {
+      logger: mockLogger,
+      process: mockProcess,
+      readline: mockReadline,
+    });
 
     const keypressHandler = (mockProcess.stdin.on as jest.Mock).mock
       .calls[0][1];
@@ -179,7 +216,11 @@ describe('setupInteractions', () => {
       onOpenDevTools: jest.fn(),
     };
 
-    setupInteractions(handlers, mockLogger, mockProcess, mockReadline);
+    setupInteractions(handlers, {
+      logger: mockLogger,
+      process: mockProcess,
+      readline: mockReadline,
+    });
 
     const keypressHandler = (mockProcess.stdin.on as jest.Mock).mock
       .calls[0][1];
@@ -199,9 +240,11 @@ describe('setupInteractions', () => {
             onOpenDevMenu() {},
             onReload() {},
           },
-          mockLogger,
-          mockProcess,
-          mockReadline
+          {
+            logger: mockLogger,
+            process: mockProcess,
+            readline: mockReadline,
+          }
         );
 
         expect(mockProcess.stdout.write).toHaveBeenNthCalledWith(

--- a/packages/repack/src/commands/common/setupInteractions.ts
+++ b/packages/repack/src/commands/common/setupInteractions.ts
@@ -1,4 +1,4 @@
-import defaultReadline from 'node:readline';
+import nodeReadline from 'node:readline';
 import * as colorette from 'colorette';
 import type { Logger } from '../../types';
 
@@ -22,10 +22,19 @@ export function setupInteractions(
     onOpenDevMenu?: () => void;
     onOpenDevTools?: () => void;
   },
-  logger: Logger = console,
-  process: NodeJS.Process = global.process,
-  readline: typeof defaultReadline = defaultReadline
+  options?: {
+    logger?: Logger;
+    process?: NodeJS.Process;
+    readline?: typeof nodeReadline;
+    silent?: boolean;
+  }
 ) {
+  const logger = options?.logger ?? console;
+  const process = options?.process ?? global.process;
+  const readline = options?.readline ?? nodeReadline;
+  // silent option is only needed for sync logs done through process.stdout.write
+  const silent = options?.silent ?? false;
+
   if (!process.stdin.setRawMode) {
     logger.warn('Interactive mode is not supported in this environment');
     return;
@@ -88,15 +97,16 @@ export function setupInteractions(
     },
   };
 
-  // use process.stdout for sync output at startup
-  for (const [key, interaction] of Object.entries(plainInteractions)) {
-    const isSupported =
-      interaction?.actionUnsupportedExplanation === undefined &&
-      interaction?.action !== undefined;
-    const text = ` ${colorette.bold(key)}: ${interaction?.helpName}${isSupported ? '' : colorette.yellow(` (unsupported${interaction?.actionUnsupportedExplanation ? `, ${interaction.actionUnsupportedExplanation}` : ' by the current bundler'})`)}\n`;
+  if (!silent) {
+    // use process.stdout for sync output at startup
+    for (const [key, interaction] of Object.entries(plainInteractions)) {
+      const isSupported =
+        interaction?.actionUnsupportedExplanation === undefined &&
+        interaction?.action !== undefined;
+      const text = ` ${colorette.bold(key)}: ${interaction?.helpName}${isSupported ? '' : colorette.yellow(` (unsupported${interaction?.actionUnsupportedExplanation ? `, ${interaction.actionUnsupportedExplanation}` : ' by the current bundler'})`)}\n`;
 
-    process.stdout.write(isSupported ? text : colorette.italic(text));
+      process.stdout.write(isSupported ? text : colorette.italic(text));
+    }
+    process.stdout.write('\nPress Ctrl+c or Ctrl+z to quit the dev server\n\n');
   }
-
-  process.stdout.write('\nPress Ctrl+c or Ctrl+z to quit the dev server\n\n');
 }

--- a/packages/repack/src/commands/common/setupInteractions.ts
+++ b/packages/repack/src/commands/common/setupInteractions.ts
@@ -26,14 +26,11 @@ export function setupInteractions(
     logger?: Logger;
     process?: NodeJS.Process;
     readline?: typeof nodeReadline;
-    silent?: boolean;
   }
 ) {
   const logger = options?.logger ?? console;
   const process = options?.process ?? global.process;
   const readline = options?.readline ?? nodeReadline;
-  // silent option is only needed for sync logs done through process.stdout.write
-  const silent = options?.silent ?? false;
 
   if (!process.stdin.setRawMode) {
     logger.warn('Interactive mode is not supported in this environment');
@@ -97,16 +94,14 @@ export function setupInteractions(
     },
   };
 
-  if (!silent) {
-    // use process.stdout for sync output at startup
-    for (const [key, interaction] of Object.entries(plainInteractions)) {
-      const isSupported =
-        interaction?.actionUnsupportedExplanation === undefined &&
-        interaction?.action !== undefined;
-      const text = ` ${colorette.bold(key)}: ${interaction?.helpName}${isSupported ? '' : colorette.yellow(` (unsupported${interaction?.actionUnsupportedExplanation ? `, ${interaction.actionUnsupportedExplanation}` : ' by the current bundler'})`)}\n`;
+  // use process.stdout for sync output at startup
+  for (const [key, interaction] of Object.entries(plainInteractions)) {
+    const isSupported =
+      interaction?.actionUnsupportedExplanation === undefined &&
+      interaction?.action !== undefined;
+    const text = ` ${colorette.bold(key)}: ${interaction?.helpName}${isSupported ? '' : colorette.yellow(` (unsupported${interaction?.actionUnsupportedExplanation ? `, ${interaction.actionUnsupportedExplanation}` : ' by the current bundler'})`)}\n`;
 
-      process.stdout.write(isSupported ? text : colorette.italic(text));
-    }
-    process.stdout.write('\nPress Ctrl+c or Ctrl+z to quit the dev server\n\n');
+    process.stdout.write(isSupported ? text : colorette.italic(text));
   }
+  process.stdout.write('\nPress Ctrl+c or Ctrl+z to quit the dev server\n\n');
 }

--- a/packages/repack/src/commands/options.ts
+++ b/packages/repack/src/commands/options.ts
@@ -60,10 +60,6 @@ export const startCommandOptions = [
     description: 'ADB reverse port on starting devServers only for Android',
   },
   {
-    name: '--silent',
-    description: 'Silents all logs to the console/stdout',
-  },
-  {
     name: '--verbose',
     description: 'Enables verbose logging',
   },

--- a/packages/repack/src/commands/rspack/start.ts
+++ b/packages/repack/src/commands/rspack/start.ts
@@ -58,27 +58,20 @@ export async function start(
 
   const reversePort = reversePortArg ?? process.argv.includes('--reverse-port');
 
-  const isSilent = args.silent;
   const isVerbose = args.verbose;
-
-  const showHttpRequests = isSilent ? false : isVerbose || args.logRequests;
+  const showHttpRequests = isVerbose || args.logRequests;
 
   const reporter = composeReporters(
     [
-      new ConsoleReporter({
-        asJson: args.json,
-        level: isSilent ? 'silent' : isVerbose ? 'verbose' : 'normal',
-      }),
+      new ConsoleReporter({ asJson: args.json, isVerbose }),
       args.logFile ? new FileReporter({ filename: args.logFile }) : undefined,
     ].filter(Boolean) as Reporter[]
   );
 
-  if (!isSilent) {
-    const version = packageJson.version;
-    process.stdout.write(
-      colorette.bold(colorette.cyan('📦 Re.Pack ' + version + '\n\n'))
-    );
-  }
+  const version = packageJson.version;
+  process.stdout.write(
+    colorette.bold(colorette.cyan('📦 Re.Pack ' + version + '\n\n'))
+  );
 
   // @ts-ignore
   const compiler = new Compiler(cliOptions, reporter);
@@ -119,7 +112,7 @@ export async function start(
               });
             },
           },
-          { logger: ctx.log, silent: isSilent }
+          { logger: ctx.log }
         );
       }
 

--- a/packages/repack/src/commands/rspack/start.ts
+++ b/packages/repack/src/commands/rspack/start.ts
@@ -119,7 +119,7 @@ export async function start(
               });
             },
           },
-          ctx.log
+          { logger: ctx.log, silent: isSilent }
         );
       }
 

--- a/packages/repack/src/commands/types.ts
+++ b/packages/repack/src/commands/types.ts
@@ -27,7 +27,6 @@ export interface StartArguments {
   logRequests?: boolean;
   platform?: string;
   reversePort?: boolean;
-  silent?: boolean;
   verbose?: boolean;
   config?: string;
   webpackConfig?: string;

--- a/packages/repack/src/commands/webpack/start.ts
+++ b/packages/repack/src/commands/webpack/start.ts
@@ -57,27 +57,20 @@ export async function start(_: string[], config: Config, args: StartArguments) {
 
   const reversePort = reversePortArg ?? process.argv.includes('--reverse-port');
 
-  const isSilent = args.silent;
   const isVerbose = args.verbose;
-
-  const showHttpRequests = isSilent ? false : isVerbose || args.logRequests;
+  const showHttpRequests = isVerbose || args.logRequests;
 
   const reporter = composeReporters(
     [
-      new ConsoleReporter({
-        asJson: args.json,
-        level: isSilent ? 'silent' : isVerbose ? 'verbose' : 'normal',
-      }),
+      new ConsoleReporter({ asJson: args.json, isVerbose }),
       args.logFile ? new FileReporter({ filename: args.logFile }) : undefined,
     ].filter(Boolean) as Reporter[]
   );
 
-  if (!isSilent) {
-    const version = packageJson.version;
-    process.stdout.write(
-      colorette.bold(colorette.cyan('📦 Re.Pack ' + version + '\n\n'))
-    );
-  }
+  const version = packageJson.version;
+  process.stdout.write(
+    colorette.bold(colorette.cyan('📦 Re.Pack ' + version + '\n\n'))
+  );
 
   const compiler = new Compiler(cliOptions, reporter, isVerbose);
 
@@ -118,7 +111,7 @@ export async function start(_: string[], config: Config, args: StartArguments) {
               });
             },
           },
-          { logger: ctx.log, silent: isSilent }
+          { logger: ctx.log }
         );
       }
 

--- a/packages/repack/src/commands/webpack/start.ts
+++ b/packages/repack/src/commands/webpack/start.ts
@@ -118,7 +118,7 @@ export async function start(_: string[], config: Config, args: StartArguments) {
               });
             },
           },
-          ctx.log
+          { logger: ctx.log, silent: isSilent }
         );
       }
 

--- a/packages/repack/src/logging/reporters/ConsoleReporter.ts
+++ b/packages/repack/src/logging/reporters/ConsoleReporter.ts
@@ -5,7 +5,7 @@ import type { LogEntry, LogType, Reporter } from '../types';
 
 export interface ConsoleReporterConfig {
   asJson?: boolean;
-  level?: 'silent' | 'normal' | 'verbose';
+  isVerbose?: boolean;
   isWorker?: boolean;
 }
 
@@ -77,13 +77,8 @@ class InteractiveConsoleReporter implements Reporter {
   constructor(private config: ConsoleReporterConfig) {}
 
   process(log: LogEntry) {
-    // Do not log anything in silent mode
-    if (this.config.level === 'silent') {
-      return;
-    }
-
     // Do not log debug messages in non-verbose mode
-    if (log.type === 'debug' && this.config.level !== 'verbose') {
+    if (log.type === 'debug' && !this.config.isVerbose) {
       return;
     }
 

--- a/packages/repack/src/plugins/LoggerPlugin.ts
+++ b/packages/repack/src/plugins/LoggerPlugin.ts
@@ -63,7 +63,7 @@ export class LoggerPlugin implements RspackPluginInstance {
       reporters.push(
         new ConsoleReporter({
           isWorker: Boolean(process.env[WORKER_ENV_KEY]),
-          level: process.env[VERBOSE_ENV_KEY] ? 'verbose' : 'normal',
+          isVerbose: Boolean(process.env[VERBOSE_ENV_KEY]),
         })
       );
     }


### PR DESCRIPTION
### Summary

removed `--silent` flag since it's handling is problematic, and it's much easier to achieve the desired result through stream redirection in the shell i.e. 

```bash
npx react-native start > /dev/null
```

### Test plan

n/a
