### PR TITLE
fix: Module Resolution Errors for ScriptManager Imports

### DIFF
--- a/.changeset/quiet-camels-design.md
+++ b/.changeset/quiet-camels-design.md
@@ -1,5 +1,5 @@
 ---
-"@callstack/repack": major
+"@callstack/repack": patch
 ---
 
-Module Resolution Errors for ScriptManager Imports in FederationRuntimePlugin
+Fix ScriptManager import path in MF runtime plugins (CorePlugin & ResolverPlugin)

--- a/.changeset/quiet-camels-design.md
+++ b/.changeset/quiet-camels-design.md
@@ -1,0 +1,5 @@
+---
+"@callstack/repack": major
+---
+
+Module Resolution Errors for ScriptManager Imports in FederationRuntimePlugin

--- a/packages/repack/src/modules/FederationRuntimePlugins/CorePlugin.ts
+++ b/packages/repack/src/modules/FederationRuntimePlugins/CorePlugin.ts
@@ -4,7 +4,7 @@ import type * as RepackClient from '../ScriptManager/index.js';
 const RepackCorePlugin: () => FederationRuntimePlugin = () => ({
   name: 'repack-core-plugin',
   loadEntry: async ({ remoteInfo }) => {
-    const client = require('../ScriptManager.js') as typeof RepackClient;
+    const client = require('../ScriptManager/ScriptManager.js') as typeof RepackClient;
     const { ScriptManager, getWebpackContext } = client;
     const { entry, entryGlobalName } = remoteInfo;
 

--- a/packages/repack/src/modules/FederationRuntimePlugins/CorePlugin.ts
+++ b/packages/repack/src/modules/FederationRuntimePlugins/CorePlugin.ts
@@ -4,7 +4,8 @@ import type * as RepackClient from '../ScriptManager/index.js';
 const RepackCorePlugin: () => FederationRuntimePlugin = () => ({
   name: 'repack-core-plugin',
   loadEntry: async ({ remoteInfo }) => {
-    const client = require('../ScriptManager/ScriptManager.js') as typeof RepackClient;
+    const client =
+      require('../ScriptManager/ScriptManager.js') as typeof RepackClient;
     const { ScriptManager, getWebpackContext } = client;
     const { entry, entryGlobalName } = remoteInfo;
 

--- a/packages/repack/src/modules/FederationRuntimePlugins/ResolverPlugin.ts
+++ b/packages/repack/src/modules/FederationRuntimePlugins/ResolverPlugin.ts
@@ -25,7 +25,7 @@ const RepackResolverPlugin: (
   name: 'repack-resolver-plugin',
   afterResolve(args) {
     const { ScriptManager } =
-      require('../ScriptManager.js') as typeof RepackClient;
+      require('../ScriptManager/ScriptManager.js') as typeof RepackClient;
     const { remoteInfo } = args;
 
     ScriptManager.shared.addResolver(


### PR DESCRIPTION
This PR resolves the module resolution errors that caused the server to fail during startup. The issues stemmed from incorrect import paths for CorePlugin and ResolverPlugin, as well as the ScriptManager module.

![Screenshot 2024-12-20 at 10 41 07](https://github.com/user-attachments/assets/7dd87efd-115c-4222-aa60-9aafa4d97642)
