### PR TITLE
fix: enable bridgeless mode to fix iOS test app build issues

### DIFF
--- a/apps/tester-app/ios/Podfile.lock
+++ b/apps/tester-app/ios/Podfile.lock
@@ -1,6 +1,6 @@
 PODS:
   - boost (1.84.0)
-  - callstack-repack (5.0.0-rc.3):
+  - callstack-repack (5.0.0-rc.4):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -1942,7 +1942,7 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   boost: 1dca942403ed9342f98334bf4c3621f011aa7946
-  callstack-repack: 5219eedfb8cb06b905edecffaecf71af4a4ecdd6
+  callstack-repack: 8972107231b7175b8340e84ca0370aa2c735dcc7
   DoubleConversion: f16ae600a246532c4020132d54af21d0ddb2a385
   FBLazyVector: be7314029d6ec6b90f0f75ce1195b8130ed9ac4f
   fmt: 10c6e61f4be25dc963c36bd73fc7b1705fe975be
@@ -2005,7 +2005,7 @@ SPEC CHECKSUMS:
   React-utils: 2bcaf4f4dfe361344bce2fae428603d518488630
   ReactCodegen: ae99a130606068ed40d1d9c0d5f25fda142a0647
   ReactCommon: 89c87b343deacc8610b099ac764848f0ce937e3e
-  ReactNativeHost: 40da1d9878e16dd3b647d4c31e5afeb0ed84683d
+  ReactNativeHost: ac28612b0443705f9aa90563ffb9647f5608613c
   ReactTestApp-DevSupport: 4aa6f6bc658a2577bcf896c63c411cb375b89d7d
   ReactTestApp-Resources: 8d72c3deef156833760694a288ff334af4d427d7
   RNCAsyncStorage: 3ad840f7b17b45ca7ebbbb0e80948564a9513315
@@ -2015,6 +2015,6 @@ SPEC CHECKSUMS:
   SwiftyRSA: 8c6dd1ea7db1b8dc4fb517a202f88bb1354bc2c6
   Yoga: f6dc1b6029519815d5516a1241821c6a9074af6d
 
-PODFILE CHECKSUM: 6d7cbe03444d5e87210979fb32a0eca299d758fe
+PODFILE CHECKSUM: 591811811bdab95f1675c6871b0554706bf77020
 
 COCOAPODS: 1.15.2

--- a/apps/tester-federation-v2/android/gradle.properties
+++ b/apps/tester-federation-v2/android/gradle.properties
@@ -40,8 +40,9 @@ reactNativeArchitectures=armeabi-v7a,arm64-v8a,x86,x86_64
 # to write custom TurboModules/Fabric components OR use libraries that
 # are providing them.
 # Note that this is incompatible with web debugging.
-#newArchEnabled=true
-#bridgelessEnabled=true
+newArchEnabled=true
+bridgelessEnabled=true
+hermesEnabled=true
 
 # Uncomment the line below to build React Native from source.
 #react.buildFromSource=true

--- a/apps/tester-federation-v2/ios/Podfile
+++ b/apps/tester-federation-v2/ios/Podfile
@@ -7,7 +7,7 @@ require "#{ws_dir}/node_modules/react-native-test-app/test_app.rb"
 workspace 'ModuleFederationTesterV2.xcworkspace'
 
 options = {
-  :bridgeless_enabled => false,
+  :bridgeless_enabled => true,
   :fabric_enabled => true,
   :hermes_enabled => true,
 }

--- a/apps/tester-federation-v2/ios/Podfile.lock
+++ b/apps/tester-federation-v2/ios/Podfile.lock
@@ -1,6 +1,6 @@
 PODS:
   - boost (1.84.0)
-  - callstack-repack (5.0.0-rc.3):
+  - callstack-repack (5.0.0-rc.4):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -1895,7 +1895,7 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   boost: 1dca942403ed9342f98334bf4c3621f011aa7946
-  callstack-repack: 5219eedfb8cb06b905edecffaecf71af4a4ecdd6
+  callstack-repack: 8972107231b7175b8340e84ca0370aa2c735dcc7
   DoubleConversion: f16ae600a246532c4020132d54af21d0ddb2a385
   FBLazyVector: be7314029d6ec6b90f0f75ce1195b8130ed9ac4f
   fmt: 10c6e61f4be25dc963c36bd73fc7b1705fe975be

--- a/apps/tester-federation/android/gradle.properties
+++ b/apps/tester-federation/android/gradle.properties
@@ -37,7 +37,8 @@ reactNativeArchitectures=armeabi-v7a,arm64-v8a,x86,x86_64
 # are providing them.
 # Note that this is incompatible with web debugging.
 newArchEnabled=true
-bridgelessEnabled=false
+bridgelessEnabled=true
+hermesEnabled=true
 
 # Uncomment the line below to build React Native from source.
 #react.buildFromSource=true

--- a/apps/tester-federation/ios/Podfile
+++ b/apps/tester-federation/ios/Podfile
@@ -7,7 +7,7 @@ require "#{ws_dir}/node_modules/react-native-test-app/test_app.rb"
 workspace 'ModuleFederationTester.xcworkspace'
 
 options = {
-  :bridgeless_enabled => false,
+  :bridgeless_enabled => true,
   :fabric_enabled => true,
   :hermes_enabled => true,
 }

--- a/apps/tester-federation/ios/Podfile.lock
+++ b/apps/tester-federation/ios/Podfile.lock
@@ -1,6 +1,6 @@
 PODS:
   - boost (1.84.0)
-  - callstack-repack (5.0.0-rc.3):
+  - callstack-repack (5.0.0-rc.4):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -1919,7 +1919,7 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   boost: 1dca942403ed9342f98334bf4c3621f011aa7946
-  callstack-repack: 5219eedfb8cb06b905edecffaecf71af4a4ecdd6
+  callstack-repack: 8972107231b7175b8340e84ca0370aa2c735dcc7
   DoubleConversion: f16ae600a246532c4020132d54af21d0ddb2a385
   FBLazyVector: be7314029d6ec6b90f0f75ce1195b8130ed9ac4f
   fmt: 10c6e61f4be25dc963c36bd73fc7b1705fe975be


### PR DESCRIPTION
The iOS test apps were failing to build due to the following error:
`/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator18.1.sdk/usr/include/c++/v1/__memory/unique_ptr.h:64:19 Invalid application of 'sizeof' to an incomplete type 'facebook::react::JSExecutorFactory'
`
Only happened with: `bridgeless_enabled => false`.

