### PR TITLE
feat: add react-native-linear-gradient

### DIFF
--- a/packages/repack/src/rules/flowTypedModulesLoadingRules.ts
+++ b/packages/repack/src/rules/flowTypedModulesLoadingRules.ts
@@ -19,6 +19,7 @@ export const FLOW_TYPED_MODULES_LOADING_RULES: RuleSetRule = {
     'react-native-performance',
     'react-native-vector-icons',
     '@react-native-community/datetimepicker',
+    'react-native-linear-gradient'
   ]),
   use: {
     loader: '@callstack/repack/flow-loader',


### PR DESCRIPTION

### Summary

- add `react-native-linear-gradient` to flow type modules
- 
### Test plan

`npm install react-native-linear-gradient` and use it in example apps