### PR TITLE
fix: ignore the MF2 runtime warning

### DIFF
--- a/.changeset/healthy-dots-tap.md
+++ b/.changeset/healthy-dots-tap.md
@@ -1,0 +1,5 @@
+---
+"@callstack/repack": patch
+---
+
+Ignore irrelevant MF2 runtime warning about request of a dependency being an expression

--- a/packages/repack/src/plugins/ModuleFederationPluginV2.ts
+++ b/packages/repack/src/plugins/ModuleFederationPluginV2.ts
@@ -242,6 +242,22 @@ export class ModuleFederationPluginV2 implements RspackPluginInstance {
     compiler.options.ignoreWarnings.push(
       (warning) => warning.name === 'EnvironmentNotSupportAsyncWarning'
     );
+    // MF2 produces warning about dynamic import in loadEsmEntry but it's not relevant
+    // in RN env since we override the loadEntry logic through a hook
+    // https://github.com/module-federation/core/blob/fa7a0bd20eb64eccd6648fea340c6078a2268e39/packages/runtime/src/utils/load.ts#L28-L37
+    compiler.options.ignoreWarnings.push((warning) => {
+      // @ts-expect-error moduleDescriptor is present in the warning object
+      const modulePath = warning.moduleDescriptor.name;
+      const moduleName = '@module-federation/runtime/dist/index.cjs.js';
+      const isMF2Runtime = modulePath.endsWith(moduleName);
+      const requestExpressionWarning =
+        /Critical dependency: the request of a dependency is an expression/;
+
+      if (isMF2Runtime && requestExpressionWarning.test(warning.message)) {
+        return true;
+      }
+      return false;
+    });
 
     const ModuleFederationPlugin = this.getModuleFederationPlugin(compiler);
 

--- a/packages/repack/src/plugins/ModuleFederationPluginV2.ts
+++ b/packages/repack/src/plugins/ModuleFederationPluginV2.ts
@@ -233,9 +233,7 @@ export class ModuleFederationPluginV2 implements RspackPluginInstance {
     return adjustedSharedDependencies;
   }
 
-  apply(compiler: Compiler) {
-    this.ensureModuleFederationPackageInstalled(compiler.context);
-
+  private setupIgnoredWarnings(compiler: Compiler) {
     // MF2 produces warning about not supporting async await
     // we can silence this warning since it works just fine
     compiler.options.ignoreWarnings = compiler.options.ignoreWarnings ?? [];
@@ -256,8 +254,14 @@ export class ModuleFederationPluginV2 implements RspackPluginInstance {
       if (isMF2Runtime && requestExpressionWarning.test(warning.message)) {
         return true;
       }
+
       return false;
     });
+  }
+
+  apply(compiler: Compiler) {
+    this.ensureModuleFederationPackageInstalled(compiler.context);
+    this.setupIgnoredWarnings(compiler);
 
     const ModuleFederationPlugin = this.getModuleFederationPlugin(compiler);
 


### PR DESCRIPTION
### Summary

This PR addresses the warnings produced by Module Federation v2 (MF2) regarding dynamic imports in the loadEsmEntry function. These warnings are not relevant in the React Native environment since the loadEntry logic is overridden through a hook.

<img width="1218" alt="image" src="https://github.com/user-attachments/assets/52dc0d3e-dd64-4976-94bf-95838b8102ee">

### Test plan

n/a
