### PR TITLE
refactor: unify handling of `--verbose` flag in both commands

### DIFF
--- a/packages/repack/src/commands/rspack/bundle.ts
+++ b/packages/repack/src/commands/rspack/bundle.ts
@@ -48,7 +48,7 @@ export async function bundle(
     throw new Error("Option '--entry-file <path>' argument is missing");
   }
 
-  if (args.verbose ?? process.argv.includes('--verbose')) {
+  if (args.verbose) {
     process.env[VERBOSE_ENV_KEY] = '1';
   }
 

--- a/packages/repack/src/commands/rspack/start.ts
+++ b/packages/repack/src/commands/rspack/start.ts
@@ -40,7 +40,7 @@ export async function start(
     cliConfig.root,
     args.config ?? args.webpackConfig
   );
-  const { reversePort: reversePortArg, ...restArgs } = args;
+  const { reversePort, ...restArgs } = args;
   const cliOptions: StartCliOptions = {
     config: {
       root: cliConfig.root,
@@ -55,8 +55,6 @@ export async function start(
   if (args.platform && !cliOptions.config.platforms.includes(args.platform)) {
     throw new Error('Unrecognized platform: ' + args.platform);
   }
-
-  const reversePort = reversePortArg ?? process.argv.includes('--reverse-port');
 
   const isVerbose = args.verbose;
   const showHttpRequests = isVerbose || args.logRequests;

--- a/packages/repack/src/commands/rspack/start.ts
+++ b/packages/repack/src/commands/rspack/start.ts
@@ -1,6 +1,7 @@
 import type { Config } from '@react-native-community/cli-types';
 import * as colorette from 'colorette';
 import packageJson from '../../../package.json';
+import { VERBOSE_ENV_KEY } from '../../env';
 import {
   ConsoleReporter,
   FileReporter,
@@ -56,12 +57,13 @@ export async function start(
     throw new Error('Unrecognized platform: ' + args.platform);
   }
 
-  const isVerbose = args.verbose;
-  const showHttpRequests = isVerbose || args.logRequests;
+  if (args.verbose) {
+    process.env[VERBOSE_ENV_KEY] = '1';
+  }
 
   const reporter = composeReporters(
     [
-      new ConsoleReporter({ asJson: args.json, isVerbose }),
+      new ConsoleReporter({ asJson: args.json, isVerbose: args.verbose }),
       args.logFile ? new FileReporter({ filename: args.logFile }) : undefined,
     ].filter(Boolean) as Reporter[]
   );
@@ -77,6 +79,8 @@ export async function start(
   const serverHost = args.host || DEFAULT_HOSTNAME;
   const serverPort = args.port ?? DEFAULT_PORT;
   const serverURL = `${args.https === true ? 'https' : 'http'}://${serverHost}:${serverPort}`;
+  const showHttpRequests = args.verbose || args.logRequests;
+
   const { createServer } = await import('@callstack/repack-dev-server');
   const { start, stop } = await createServer({
     options: {

--- a/packages/repack/src/commands/webpack/Compiler.ts
+++ b/packages/repack/src/commands/webpack/Compiler.ts
@@ -4,7 +4,7 @@ import path from 'node:path';
 import { Worker } from 'node:worker_threads';
 import type { SendProgress } from '@callstack/repack-dev-server';
 import type webpack from 'webpack';
-import { VERBOSE_ENV_KEY, WORKER_ENV_KEY } from '../../env';
+import { WORKER_ENV_KEY } from '../../env';
 import type { LogType, Reporter } from '../../logging';
 import { DEV_SERVER_ASSET_TYPES } from '../consts';
 import type { CliOptions } from '../types';
@@ -26,8 +26,7 @@ export class Compiler extends EventEmitter {
 
   constructor(
     private cliOptions: CliOptions,
-    private reporter: Reporter,
-    private isVerbose?: boolean
+    private reporter: Reporter
   ) {
     super();
   }
@@ -46,7 +45,6 @@ export class Compiler extends EventEmitter {
       env: {
         ...process.env,
         [WORKER_ENV_KEY]: '1',
-        [VERBOSE_ENV_KEY]: this.isVerbose ? '1' : undefined,
       },
       workerData,
     });

--- a/packages/repack/src/commands/webpack/bundle.ts
+++ b/packages/repack/src/commands/webpack/bundle.ts
@@ -47,7 +47,7 @@ export async function bundle(
     throw new Error("Option '--entry-file <path>' argument is missing");
   }
 
-  if (args.verbose ?? process.argv.includes('--verbose')) {
+  if (args.verbose) {
     process.env[VERBOSE_ENV_KEY] = '1';
   }
 

--- a/packages/repack/src/commands/webpack/start.ts
+++ b/packages/repack/src/commands/webpack/start.ts
@@ -39,7 +39,7 @@ export async function start(_: string[], config: Config, args: StartArguments) {
     config.root,
     args.config ?? args.webpackConfig
   );
-  const { reversePort: reversePortArg, ...restArgs } = args;
+  const { reversePort, ...restArgs } = args;
   const cliOptions: StartCliOptions = {
     config: {
       root: config.root,
@@ -54,8 +54,6 @@ export async function start(_: string[], config: Config, args: StartArguments) {
   if (args.platform && !cliOptions.config.platforms.includes(args.platform)) {
     throw new Error('Unrecognized platform: ' + args.platform);
   }
-
-  const reversePort = reversePortArg ?? process.argv.includes('--reverse-port');
 
   const isVerbose = args.verbose;
   const showHttpRequests = isVerbose || args.logRequests;

--- a/packages/repack/src/commands/webpack/start.ts
+++ b/packages/repack/src/commands/webpack/start.ts
@@ -3,6 +3,7 @@ import type { Config } from '@react-native-community/cli-types';
 import * as colorette from 'colorette';
 import type webpack from 'webpack';
 import packageJson from '../../../package.json';
+import { VERBOSE_ENV_KEY } from '../../env';
 import {
   ConsoleReporter,
   FileReporter,
@@ -55,12 +56,13 @@ export async function start(_: string[], config: Config, args: StartArguments) {
     throw new Error('Unrecognized platform: ' + args.platform);
   }
 
-  const isVerbose = args.verbose;
-  const showHttpRequests = isVerbose || args.logRequests;
+  if (args.verbose) {
+    process.env[VERBOSE_ENV_KEY] = '1';
+  }
 
   const reporter = composeReporters(
     [
-      new ConsoleReporter({ asJson: args.json, isVerbose }),
+      new ConsoleReporter({ asJson: args.json, isVerbose: args.verbose }),
       args.logFile ? new FileReporter({ filename: args.logFile }) : undefined,
     ].filter(Boolean) as Reporter[]
   );
@@ -70,11 +72,12 @@ export async function start(_: string[], config: Config, args: StartArguments) {
     colorette.bold(colorette.cyan('📦 Re.Pack ' + version + '\n\n'))
   );
 
-  const compiler = new Compiler(cliOptions, reporter, isVerbose);
+  const compiler = new Compiler(cliOptions, reporter);
 
   const serverHost = args.host || DEFAULT_HOSTNAME;
   const serverPort = args.port ?? DEFAULT_PORT;
   const serverURL = `${args.https === true ? 'https' : 'http'}://${serverHost}:${serverPort}`;
+  const showHttpRequests = args.verbose || args.logRequests;
 
   const { createServer } = await import('@callstack/repack-dev-server');
   const { start, stop } = await createServer({

--- a/packages/repack/src/plugins/LoggerPlugin.ts
+++ b/packages/repack/src/plugins/LoggerPlugin.ts
@@ -58,12 +58,16 @@ export class LoggerPlugin implements RspackPluginInstance {
       this.config.output = { console: true };
     }
 
+    const isTruthyEnv = (env: string | undefined) => {
+      return !!env && env !== 'false' && env !== '0';
+    };
+
     const reporters = [];
     if (this.config.output.console) {
       reporters.push(
         new ConsoleReporter({
-          isWorker: Boolean(process.env[WORKER_ENV_KEY]),
-          isVerbose: Boolean(process.env[VERBOSE_ENV_KEY]),
+          isWorker: isTruthyEnv(process.env[WORKER_ENV_KEY]),
+          isVerbose: isTruthyEnv(process.env[VERBOSE_ENV_KEY]),
         })
       );
     }


### PR DESCRIPTION
### Summary

- [x] - unified how `verbose` arg is handled in both start and bundle commands
- [x] - check for `false` and `0` when asserting value of `verbose` flag

### Test plan

n/a
