### PR TITLE
fix: add transform react jsx automatic to node module rules

### DIFF
--- a/.changeset/slimy-dragons-swim.md
+++ b/.changeset/slimy-dragons-swim.md
@@ -1,0 +1,5 @@
+---
+"@callstack/repack": patch
+---
+
+Fix type JSX runtime transform when transpiling node modules

--- a/apps/tester-app/ios/Podfile.lock
+++ b/apps/tester-app/ios/Podfile.lock
@@ -1,6 +1,6 @@
 PODS:
   - boost (1.84.0)
-  - callstack-repack (5.0.0-rc.0):
+  - callstack-repack (5.0.0-rc.2):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -1852,7 +1852,7 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   boost: 1dca942403ed9342f98334bf4c3621f011aa7946
-  callstack-repack: 75464b0e26467fc4a7236373399bc0fc2281f495
+  callstack-repack: 3106db24c24f7a76a380230ff7794d225cecb760
   DoubleConversion: f16ae600a246532c4020132d54af21d0ddb2a385
   FBLazyVector: 7075bb12898bc3998fd60f4b7ca422496cc2cdf7
   fmt: 10c6e61f4be25dc963c36bd73fc7b1705fe975be

--- a/packages/repack/src/rules/nodeModulesLoadingRules.ts
+++ b/packages/repack/src/rules/nodeModulesLoadingRules.ts
@@ -19,7 +19,7 @@ export const NODE_MODULES_LOADING_RULES: RuleSetRule = {
     'react-native-tvos',
     '@callstack/react-native-visionos',
   ]),
