### PR TITLE
chore: ignore the warning from setupTests in reanimated plugin

### DIFF
--- a/.changeset/thick-pillows-act.md
+++ b/.changeset/thick-pillows-act.md
@@ -1,0 +1,5 @@
+---
+"@callstack/repack": patch
+---
+
+Ignore setUpTests warning from Reanimated by default

--- a/packages/plugin-reanimated/src/plugin.ts
+++ b/packages/plugin-reanimated/src/plugin.ts
@@ -5,5 +5,13 @@ export class ReanimatedPlugin implements RspackPluginInstance {
   apply(compiler: Compiler) {
     // add rules for transpiling wih reanimated loader
     compiler.options.module.rules.push(reanimatedModuleRules);
+
+    // ignore the 'setUpTests' warning from reanimated which is not relevant
+    compiler.options.ignoreWarnings = compiler.options.ignoreWarnings ?? [];
+    compiler.options.ignoreWarnings.push((warning) =>
+      /'`setUpTests` is available only in Jest environment\.'/.test(
+        warning.message
+      )
+    );
   }
 }


### PR DESCRIPTION
### Summary

Added warning from reanimated to ignored ones since it's not relevant in runtime and is only used in tests

<img width="961" alt="image" src="https://github.com/user-attachments/assets/67aa5c13-c969-4d28-b1ad-80ab1d1bdc91">

### Test plan

n/a
