### PR TITLE
chore: update vscode workspace settings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,11 +3,13 @@
   "editor.defaultFormatter": "biomejs.biome",
   "editor.formatOnSave": true,
   "files.associations": {
+    "package.json": "json",
     "*.json": "jsonc"
   },
   "editor.codeActionsOnSave": {
     "source.organizeImports.biome": "explicit"
   },
+  "npm.packageManager": "pnpm",
   "[css]": {
     "editor.formatOnSave": true,
     "editor.defaultFormatter": "biomejs.biome"


### PR DESCRIPTION
### Summary

fixes an issue happening in VSCode, where the package version information wouldn't be displayed when hovering over it's name. 

### Test plan

n/a