-  rules: [
+  oneOf: [
     {
       test: /jsx?$/,
       use: [
@@ -35,6 +35,11 @@ export const NODE_MODULES_LOADING_RULES: RuleSetRule = {
                 syntax: 'ecmascript',
                 jsx: true,
               },
+              transform: {
+                react: {
+                  runtime: 'automatic',
+                },
+              },
               externalHelpers: true,
             },
             module: {
@@ -47,7 +52,38 @@ export const NODE_MODULES_LOADING_RULES: RuleSetRule = {
       ],
     },
     {
-      test: /tsx?$/,
+      test: /ts$/,
+      use: [
+        {
+          loader: 'builtin:swc-loader',
+          options: {
+            env: {
+              targets: { 'react-native': '0.74' },
+            },
+            jsc: {
+              parser: {
+                syntax: 'typescript',
+                tsx: false,
+              },
+              transform: {
+                react: {
+                  runtime: 'automatic',
+                },
+              },
+              loose: true,
+              externalHelpers: true,
+            },
+            module: {
+              type: 'commonjs',
+              strict: false,
+              strictMode: false,
+            },
+          },
+        },
+      ],
+    },
+    {
+      test: /tsx$/,
       use: [
         {
           loader: 'builtin:swc-loader',
@@ -59,6 +95,11 @@ export const NODE_MODULES_LOADING_RULES: RuleSetRule = {
               parser: {
                 syntax: 'typescript',
                 tsx: true,
+              },
+              transform: {
+                react: {
+                  runtime: 'automatic',
+                },
               },
               loose: true,
               externalHelpers: true,

--- a/packages/repack/src/rules/nodeModulesLoadingRules.ts
+++ b/packages/repack/src/rules/nodeModulesLoadingRules.ts
@@ -1,6 +1,33 @@
 import type { RuleSetRule } from '@rspack/core';
 import { getModulePaths } from '../utils';
 
+const makeSwcLoaderConfig = (syntax: 'js' | 'ts', jsx: boolean) => ({
+  loader: 'builtin:swc-loader',
+  options: {
+    env: {
+      targets: { 'react-native': '0.74' },
+    },
+    jsc: {
+      externalHelpers: true,
+      loose: true,
+      parser:
+        syntax === 'js'
+          ? { syntax: 'ecmascript', jsx: jsx }
+          : { syntax: 'typescript', tsx: jsx },
+      transform: {
+        react: {
+          runtime: 'automatic',
+        },
+      },
+    },
+    module: {
+      type: 'commonjs',
+      strict: false,
+      strictMode: false,
+    },
+  },
+});
+
 /**
  * @constant NODE_MODULES_LOADING_RULES
  * @type {RuleSetRule}
@@ -22,96 +49,15 @@ export const NODE_MODULES_LOADING_RULES: RuleSetRule = {
   oneOf: [
     {
       test: /jsx?$/,
-      use: [
-        {
-          loader: 'builtin:swc-loader',
-          options: {
-            env: {
-              targets: { 'react-native': '0.74' },
-            },
-            jsc: {
-              externalHelpers: true,
-              loose: true,
-              parser: {
-                syntax: 'ecmascript',
-                jsx: true,
-              },
-              transform: {
-                react: {
-                  runtime: 'automatic',
-                },
-              },
-            },
-            module: {
-              type: 'commonjs',
-              strict: false,
-              strictMode: false,
-            },
-          },
-        },
-      ],
+      use: [makeSwcLoaderConfig('js', true)],
     },
     {
       test: /ts$/,
-      use: [
-        {
-          loader: 'builtin:swc-loader',
-          options: {
-            env: {
-              targets: { 'react-native': '0.74' },
-            },
-            jsc: {
-              externalHelpers: true,
-              loose: true,
-              parser: {
-                syntax: 'typescript',
-                tsx: false,
-              },
-              transform: {
-                react: {
-                  runtime: 'automatic',
-                },
-              },
-            },
-            module: {
-              type: 'commonjs',
-              strict: false,
-              strictMode: false,
-            },
-          },
-        },
-      ],
+      use: [makeSwcLoaderConfig('ts', false)],
     },
     {
       test: /tsx$/,
-      use: [
-        {
-          loader: 'builtin:swc-loader',
-          options: {
-            env: {
-              targets: { 'react-native': '0.74' },
-            },
-            jsc: {
-              externalHelpers: true,
-              loose: true,
-              parser: {
-                syntax: 'typescript',
-                tsx: true,
-              },
-              transform: {
-                react: {
-                  runtime: 'automatic',
-                },
-              },
-            },
-            module: {
-              type: 'commonjs',
-              strict: false,
-              strictMode: false,
-            },
-          },
-        },
-      ],
+      use: [makeSwcLoaderConfig('ts', true)],
     },
   ],
 };

--- a/packages/repack/src/rules/nodeModulesLoadingRules.ts
+++ b/packages/repack/src/rules/nodeModulesLoadingRules.ts
@@ -30,6 +30,7 @@ export const NODE_MODULES_LOADING_RULES: RuleSetRule = {
               targets: { 'react-native': '0.74' },
             },
             jsc: {
+              externalHelpers: true,
               loose: true,
               parser: {
                 syntax: 'ecmascript',
@@ -40,7 +41,6 @@ export const NODE_MODULES_LOADING_RULES: RuleSetRule = {
                   runtime: 'automatic',
                 },
               },
-              externalHelpers: true,
             },
             module: {
               type: 'commonjs',
@@ -61,6 +61,8 @@ export const NODE_MODULES_LOADING_RULES: RuleSetRule = {
               targets: { 'react-native': '0.74' },
             },
             jsc: {
+              externalHelpers: true,
+              loose: true,
               parser: {
                 syntax: 'typescript',
                 tsx: false,
@@ -70,8 +72,6 @@ export const NODE_MODULES_LOADING_RULES: RuleSetRule = {
                   runtime: 'automatic',
                 },
               },
-              loose: true,
-              externalHelpers: true,
             },
             module: {
               type: 'commonjs',
@@ -92,6 +92,8 @@ export const NODE_MODULES_LOADING_RULES: RuleSetRule = {
               targets: { 'react-native': '0.74' },
             },
             jsc: {
+              externalHelpers: true,
+              loose: true,
               parser: {
                 syntax: 'typescript',
                 tsx: true,
@@ -101,8 +103,6 @@ export const NODE_MODULES_LOADING_RULES: RuleSetRule = {
                   runtime: 'automatic',
                 },
               },
-              loose: true,
-              externalHelpers: true,
             },
             module: {
               type: 'commonjs',

--- a/packages/repack/src/rules/reactNativeLoadingRules.ts
+++ b/packages/repack/src/rules/reactNativeLoadingRules.ts
@@ -26,6 +26,8 @@ export const REACT_NATIVE_LOADING_RULES: RuleSetRule = {
           targets: { 'react-native': '0.74' },
         },
         jsc: {
+          externalHelpers: true,
+          loose: true,
           parser: {
             syntax: 'ecmascript',
             jsx: true,
@@ -36,8 +38,6 @@ export const REACT_NATIVE_LOADING_RULES: RuleSetRule = {
               runtime: 'automatic',
             },
           },
-          loose: true,
-          externalHelpers: true,
         },
         module: {
           type: 'commonjs',

--- a/packages/repack/src/rules/reactNativeLoadingRules.ts
+++ b/packages/repack/src/rules/reactNativeLoadingRules.ts
@@ -31,6 +31,11 @@ export const REACT_NATIVE_LOADING_RULES: RuleSetRule = {
             jsx: true,
             exportDefaultFrom: true,
           },
+          transform: {
+            react: {
+              runtime: 'automatic',
+            },
+          },
           loose: true,
           externalHelpers: true,
         },


### PR DESCRIPTION
### Summary

This PR fixes the discrepancy between Re.Pack default module transform rules and the official RN Babel preset. 

`swc` uses `classic` runtime transform, while RN babel preset uses `automatic` JSX transform so we need to declare `runtime: 'automatic'` explicitly for the node module rules.

### Test plan

- [x] - testers work
