### PR TITLE
fix: split ts & tsx rules in codegen & enable source maps

### DIFF
--- a/.changeset/smooth-zebras-hunt.md
+++ b/.changeset/smooth-zebras-hunt.md
@@ -1,0 +1,5 @@
+---
+"@callstack/repack": patch
+---
+
+Fix missing sourcemap generation for codegen related files and configure separate rules for ts & tsx files

--- a/packages/repack/src/rules/reactNativeCodegenRules.ts
+++ b/packages/repack/src/rules/reactNativeCodegenRules.ts
@@ -7,9 +7,9 @@ import type { RuleSetRule } from '@rspack/core';
  */
 export const REACT_NATIVE_CODEGEN_RULES: RuleSetRule = {
   test: /(?:^|[\\/])(?:Native\w+|(\w+)NativeComponent)\.[jt]sx?$/,
-  rules: [
+  oneOf: [
     {
-      test: /\.tsx?$/,
+      test: /\.ts$/,
       use: [
         {
           loader: 'babel-loader',
@@ -17,7 +17,29 @@ export const REACT_NATIVE_CODEGEN_RULES: RuleSetRule = {
             babelrc: false,
             configFile: false,
             plugins: [
-              '@babel/plugin-syntax-typescript',
+              [
+                '@babel/plugin-syntax-typescript',
+                { isTSX: false, allowNamespaces: true },
+              ],
+              '@react-native/babel-plugin-codegen',
+            ],
+          },
+        },
+      ],
+    },
+    {
+      test: /\.tsx$/,
+      use: [
+        {
+          loader: 'babel-loader',
+          options: {
+            babelrc: false,
+            configFile: false,
+            plugins: [
+              [
+                '@babel/plugin-syntax-typescript',
+                { isTSX: true, allowNamespaces: true },
+              ],
               '@react-native/babel-plugin-codegen',
             ],
           },

--- a/packages/repack/src/rules/reactNativeCodegenRules.ts
+++ b/packages/repack/src/rules/reactNativeCodegenRules.ts
@@ -7,61 +7,47 @@ import type { RuleSetRule } from '@rspack/core';
  */
 export const REACT_NATIVE_CODEGEN_RULES: RuleSetRule = {
   test: /(?:^|[\\/])(?:Native\w+|(\w+)NativeComponent)\.[jt]sx?$/,
-  oneOf: [
-    {
-      test: /\.ts$/,
-      use: [
+  use: {
+    loader: 'babel-loader',
+    options: {
+      babelrc: false,
+      configFile: false,
+      parserOpts: {
+        // hermes-parser strips all comments so the information about flow pragma is lost
+        // assume flow when dealing with JS files as a workaround
+        flow: 'all',
+      },
+      plugins: [
+        'babel-plugin-syntax-hermes-parser',
+        ['@babel/plugin-syntax-typescript', false],
+        '@react-native/babel-plugin-codegen',
+      ],
+      // config merging reference: https://babeljs.io/docs/options#pluginpreset-entries
+      overrides: [
         {
-          loader: 'babel-loader',
-          options: {
-            babelrc: false,
-            configFile: false,
-            plugins: [
-              [
-                '@babel/plugin-syntax-typescript',
-                { isTSX: false, allowNamespaces: true },
-              ],
-              '@react-native/babel-plugin-codegen',
+          test: /\.ts$/,
+          plugins: [
+            [
+              '@babel/plugin-syntax-typescript',
+              { isTSX: false, allowNamespaces: true },
             ],
-          },
+          ],
+        },
+        {
+          test: /\.tsx$/,
+          plugins: [
+            [
+              '@babel/plugin-syntax-typescript',
+              { isTSX: true, allowNamespaces: true },
+            ],
+          ],
         },
       ],
+      // source maps are usually set based on the devtool option in config
+      // Re.Pack templates disable the devtool by default and the flag in loader is not set
+      // we need to enable sourcemaps for the loader explicitly here
+      sourceMaps: true,
     },
-    {
-      test: /\.tsx$/,
-      use: [
-        {
-          loader: 'babel-loader',
-          options: {
-            babelrc: false,
-            configFile: false,
-            plugins: [
-              [
-                '@babel/plugin-syntax-typescript',
-                { isTSX: true, allowNamespaces: true },
-              ],
-              '@react-native/babel-plugin-codegen',
-            ],
-          },
-        },
-      ],
-    },
-    {
-      test: /\.jsx?$/,
-      use: [
-        {
-          loader: 'babel-loader',
-          options: {
-            babelrc: false,
-            configFile: false,
-            plugins: [
-              'babel-plugin-syntax-hermes-parser',
-              '@react-native/babel-plugin-codegen',
-            ],
-          },
-        },
-      ],
-    },
-  ],
+  },
   type: 'javascript/auto',
 };


### PR DESCRIPTION
### Summary

- [x] - enable sourcemaps for codegen related files
- [x] - separate rules for ts & tsx in codegen rule
- [x] - assume flow when dealing with JS codegen files  

### Test plan

- [x] - testers work
