### PR TITLE
fix: refresh utils missing apply compiler in DevelopmentPlugin

### DIFF
--- a/.changeset/fifty-rockets-laugh.md
+++ b/.changeset/fifty-rockets-laugh.md
@@ -1,0 +1,5 @@
+---
+"@callstack/repack": patch
+---
+
+Fix missing apply on ProvidePlugin for React Refresh Utils in DevelopmentPlugin

--- a/packages/repack/src/plugins/DevelopmentPlugin.ts
+++ b/packages/repack/src/plugins/DevelopmentPlugin.ts
@@ -107,7 +107,7 @@ export class DevelopmentPlugin implements RspackPluginInstance {
 
       new compiler.webpack.ProvidePlugin({
         __react_refresh_utils__: refreshUtilsPath,
-      });
+      }).apply(compiler);
 
       const refreshPath = path.dirname(require.resolve('react-refresh'));
       compiler.options.resolve.alias = {


### PR DESCRIPTION
### Summary

added missing `.apply(compiler)` for providing `reactRefreshUtils`

### Test plan

n/a
