### PR TITLE
feat: include `@rspack/react-refresh-plugin` with Re.Pack

### DIFF
--- a/.changeset/cold-chefs-confess.md
+++ b/.changeset/cold-chefs-confess.md
@@ -1,0 +1,6 @@
+---
+"@callstack/repack": minor
+"@callstack/repack-init": minor
+---
+
+Include `@rspack/plugin-react-refresh` with Re.Pack instead of requiring user to install it

--- a/apps/tester-app/package.json
+++ b/apps/tester-app/package.json
@@ -32,7 +32,6 @@
     "@react-native/typescript-config": "0.76.1",
     "@rsdoctor/rspack-plugin": "^0.4.5",
     "@rspack/core": "1.0.8",
-    "@rspack/plugin-react-refresh": "1.0.0",
     "@svgr/webpack": "^8.1.0",
     "@swc/helpers": "^0.5.13",
     "@types/jest": "^29.5.12",

--- a/apps/tester-federation-v2/package.json
+++ b/apps/tester-federation-v2/package.json
@@ -29,7 +29,6 @@
     "@react-native-community/cli-platform-android": "15.0.1",
     "@rsdoctor/rspack-plugin": "^0.4.5",
     "@rspack/core": "1.0.8",
-    "@rspack/plugin-react-refresh": "1.0.0",
     "@swc/helpers": "^0.5.13",
     "@types/jest": "^29.5.12",
     "@types/react": "^18.2.51",

--- a/apps/tester-federation/package.json
+++ b/apps/tester-federation/package.json
@@ -36,7 +36,6 @@
     "@react-native-community/cli-platform-android": "15.0.1",
     "@rsdoctor/rspack-plugin": "^0.4.5",
     "@rspack/core": "1.0.8",
-    "@rspack/plugin-react-refresh": "1.0.0",
     "@swc/helpers": "^0.5.13",
     "@types/jest": "^29.5.12",
     "@types/react": "^18.2.51",

--- a/packages/init/src/tasks/addDependencies.ts
+++ b/packages/init/src/tasks/addDependencies.ts
@@ -8,7 +8,6 @@ import logger from '../utils/logger.js';
 
 const rspackDependencies = [
   '@rspack/core@1.0.3', // 1.0.4 breaks sourcemaps
-  '@rspack/plugin-react-refresh',
   'babel-loader', // still needed for codegen
   '@swc/helpers',
   '@callstack/repack',
@@ -18,7 +17,6 @@ const webpackDependencies = [
   'webpack',
   'terser-webpack-plugin',
   'babel-loader',
-  '@rspack/plugin-react-refresh',
   '@callstack/repack',
 ];
 

--- a/packages/repack/package.json
+++ b/packages/repack/package.json
@@ -60,7 +60,6 @@
     "@react-native-community/cli": "*",
     "@react-native-community/cli-types": "*",
     "@rspack/core": ">=1",
-    "@rspack/plugin-react-refresh": ">=1",
     "react-native": ">=0.74",
     "webpack": ">=5.90"
   },
@@ -78,6 +77,7 @@
   "dependencies": {
     "@callstack/repack-dev-server": "workspace:*",
     "@discoveryjs/json-ext": "^0.5.7",
+    "@rspack/plugin-react-refresh": "1.0.0",
     "colorette": "^2.0.20",
     "dedent": "^0.7.0",
     "events": "^3.3.0",

--- a/packages/repack/package.json
+++ b/packages/repack/package.json
@@ -103,7 +103,6 @@
     "@module-federation/enhanced": "0.6.10",
     "@module-federation/sdk": "0.6.10",
     "@rspack/core": "1.0.8",
-    "@rspack/plugin-react-refresh": "1.0.0",
     "@swc/helpers": "0.5.13",
     "@types/dedent": "^0.7.0",
     "@types/jest": "^29.5.12",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -433,6 +433,9 @@ importers:
       '@discoveryjs/json-ext':
         specifier: ^0.5.7
         version: 0.5.7
+      '@rspack/plugin-react-refresh':
+        specifier: 1.0.0
+        version: 1.0.0(react-refresh@0.14.2)
       colorette:
         specifier: ^2.0.20
         version: 2.0.20
@@ -503,9 +506,6 @@ importers:
       '@rspack/core':
         specifier: 1.0.8
         version: 1.0.8(@swc/helpers@0.5.13)
-      '@rspack/plugin-react-refresh':
-        specifier: 1.0.0
-        version: 1.0.0(react-refresh@0.14.2)
       '@swc/helpers':
         specifier: 0.5.13
         version: 0.5.13

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -93,9 +93,6 @@ importers:
       '@rspack/core':
         specifier: 1.0.8
         version: 1.0.8(@swc/helpers@0.5.13)
-      '@rspack/plugin-react-refresh':
-        specifier: 1.0.0
-        version: 1.0.0(react-refresh@0.14.2)
       '@svgr/webpack':
         specifier: ^8.1.0
         version: 8.1.0(typescript@5.5.3)
@@ -190,9 +187,6 @@ importers:
       '@rspack/core':
         specifier: 1.0.8
         version: 1.0.8(@swc/helpers@0.5.13)
-      '@rspack/plugin-react-refresh':
-        specifier: 1.0.0
-        version: 1.0.0(react-refresh@0.14.2)
       '@swc/helpers':
         specifier: ^0.5.13
         version: 0.5.13
@@ -275,9 +269,6 @@ importers:
       '@rspack/core':
         specifier: 1.0.8
         version: 1.0.8(@swc/helpers@0.5.13)
-      '@rspack/plugin-react-refresh':
-        specifier: 1.0.0
-        version: 1.0.0(react-refresh@0.14.2)
       '@swc/helpers':
         specifier: ^0.5.13
         version: 0.5.13


### PR DESCRIPTION
### Summary

Closes #804 

`@rspack/react-refresh-plugin` is now included in Re.Pack instead of being a peer dependcy since it's used in both webpack and rspack variants

### Test plan

n/a
