### PR TITLE
feat: `adb reverse` interaction & run `adb reverse` by default

### DIFF
--- a/.changeset/smart-carrots-sneeze.md
+++ b/.changeset/smart-carrots-sneeze.md
@@ -1,0 +1,5 @@
+---
+"@callstack/repack": minor
+---
+
+Added `adb reverse` interaction & `adb reverse` command is now run by default when bundling for Android

--- a/packages/repack/src/commands/common/__tests__/setupInteractions.test.ts
+++ b/packages/repack/src/commands/common/__tests__/setupInteractions.test.ts
@@ -239,6 +239,7 @@ describe('setupInteractions', () => {
             onOpenDevTools: debuggerSupport ? jest.fn() : undefined,
             onOpenDevMenu() {},
             onReload() {},
+            onAdbReverse() {},
           },
           {
             logger: mockLogger,
@@ -261,6 +262,10 @@ describe('setupInteractions', () => {
         );
         expect(mockProcess.stdout.write).toHaveBeenNthCalledWith(
           4,
+          ' a: Run adb reverse\n'
+        );
+        expect(mockProcess.stdout.write).toHaveBeenNthCalledWith(
+          5,
           '\nPress Ctrl+c or Ctrl+z to quit the dev server\n\n'
         );
       });

--- a/packages/repack/src/commands/common/runAdbReverse.ts
+++ b/packages/repack/src/commands/common/runAdbReverse.ts
@@ -21,15 +21,15 @@ export async function runAdbReverse({
   try {
     await execa.command(command);
     if (verbose) {
-      logger.info('ADB reverse success');
+      logger.info('adb reverse success');
     }
-    logger.debug(`ADB reverse success: ${info}`);
+    logger.debug(`adb reverse success: ${info}`);
   } catch (error) {
     const message =
       (error as Error).message.split('error:')[1] || (error as Error).message;
     if (verbose) {
-      logger.warn(`ADB reverse failed: "${message.trim()}"`);
+      logger.warn(`adb reverse failed: "${message.trim()}"`);
     }
-    logger.debug(`ADB reverse failed: "${message.trim()}" ${info}`);
+    logger.debug(`adb reverse failed: "${message.trim()}" ${info}`);
   }
 }

--- a/packages/repack/src/commands/common/runAdbReverse.ts
+++ b/packages/repack/src/commands/common/runAdbReverse.ts
@@ -6,13 +6,14 @@ export async function runAdbReverse(port: number, logger: Logger = console) {
     ? `${process.env.ANDROID_HOME}/platform-tools/adb`
     : 'adb';
   const command = `${adbPath} reverse tcp:${port} tcp:${port}`;
+  const info = JSON.stringify({ port, adbPath, command });
+
   try {
     await execa.command(command);
-    logger.info(`Successfully run: ${command}`);
+    logger.debug(`ADB reverse success: ${info}`);
   } catch (error) {
-    // Get just the error message
     const message =
       (error as Error).message.split('error:')[1] || (error as Error).message;
-    logger.warn(`Failed to run: ${command} - ${message.trim()}`);
+    logger.debug(`ADB reverse failed: "${message.trim()}" ${info}`);
   }
 }

--- a/packages/repack/src/commands/common/runAdbReverse.ts
+++ b/packages/repack/src/commands/common/runAdbReverse.ts
@@ -1,7 +1,17 @@
 import execa from 'execa';
 import type { Logger } from '../../types';
 
-export async function runAdbReverse(port: number, logger: Logger = console) {
+interface RunAdbReverseParams {
+  port: number;
+  verbose?: boolean;
+  logger?: Logger;
+}
+
+export async function runAdbReverse({
+  port,
+  verbose = false,
+  logger = console,
+}: RunAdbReverseParams) {
   const adbPath = process.env.ANDROID_HOME
     ? `${process.env.ANDROID_HOME}/platform-tools/adb`
     : 'adb';
@@ -10,10 +20,16 @@ export async function runAdbReverse(port: number, logger: Logger = console) {
 
   try {
     await execa.command(command);
+    if (verbose) {
+      logger.info('ADB reverse success');
+    }
     logger.debug(`ADB reverse success: ${info}`);
   } catch (error) {
     const message =
       (error as Error).message.split('error:')[1] || (error as Error).message;
+    if (verbose) {
+      logger.warn(`ADB reverse failed: "${message.trim()}"`);
+    }
     logger.debug(`ADB reverse failed: "${message.trim()}" ${info}`);
   }
 }

--- a/packages/repack/src/commands/common/setupInteractions.ts
+++ b/packages/repack/src/commands/common/setupInteractions.ts
@@ -21,6 +21,7 @@ export function setupInteractions(
     onReload?: () => void;
     onOpenDevMenu?: () => void;
     onOpenDevTools?: () => void;
+    onAdbReverse?: () => void;
   },
   options?: {
     logger?: Logger;
@@ -91,6 +92,11 @@ export function setupInteractions(
       action: handlers.onOpenDevTools,
       postPerformMessage: 'Opening debugger',
       helpName: 'Open debugger',
+    },
+    a: {
+      action: handlers.onAdbReverse,
+      postPerformMessage: 'Running ADB reverse',
+      helpName: 'Run ADB reverse',
     },
   };
 

--- a/packages/repack/src/commands/common/setupInteractions.ts
+++ b/packages/repack/src/commands/common/setupInteractions.ts
@@ -95,8 +95,8 @@ export function setupInteractions(
     },
     a: {
       action: handlers.onAdbReverse,
-      postPerformMessage: 'Running ADB reverse',
-      helpName: 'Run ADB reverse',
+      postPerformMessage: 'Running adb reverse',
+      helpName: 'Run adb reverse',
     },
   };
 

--- a/packages/repack/src/commands/options.ts
+++ b/packages/repack/src/commands/options.ts
@@ -51,9 +51,8 @@ export const startCommandOptions = [
       'Run the dev server for the specified platform only. By default, the dev server will bundle for all platforms.',
   },
   {
-    name: '--no-reverse-port',
-    description:
-      'Disables running ADB reverse automatically when bundling for Android',
+    name: '--reverse-port',
+    description: 'ADB reverse port on starting devServers only for Android',
   },
   {
     name: '--verbose',

--- a/packages/repack/src/commands/options.ts
+++ b/packages/repack/src/commands/options.ts
@@ -51,8 +51,9 @@ export const startCommandOptions = [
       'Run the dev server for the specified platform only. By default, the dev server will bundle for all platforms.',
   },
   {
-    name: '--reverse-port',
-    description: 'ADB reverse port on starting devServers only for Android',
+    name: '--no-reverse-port',
+    description:
+      'Disables running ADB reverse automatically when bundling for Android',
   },
   {
     name: '--verbose',

--- a/packages/repack/src/commands/rspack/Compiler.ts
+++ b/packages/repack/src/commands/rspack/Compiler.ts
@@ -10,7 +10,12 @@ import type {
 import memfs from 'memfs';
 import type { Reporter } from '../../logging';
 import type { HMRMessageBody } from '../../types';
-import { adaptFilenameToPlatform, getEnvOptions, loadConfig } from '../common';
+import {
+  adaptFilenameToPlatform,
+  getEnvOptions,
+  loadConfig,
+  runAdbReverse,
+} from '../common';
 import { DEV_SERVER_ASSET_TYPES } from '../consts';
 import type { StartCliOptions } from '../types';
 import type { CompilerAsset, MultiWatching } from './types';
@@ -73,6 +78,12 @@ export class Compiler {
     this.compiler.hooks.watchRun.tap('repack:watch', () => {
       this.isCompilationInProgress = true;
       this.platforms.forEach((platform) => {
+        if (platform === 'android') {
+          void runAdbReverse({
+            port: this.cliOptions.arguments.start.port!,
+            logger: this.devServerContext.log,
+          });
+        }
         this.devServerContext.notifyBuildStart(platform);
       });
     });

--- a/packages/repack/src/commands/rspack/start.ts
+++ b/packages/repack/src/commands/rspack/start.ts
@@ -126,7 +126,11 @@ export async function start(
         );
       }
 
-      if (reversePort) {
+      if (
+        reversePort ||
+        args.platform === undefined ||
+        args.platform === 'android'
+      ) {
         void runAdbReverse({ port: serverPort, logger: ctx.log });
       }
 

--- a/packages/repack/src/commands/rspack/start.ts
+++ b/packages/repack/src/commands/rspack/start.ts
@@ -110,13 +110,20 @@ export async function start(
                 method: 'POST',
               });
             },
+            onAdbReverse() {
+              void runAdbReverse({
+                port: serverPort,
+                logger: ctx.log,
+                verbose: true,
+              });
+            },
           },
           { logger: ctx.log }
         );
       }
 
       if (reversePort) {
-        void runAdbReverse(serverPort, ctx.log);
+        void runAdbReverse({ port: serverPort, logger: ctx.log });
       }
 
       compiler.setDevServerContext(ctx);

--- a/packages/repack/src/commands/rspack/start.ts
+++ b/packages/repack/src/commands/rspack/start.ts
@@ -115,8 +115,8 @@ export async function start(
         );
       }
 
-      if (reversePort && args.port) {
-        void runAdbReverse(args.port, ctx.log);
+      if (reversePort) {
+        void runAdbReverse(serverPort, ctx.log);
       }
 
       compiler.setDevServerContext(ctx);

--- a/packages/repack/src/commands/rspack/start.ts
+++ b/packages/repack/src/commands/rspack/start.ts
@@ -42,6 +42,13 @@ export async function start(
     args.config ?? args.webpackConfig
   );
   const { reversePort, ...restArgs } = args;
+
+  const serverProtocol = args.https ? 'https' : 'http';
+  const serverHost = args.host || DEFAULT_HOSTNAME;
+  const serverPort = args.port ?? DEFAULT_PORT;
+  const serverURL = `${serverProtocol}://${serverHost}:${serverPort}`;
+  const showHttpRequests = args.verbose || args.logRequests;
+
   const cliOptions: StartCliOptions = {
     config: {
       root: cliConfig.root,
@@ -50,7 +57,9 @@ export async function start(
       reactNativePath: cliConfig.reactNativePath,
     },
     command: 'start',
-    arguments: { start: { ...restArgs } },
+    arguments: {
+      start: { ...restArgs, host: serverHost, port: serverPort },
+    },
   };
 
   if (args.platform && !cliOptions.config.platforms.includes(args.platform)) {
@@ -75,11 +84,6 @@ export async function start(
 
   // @ts-ignore
   const compiler = new Compiler(cliOptions, reporter);
-
-  const serverHost = args.host || DEFAULT_HOSTNAME;
-  const serverPort = args.port ?? DEFAULT_PORT;
-  const serverURL = `${args.https === true ? 'https' : 'http'}://${serverHost}:${serverPort}`;
-  const showHttpRequests = args.verbose || args.logRequests;
 
   const { createServer } = await import('@callstack/repack-dev-server');
   const { start, stop } = await createServer({

--- a/packages/repack/src/commands/webpack/start.ts
+++ b/packages/repack/src/commands/webpack/start.ts
@@ -113,8 +113,8 @@ export async function start(_: string[], config: Config, args: StartArguments) {
         );
       }
 
-      if (reversePort && args.port) {
-        void runAdbReverse(args.port, ctx.log);
+      if (reversePort) {
+        void runAdbReverse(serverPort, ctx.log);
       }
 
       const lastStats: Record<string, webpack.StatsCompilation> = {};

--- a/packages/repack/src/commands/webpack/start.ts
+++ b/packages/repack/src/commands/webpack/start.ts
@@ -124,7 +124,11 @@ export async function start(_: string[], config: Config, args: StartArguments) {
         );
       }
 
-      if (reversePort) {
+      if (
+        reversePort ||
+        args.platform === undefined ||
+        args.platform === 'android'
+      ) {
         void runAdbReverse({ port: serverPort, logger: ctx.log });
       }
 

--- a/packages/repack/src/commands/webpack/start.ts
+++ b/packages/repack/src/commands/webpack/start.ts
@@ -41,6 +41,13 @@ export async function start(_: string[], config: Config, args: StartArguments) {
     args.config ?? args.webpackConfig
   );
   const { reversePort, ...restArgs } = args;
+
+  const serverProtocol = args.https ? 'https' : 'http';
+  const serverHost = args.host || DEFAULT_HOSTNAME;
+  const serverPort = args.port ?? DEFAULT_PORT;
+  const serverURL = `${serverProtocol}://${serverHost}:${serverPort}`;
+  const showHttpRequests = args.verbose || args.logRequests;
+
   const cliOptions: StartCliOptions = {
     config: {
       root: config.root,
@@ -49,7 +56,9 @@ export async function start(_: string[], config: Config, args: StartArguments) {
       reactNativePath: config.reactNativePath,
     },
     command: 'start',
-    arguments: { start: { ...restArgs } },
+    arguments: {
+      start: { ...restArgs, host: serverHost, port: serverPort },
+    },
   };
 
   if (args.platform && !cliOptions.config.platforms.includes(args.platform)) {
@@ -73,11 +82,6 @@ export async function start(_: string[], config: Config, args: StartArguments) {
   );
 
   const compiler = new Compiler(cliOptions, reporter);
-
-  const serverHost = args.host || DEFAULT_HOSTNAME;
-  const serverPort = args.port ?? DEFAULT_PORT;
-  const serverURL = `${args.https === true ? 'https' : 'http'}://${serverHost}:${serverPort}`;
-  const showHttpRequests = args.verbose || args.logRequests;
 
   const { createServer } = await import('@callstack/repack-dev-server');
   const { start, stop } = await createServer({

--- a/packages/repack/src/commands/webpack/start.ts
+++ b/packages/repack/src/commands/webpack/start.ts
@@ -108,13 +108,20 @@ export async function start(_: string[], config: Config, args: StartArguments) {
                 method: 'POST',
               });
             },
+            onAdbReverse() {
+              void runAdbReverse({
+                port: serverPort,
+                logger: ctx.log,
+                verbose: true,
+              });
+            },
           },
           { logger: ctx.log }
         );
       }
 
       if (reversePort) {
-        void runAdbReverse(serverPort, ctx.log);
+        void runAdbReverse({ port: serverPort, logger: ctx.log });
       }
 
       const lastStats: Record<string, webpack.StatsCompilation> = {};
@@ -122,7 +129,7 @@ export async function start(_: string[], config: Config, args: StartArguments) {
       compiler.on('watchRun', ({ platform }) => {
         ctx.notifyBuildStart(platform);
         if (platform === 'android') {
-          void runAdbReverse(args.port ?? DEFAULT_PORT, ctx.log);
+          void runAdbReverse({ port: serverPort, logger: ctx.log });
         }
       });
 


### PR DESCRIPTION
### Summary

- [x] - add `adb reverse` interaction under `a`
- [x] - run `adb reverse` by default 
- [x] - automatic `adb reverse` logs are now debug only
- [x] - manual trigger of `adb reverse` through interaction shows up in logs normally

I didn't want to introduce a breaking change in CLI options in this PR so for now we check if the platform is not `ios`. Separate PR will change the `--reverse-port` flag into `--no-reverse-port`

### Test plan

- [x] - unit tessts pass
- [x] - adb interaction works in testers 
