### PR TITLE
fix: source-map matching in React Native DevTools

### DIFF
--- a/.changeset/cold-apes-swim.md
+++ b/.changeset/cold-apes-swim.md
@@ -1,0 +1,5 @@
+---
+"@callstack/repack": patch
+---
+
+Fix sourceURL of bundles so source maps can be matched in dev tools

--- a/apps/tester-app/rspack.config.mjs
+++ b/apps/tester-app/rspack.config.mjs
@@ -43,6 +43,7 @@ export default (env) => {
       filename: 'index.bundle',
       chunkFilename: '[name].chunk.bundle',
       publicPath: Repack.getPublicPath({ platform, devServer }),
+      uniqueName: 'tester-app',
     },
     optimization: {
       minimize,

--- a/apps/tester-app/webpack.config.mjs
+++ b/apps/tester-app/webpack.config.mjs
@@ -56,6 +56,7 @@ export default (env) => {
       filename: 'index.bundle',
       chunkFilename: '[name].chunk.bundle',
       publicPath: Repack.getPublicPath({ platform, devServer }),
+      uniqueName: 'tester-app',
     },
     optimization: {
       minimize,

--- a/apps/tester-federation-v2/rspack.config.host-app.mjs
+++ b/apps/tester-federation-v2/rspack.config.host-app.mjs
@@ -42,7 +42,7 @@ export default (env) => {
       filename: 'index.bundle',
       chunkFilename: '[name].chunk.bundle',
       publicPath: Repack.getPublicPath({ platform, devServer }),
-      uniqueName: 'MF2-HostApp',
+      uniqueName: 'MF2Tester-HostApp',
     },
     optimization: {
       minimize,

--- a/apps/tester-federation-v2/rspack.config.mini-app.mjs
+++ b/apps/tester-federation-v2/rspack.config.mini-app.mjs
@@ -39,7 +39,7 @@ export default (env) => {
       filename: 'index.bundle',
       chunkFilename: '[name].chunk.bundle',
       publicPath: Repack.getPublicPath({ platform, devServer }),
-      uniqueName: 'MF2-MiniApp',
+      uniqueName: 'MF2Tester-MiniApp',
     },
     optimization: {
       minimize,

--- a/apps/tester-federation-v2/webpack.config.host-app.mjs
+++ b/apps/tester-federation-v2/webpack.config.host-app.mjs
@@ -42,7 +42,7 @@ export default (env) => {
       filename: 'index.bundle',
       chunkFilename: '[name].chunk.bundle',
       publicPath: Repack.getPublicPath({ platform, devServer }),
-      uniqueName: 'MFTester-HostApp',
+      uniqueName: 'MF2Tester-HostApp',
     },
     optimization: {
       minimize,

--- a/apps/tester-federation-v2/webpack.config.mini-app.mjs
+++ b/apps/tester-federation-v2/webpack.config.mini-app.mjs
@@ -36,7 +36,7 @@ export default (env) => {
       filename: 'index.bundle',
       chunkFilename: '[name].chunk.bundle',
       publicPath: Repack.getPublicPath({ platform, devServer }),
-      uniqueName: 'MFTester-MiniApp',
+      uniqueName: 'MF2Tester-MiniApp',
     },
     optimization: {
       minimize,

--- a/packages/repack/android/src/main/java/com/callstack/repack/FileSystemScriptLoader.kt
+++ b/packages/repack/android/src/main/java/com/callstack/repack/FileSystemScriptLoader.kt
@@ -12,12 +12,12 @@ class FileSystemScriptLoader(private val reactContext: ReactContext, private val
                 val path = config.url.path
                 val file = File(path)
                 val code: ByteArray = FileInputStream(file).use { it.readBytes() }
-                nativeLoader.evaluate(code, config.uniqueId, promise)
+                nativeLoader.evaluate(code, config.sourceUrl, promise)
             } else {
                 val assetName = config.url.file.split("/").last()
                 val inputStream = reactContext.assets.open(assetName)
                 val code: ByteArray = inputStream.use { it.readBytes() }
-                nativeLoader.evaluate(code, config.uniqueId, promise)
+                nativeLoader.evaluate(code, config.sourceUrl, promise)
             }
         } catch (error: Exception) {
             promise.reject(

--- a/packages/repack/android/src/main/java/com/callstack/repack/RemoteScriptLoader.kt
+++ b/packages/repack/android/src/main/java/com/callstack/repack/RemoteScriptLoader.kt
@@ -107,7 +107,7 @@ class RemoteScriptLoader(val reactContext: ReactContext, private val nativeLoade
                 throw Exception("Script file exists but could not be read: $file")
             }
 
-            nativeLoader.evaluate(code, config.uniqueId, promise)
+            nativeLoader.evaluate(code, config.sourceUrl, promise)
         } catch (error: Exception) {
             promise.reject(
                     ScriptLoadingError.ScriptEvalFailure.code,

--- a/packages/repack/android/src/main/java/com/callstack/repack/ScriptConfig.kt
+++ b/packages/repack/android/src/main/java/com/callstack/repack/ScriptConfig.kt
@@ -8,17 +8,18 @@ import okhttp3.RequestBody.Companion.toRequestBody
 import java.net.URL
 
 data class ScriptConfig(
-        val scriptId: String,
-        val url: URL,
-        val query: String?,
-        val fetch: Boolean,
-        val absolute: Boolean,
-        val method: String,
-        val body: RequestBody?,
-        val timeout: Int,
-        val headers: Headers,
-        val verifyScriptSignature: String,
-        val uniqueId: String
+    val scriptId: String,
+    val url: URL,
+    val query: String?,
+    val fetch: Boolean,
+    val absolute: Boolean,
+    val method: String,
+    val body: RequestBody?,
+    val timeout: Int,
+    val headers: Headers,
+    val verifyScriptSignature: String,
+    val uniqueId: String,
+    val sourceUrl: String
 ) {
     companion object {
         fun fromReadableMap(scriptId: String, value: ReadableMap): ScriptConfig {
@@ -40,6 +41,8 @@ data class ScriptConfig(
                         urlString
                     }
             )
+
+            val sourceUrl = URL(urlString).toString()
 
             val headers = Headers.Builder()
             val keyIterator = headersMap?.keySetIterator()
@@ -65,7 +68,8 @@ data class ScriptConfig(
                     timeout,
                     headers.build(),
                     verifyScriptSignature,
-                    uniqueId
+                    uniqueId,
+                    sourceUrl
             )
         }
     }

--- a/packages/repack/android/src/main/java/com/callstack/repack/ScriptConfig.kt
+++ b/packages/repack/android/src/main/java/com/callstack/repack/ScriptConfig.kt
@@ -36,24 +36,24 @@ data class ScriptConfig(
             val uniqueId = requireNotNull(value.getString("uniqueId"))
 
             val initialUrl = URL(urlString)
-            val initialUri = initialUrl.toURI()
+            val uri = initialUrl.toURI()
 
             val sourceUrl = initialUrl.toString()
 
             // overrides any existing query in the URL with config.query
-            val uri = if (query != null) {
+            val finalUri = if (query != null) {
                 URI(
-                    initialUri.scheme,
-                    initialUri.authority,
-                    initialUri.path,
+                    uri.scheme,
+                    uri.authority,
+                    uri.path,
                     query,
-                    initialUri.fragment
+                    uri.fragment
                 )
             } else {
-                initialUri
+                uri
             }
 
-            val url = uri.toURL()
+            val url = finalUri.toURL()
 
             val headers = Headers.Builder()
             val keyIterator = headersMap?.keySetIterator()

--- a/packages/repack/ios/ScriptConfig.h
+++ b/packages/repack/ios/ScriptConfig.h
@@ -20,6 +20,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (readonly) NSNumber *timeout;
 @property (readonly) NSString *verifyScriptSignature;
 @property (readonly) NSString *uniqueId;
+@property (readonly) NSString *sourceUrl;
 
 #ifdef RCT_NEW_ARCH_ENABLED
 + (ScriptConfig *)fromConfig:(JS::NativeScriptManager::NormalizedScriptLocator &)config
@@ -38,7 +39,8 @@ NS_ASSUME_NONNULL_BEGIN
                         withBody:(nullable NSData *)body
                      withTimeout:(NSNumber *)timeout
        withVerifyScriptSignature:(NSString *)verifyScriptSignature
-                    withUniqueId:(NSString *)uniqueId;
+                    withUniqueId:(NSString *)uniqueId
+                   withSourceUrl:(NSString *)sourceUrl;
 
 NS_ASSUME_NONNULL_END
 

--- a/packages/repack/ios/ScriptConfig.mm
+++ b/packages/repack/ios/ScriptConfig.mm
@@ -21,14 +21,16 @@
                 withScriptId:(nonnull NSString *)scriptId
 {
   NSDictionary *_Nullable headers = (NSDictionary *)config.headers();
+  
   NSURLComponents *urlComponents = [NSURLComponents componentsWithString:config.url()];
+  NSString *sourceUrl = urlComponents.URL.absoluteString;
+    
+  // overrides any existing query in the URL with config.query
   if (config.query() != nil) {
     urlComponents.percentEncodedQuery = config.query();
   }
+    
   NSURL *url = urlComponents.URL;
-
-  urlComponents.query = nil;
-  NSString *sourceUrl = urlComponents.URL.absoluteString;
 
   return [[ScriptConfig alloc] initWithScript:scriptId
                                       withURL:url

--- a/packages/repack/ios/ScriptConfig.mm
+++ b/packages/repack/ios/ScriptConfig.mm
@@ -14,6 +14,7 @@
 @synthesize timeout = _timeout;
 @synthesize verifyScriptSignature = _verifyScriptSignature;
 @synthesize uniqueId = _uniqueId;
+@synthesize sourceUrl = _sourceUrl;
 
 #ifdef RCT_NEW_ARCH_ENABLED
 + (ScriptConfig *)fromConfig:(JS::NativeScriptManager::NormalizedScriptLocator &)config
@@ -26,6 +27,9 @@
   }
   NSURL *url = urlComponents.URL;
 
+  urlComponents.query = nil;
+  NSString *sourceUrl = urlComponents.URL.absoluteString;
+
   return [[ScriptConfig alloc] initWithScript:scriptId
                                       withURL:url
                                    withMethod:config.method()
@@ -36,7 +40,8 @@
                                      withBody:[config.body() dataUsingEncoding:NSUTF8StringEncoding]
                                   withTimeout:[NSNumber numberWithDouble:config.timeout()]
                     withVerifyScriptSignature:config.verifyScriptSignature()
-                                 withUniqueId:config.uniqueId()];
+                                 withUniqueId:config.uniqueId()
+                                withSourceUrl:sourceUrl];
 }
 #else
 + (ScriptConfig *)fromConfig:(NSDictionary *)config withScriptId:(nonnull NSString *)scriptId
@@ -46,6 +51,9 @@
     urlComponents.percentEncodedQuery = config[@"query"];
   }
   NSURL *url = urlComponents.URL;
+
+  urlComponents.query = nil;
+  NSString *sourceUrl = urlComponents.URL.absoluteString;
 
   return [[ScriptConfig alloc] initWithScript:scriptId
                                       withURL:url
@@ -57,7 +65,8 @@
                                      withBody:[config[@"body"] dataUsingEncoding:NSUTF8StringEncoding]
                                   withTimeout:config[@"timeout"]
                     withVerifyScriptSignature:config[@"verifyScriptSignature"]
-                                 withUniqueId:config[@"uniqueId"]];
+                                 withUniqueId:config[@"uniqueId"]
+                                withSourceUrl:sourceUrl];
 }
 #endif
 
@@ -80,6 +89,7 @@
                      withTimeout:(nonnull NSNumber *)timeout
        withVerifyScriptSignature:(NSString *)verifyScriptSignature
                     withUniqueId:(NSString *)uniqueId
+                   withSourceUrl:(nonnull NSString *)sourceUrl
 {
   _scriptId = scriptId;
   _url = url;
@@ -92,6 +102,7 @@
   _timeout = timeout;
   _verifyScriptSignature = verifyScriptSignature;
   _uniqueId = uniqueId;
+  _sourceUrl = sourceUrl;
   return self;
 }
 

--- a/packages/repack/ios/ScriptConfig.mm
+++ b/packages/repack/ios/ScriptConfig.mm
@@ -21,15 +21,15 @@
                 withScriptId:(nonnull NSString *)scriptId
 {
   NSDictionary *_Nullable headers = (NSDictionary *)config.headers();
-  
+
   NSURLComponents *urlComponents = [NSURLComponents componentsWithString:config.url()];
   NSString *sourceUrl = urlComponents.URL.absoluteString;
-    
+
   // overrides any existing query in the URL with config.query
   if (config.query() != nil) {
     urlComponents.percentEncodedQuery = config.query();
   }
-    
+
   NSURL *url = urlComponents.URL;
 
   return [[ScriptConfig alloc] initWithScript:scriptId

--- a/packages/repack/ios/ScriptManager.mm
+++ b/packages/repack/ios/ScriptManager.mm
@@ -189,7 +189,7 @@ RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(unstable_evaluateScript
       @throw [NSError errorWithDomain:errorMessage code:0 userInfo:nil];
     }
 
-    [self evaluateJavascript:data url:config.uniqueId resolve:resolve reject:reject];
+    [self evaluateJavascript:data url:config.sourceUrl resolve:resolve reject:reject];
   } @catch (NSError *error) {
     reject(CodeExecutionFailure, error.domain, nil);
   }
@@ -304,7 +304,7 @@ RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(unstable_evaluateScript
       filesystemScriptUrl = [[NSBundle mainBundle] URLForResource:scriptName withExtension:scriptExtension];
     }
     NSData *data = [[NSData alloc] initWithContentsOfFile:[filesystemScriptUrl path]];
-    [self evaluateJavascript:data url:config.uniqueId resolve:resolve reject:reject];
+    [self evaluateJavascript:data url:config.sourceUrl resolve:resolve reject:reject];
   } @catch (NSError *error) {
     reject(CodeExecutionFailure, error.localizedDescription, nil);
   }

--- a/packages/repack/src/plugins/DevelopmentPlugin.ts
+++ b/packages/repack/src/plugins/DevelopmentPlugin.ts
@@ -83,6 +83,9 @@ export class DevelopmentPlugin implements RspackPluginInstance {
         module: true,
         columns: true,
         noSources: false,
+        namespace:
+          compiler.options.output.devtoolNamespace ??
+          compiler.options.output.uniqueName,
       }).apply(compiler);
 
       // setup React Refresh manually instead of using the official plugin

--- a/packages/repack/src/plugins/RepackPlugin.ts
+++ b/packages/repack/src/plugins/RepackPlugin.ts
@@ -178,6 +178,10 @@ export class RepackPlugin implements RspackPluginInstance {
     }).apply(compiler);
 
     if (this.config.sourceMaps) {
+      // TODO Fix sourcemap directory structure
+      // Right now its very messy and not every node module is inside of the node module
+      // like React Devtools backend etc or some symilinked module appear with relative path
+      // We should normalize this through a custom handler and provide an output similar to Metro
       new compiler.webpack.SourceMapDevToolPlugin({
         test: /\.(js)?bundle$/,
         filename: '[file].map',

--- a/packages/repack/src/plugins/RepackPlugin.ts
+++ b/packages/repack/src/plugins/RepackPlugin.ts
@@ -185,6 +185,9 @@ export class RepackPlugin implements RspackPluginInstance {
         module: true,
         columns: true,
         noSources: false,
+        namespace:
+          compiler.options.output.devtoolNamespace ??
+          compiler.options.output.uniqueName,
       }).apply(compiler);
     }
 


### PR DESCRIPTION
### Summary

Fix bad source-map matching in DevTools by aligning the following:

- [x] - add namespace to `SourceMapDevToolPlugin`
- [x] - align `sourceURL` that gets passed to JSI `evaluateJavascript`

Before:
![image](https://github.com/user-attachments/assets/0f629c46-58b0-40ea-89c0-bafc201122c9)

After:
![image](https://github.com/user-attachments/assets/4a9f4240-3b4c-48f9-a6da-36766af3321e)


### Test plan

- [x] - proper mapping in DevTools in testers on iOS
- [x] - proper mapping in DevTools in testers on Android 
