### PR TITLE
[BREAKING] feat: invert the `--reverse-port` CLI option

### DIFF
--- a/.changeset/dull-ants-change.md
+++ b/.changeset/dull-ants-change.md
@@ -1,0 +1,5 @@
+---
+"@callstack/repack": major
+---
+
+Removed `--reverse-port` CLI option and replaced it with `--no-reverse-port` CLI option.

--- a/packages/repack/src/commands/options.ts
+++ b/packages/repack/src/commands/options.ts
@@ -51,8 +51,9 @@ export const startCommandOptions = [
       'Run the dev server for the specified platform only. By default, the dev server will bundle for all platforms.',
   },
   {
-    name: '--reverse-port',
-    description: 'ADB reverse port on starting devServers only for Android',
+    name: '--no-reverse-port',
+    description:
+      'Disables running ADB reverse automatically when bundling for Android',
   },
   {
     name: '--verbose',

--- a/packages/repack/src/commands/rspack/start.ts
+++ b/packages/repack/src/commands/rspack/start.ts
@@ -126,11 +126,7 @@ export async function start(
         );
       }
 
-      if (
-        reversePort ||
-        args.platform === undefined ||
-        args.platform === 'android'
-      ) {
+      if (reversePort) {
         void runAdbReverse({ port: serverPort, logger: ctx.log });
       }
 

--- a/packages/repack/src/commands/webpack/start.ts
+++ b/packages/repack/src/commands/webpack/start.ts
@@ -124,11 +124,7 @@ export async function start(_: string[], config: Config, args: StartArguments) {
         );
       }
 
-      if (
-        reversePort ||
-        args.platform === undefined ||
-        args.platform === 'android'
-      ) {
+      if (reversePort) {
         void runAdbReverse({ port: serverPort, logger: ctx.log });
       }
 


### PR DESCRIPTION
### Summary

Since `adb reverse` will be now run by default, the CLI option of `--reverse-port` was reworked into `--no-reverse-port` to turn off the default behaviour

### Test plan

n/a
