### PR TITLE
Revert "chore: export commands from package entrypoint"

### DIFF
--- a/.changeset/tasty-dolls-lie.md
+++ b/.changeset/tasty-dolls-lie.md
@@ -1,5 +1,0 @@
----
-"@callstack/repack": patch
----
-
-Export commands from package entrypoint

--- a/packages/repack/src/index.ts
+++ b/packages/repack/src/index.ts
@@ -4,5 +4,3 @@ export * from './types';
 export * from './logging';
 export * from './rules';
 export * from './utils';
-export { default as commands } from './commands/rspack';
-export { default as webpackCommands } from './commands/webpack';


### PR DESCRIPTION
Reverts callstack/repack#802

This change caused the need to include both `webpack` and `rspack` after initializing new project using `repack-init` and this is not desired