### PR TITLE
fix: ScriptManager import path in MF runtime plugins (CorePlugin & ResolverPlugin)

### DIFF
--- a/.changeset/lazy-comics-promise.md
+++ b/.changeset/lazy-comics-promise.md
@@ -1,0 +1,5 @@
+---
+"@callstack/repack": patch
+---
+
+Fix ScriptManager import path in MF runtime plugins (CorePlugin & ResolverPlugin)

--- a/packages/repack/src/modules/FederationRuntimePlugins/CorePlugin.ts
+++ b/packages/repack/src/modules/FederationRuntimePlugins/CorePlugin.ts
@@ -4,7 +4,8 @@ import type * as RepackClient from '../ScriptManager/index.js';
 const RepackCorePlugin: () => FederationRuntimePlugin = () => ({
   name: 'repack-core-plugin',
   loadEntry: async ({ remoteInfo }) => {
-    const client = require('../ScriptManager.js') as typeof RepackClient;
+    const client =
+      require('../ScriptManager/index.js') as typeof RepackClient;
     const { ScriptManager, getWebpackContext } = client;
     const { entry, entryGlobalName } = remoteInfo;
 

--- a/packages/repack/src/modules/FederationRuntimePlugins/CorePlugin.ts
+++ b/packages/repack/src/modules/FederationRuntimePlugins/CorePlugin.ts
@@ -4,8 +4,7 @@ import type * as RepackClient from '../ScriptManager/index.js';
 const RepackCorePlugin: () => FederationRuntimePlugin = () => ({
   name: 'repack-core-plugin',
   loadEntry: async ({ remoteInfo }) => {
-    const client =
-      require('../ScriptManager/index.js') as typeof RepackClient;
+    const client = require('../ScriptManager/index.js') as typeof RepackClient;
     const { ScriptManager, getWebpackContext } = client;
     const { entry, entryGlobalName } = remoteInfo;
 

--- a/packages/repack/src/modules/FederationRuntimePlugins/ResolverPlugin.ts
+++ b/packages/repack/src/modules/FederationRuntimePlugins/ResolverPlugin.ts
@@ -25,7 +25,7 @@ const RepackResolverPlugin: (
   name: 'repack-resolver-plugin',
   afterResolve(args) {
     const { ScriptManager } =
-      require('../ScriptManager.js') as typeof RepackClient;
+      require('../ScriptManager/index.js') as typeof RepackClient;
     const { remoteInfo } = args;
 
     ScriptManager.shared.addResolver(


### PR DESCRIPTION
Fix for the reverted changes: https://github.com/callstack/repack/pull/834