### PR TITLE
fix: expose MF2 plugin config to external tooling

### DIFF
--- a/.changeset/honest-items-happen.md
+++ b/.changeset/honest-items-happen.md
@@ -1,0 +1,5 @@
+---
+"@callstack/repack": patch
+---
+
+Expose MF2 config property to external tooling

--- a/packages/repack/src/plugins/ModuleFederationPluginV2.ts
+++ b/packages/repack/src/plugins/ModuleFederationPluginV2.ts
@@ -81,7 +81,7 @@ export interface ModuleFederationPluginV2Config
  * @category Webpack Plugin
  */
 export class ModuleFederationPluginV2 implements RspackPluginInstance {
-  private config: MF.ModuleFederationPluginOptions;
+  public config: MF.ModuleFederationPluginOptions;
   private deepImports: boolean;
 
   constructor(pluginConfig: ModuleFederationPluginV2Config) {


### PR DESCRIPTION
### Summary

- [x] - expose `config` to external tooling like Zephyr Cloud for adjusting the config during the build

### Test plan

n/a
