### PR TITLE
fix: missing swc config in RN & NM rules

### DIFF
--- a/.changeset/nervous-wasps-applaud.md
+++ b/.changeset/nervous-wasps-applaud.md
@@ -1,0 +1,5 @@
+---
+"@callstack/repack": patch
+---
+
+Fix missing config for swc loader rules

--- a/apps/tester-app/rspack.config.mjs
+++ b/apps/tester-app/rspack.config.mjs
@@ -64,7 +64,6 @@ export default (env) => {
             /** @type {import('@rspack/core').SwcLoaderOptions} */
             options: {
               env: {
-                bugfixes: true,
                 loose: true,
                 targets: {
                   'react-native': '0.74',

--- a/apps/tester-app/rspack.config.mjs
+++ b/apps/tester-app/rspack.config.mjs
@@ -64,6 +64,8 @@ export default (env) => {
             /** @type {import('@rspack/core').SwcLoaderOptions} */
             options: {
               env: {
+                bugfixes: true,
+                loose: true,
                 targets: {
                   'react-native': '0.74',
                 },

--- a/apps/tester-federation-v2/rspack.config.host-app.mjs
+++ b/apps/tester-federation-v2/rspack.config.host-app.mjs
@@ -58,7 +58,11 @@ export default (env) => {
           use: {
             loader: 'builtin:swc-loader',
             options: {
-              env: { targets: { 'react-native': '0.74' } },
+              env: {
+                bugfixes: true,
+                loose: true,
+                targets: { 'react-native': '0.74' },
+              },
               jsc: { externalHelpers: true },
             },
           },
@@ -74,6 +78,8 @@ export default (env) => {
             options: {
               sourceMaps: true,
               env: {
+                bugfixes: true,
+                loose: true,
                 targets: { 'react-native': '0.74' },
               },
               jsc: {

--- a/apps/tester-federation-v2/rspack.config.host-app.mjs
+++ b/apps/tester-federation-v2/rspack.config.host-app.mjs
@@ -59,7 +59,6 @@ export default (env) => {
             loader: 'builtin:swc-loader',
             options: {
               env: {
-                bugfixes: true,
                 loose: true,
                 targets: { 'react-native': '0.74' },
               },
@@ -78,7 +77,6 @@ export default (env) => {
             options: {
               sourceMaps: true,
               env: {
-                bugfixes: true,
                 loose: true,
                 targets: { 'react-native': '0.74' },
               },

--- a/apps/tester-federation-v2/rspack.config.mini-app.mjs
+++ b/apps/tester-federation-v2/rspack.config.mini-app.mjs
@@ -58,7 +58,6 @@ export default (env) => {
             loader: 'builtin:swc-loader',
             options: {
               env: {
-                bugfixes: true,
                 loose: true,
                 targets: { 'react-native': '0.74' },
               },
@@ -77,7 +76,6 @@ export default (env) => {
             options: {
               sourceMaps: true,
               env: {
-                bugfixes: true,
                 loose: true,
                 targets: { 'react-native': '0.74' },
               },

--- a/apps/tester-federation-v2/rspack.config.mini-app.mjs
+++ b/apps/tester-federation-v2/rspack.config.mini-app.mjs
@@ -57,7 +57,11 @@ export default (env) => {
           use: {
             loader: 'builtin:swc-loader',
             options: {
-              env: { targets: { 'react-native': '0.74' } },
+              env: {
+                bugfixes: true,
+                loose: true,
+                targets: { 'react-native': '0.74' },
+              },
               jsc: { externalHelpers: true },
             },
           },
@@ -73,6 +77,8 @@ export default (env) => {
             options: {
               sourceMaps: true,
               env: {
+                bugfixes: true,
+                loose: true,
                 targets: { 'react-native': '0.74' },
               },
               jsc: {

--- a/apps/tester-federation/rspack.config.host-app.mjs
+++ b/apps/tester-federation/rspack.config.host-app.mjs
@@ -64,7 +64,11 @@ export default (env) => {
           use: {
             loader: 'builtin:swc-loader',
             options: {
-              env: { targets: { 'react-native': '0.74' } },
+              env: {
+                bugfixes: true,
+                loose: true,
+                targets: { 'react-native': '0.74' },
+              },
               jsc: { externalHelpers: true },
             },
           },
@@ -80,6 +84,8 @@ export default (env) => {
             options: {
               sourceMaps: true,
               env: {
+                bugfixes: true,
+                loose: true,
                 targets: { 'react-native': '0.74' },
               },
               jsc: {

--- a/apps/tester-federation/rspack.config.host-app.mjs
+++ b/apps/tester-federation/rspack.config.host-app.mjs
@@ -65,7 +65,6 @@ export default (env) => {
             loader: 'builtin:swc-loader',
             options: {
               env: {
-                bugfixes: true,
                 loose: true,
                 targets: { 'react-native': '0.74' },
               },
@@ -84,7 +83,6 @@ export default (env) => {
             options: {
               sourceMaps: true,
               env: {
-                bugfixes: true,
                 loose: true,
                 targets: { 'react-native': '0.74' },
               },

--- a/apps/tester-federation/rspack.config.mini-app.mjs
+++ b/apps/tester-federation/rspack.config.mini-app.mjs
@@ -64,7 +64,6 @@ export default (env) => {
             loader: 'builtin:swc-loader',
             options: {
               env: {
-                bugfixes: true,
                 loose: true,
                 targets: { 'react-native': '0.74' },
               },
@@ -83,7 +82,6 @@ export default (env) => {
             options: {
               sourceMaps: true,
               env: {
-                bugfixes: true,
                 loose: true,
                 targets: { 'react-native': '0.74' },
               },

--- a/apps/tester-federation/rspack.config.mini-app.mjs
+++ b/apps/tester-federation/rspack.config.mini-app.mjs
@@ -63,7 +63,11 @@ export default (env) => {
           use: {
             loader: 'builtin:swc-loader',
             options: {
-              env: { targets: { 'react-native': '0.74' } },
+              env: {
+                bugfixes: true,
+                loose: true,
+                targets: { 'react-native': '0.74' },
+              },
               jsc: { externalHelpers: true },
             },
           },
@@ -79,6 +83,8 @@ export default (env) => {
             options: {
               sourceMaps: true,
               env: {
+                bugfixes: true,
+                loose: true,
                 targets: { 'react-native': '0.74' },
               },
               jsc: {

--- a/packages/repack/src/rules/nodeModulesLoadingRules.ts
+++ b/packages/repack/src/rules/nodeModulesLoadingRules.ts
@@ -5,7 +5,6 @@ const makeSwcLoaderConfig = (syntax: 'js' | 'ts', jsx: boolean) => ({
   loader: 'builtin:swc-loader',
   options: {
     env: {
-      bugfixes: true,
       loose: true,
       targets: { 'react-native': '0.74' },
     },

--- a/packages/repack/src/rules/nodeModulesLoadingRules.ts
+++ b/packages/repack/src/rules/nodeModulesLoadingRules.ts
@@ -5,6 +5,8 @@ const makeSwcLoaderConfig = (syntax: 'js' | 'ts', jsx: boolean) => ({
   loader: 'builtin:swc-loader',
   options: {
     env: {
+      bugfixes: true,
+      loose: true,
       targets: { 'react-native': '0.74' },
     },
     jsc: {
@@ -24,6 +26,7 @@ const makeSwcLoaderConfig = (syntax: 'js' | 'ts', jsx: boolean) => ({
       type: 'commonjs',
       strict: false,
       strictMode: false,
+      noInterop: false,
     },
   },
 });

--- a/packages/repack/src/rules/reactNativeLoadingRules.ts
+++ b/packages/repack/src/rules/reactNativeLoadingRules.ts
@@ -23,7 +23,6 @@ export const REACT_NATIVE_LOADING_RULES: RuleSetRule = {
       loader: 'builtin:swc-loader',
       options: {
         env: {
-          bugfixes: true,
           loose: true,
           targets: { 'react-native': '0.74' },
         },

--- a/packages/repack/src/rules/reactNativeLoadingRules.ts
+++ b/packages/repack/src/rules/reactNativeLoadingRules.ts
@@ -23,6 +23,8 @@ export const REACT_NATIVE_LOADING_RULES: RuleSetRule = {
       loader: 'builtin:swc-loader',
       options: {
         env: {
+          bugfixes: true,
+          loose: true,
           targets: { 'react-native': '0.74' },
         },
         jsc: {
@@ -47,6 +49,7 @@ export const REACT_NATIVE_LOADING_RULES: RuleSetRule = {
           strict: false,
           strictMode: false,
           lazy: REACT_NATIVE_LAZY_IMPORTS,
+          noInterop: false,
         },
       },
     },

--- a/templates_v5/rspack.config.cjs
+++ b/templates_v5/rspack.config.cjs
@@ -104,6 +104,8 @@ module.exports = (env) => {
             loader: 'builtin:swc-loader',
             options: {
               env: {
+                bugfixes: true,
+                loose: true,
                 targets: {
                   'react-native': '0.74',
                 },

--- a/templates_v5/rspack.config.cjs
+++ b/templates_v5/rspack.config.cjs
@@ -104,7 +104,6 @@ module.exports = (env) => {
             loader: 'builtin:swc-loader',
             options: {
               env: {
-                bugfixes: true,
                 loose: true,
                 targets: {
                   'react-native': '0.74',

--- a/templates_v5/rspack.config.mjs
+++ b/templates_v5/rspack.config.mjs
@@ -102,7 +102,6 @@ export default (env) => {
             /** @type {import('@rspack/core').SwcLoaderOptions} */
             options: {
               env: {
-                bugfixes: true,
                 loose: true,
                 targets: {
                   'react-native': '0.74',

--- a/templates_v5/rspack.config.mjs
+++ b/templates_v5/rspack.config.mjs
@@ -102,6 +102,8 @@ export default (env) => {
             /** @type {import('@rspack/core').SwcLoaderOptions} */
             options: {
               env: {
+                bugfixes: true,
+                loose: true,
                 targets: {
                   'react-native': '0.74',
                 },


### PR DESCRIPTION
### Summary

added some missing configuration to `builtin:swc-loader` rules:
- [x] - enabled `loose` in env options which as it turns out is different from `loose` in jsc options - and we need both to match the babel preset
- [x] - added explicit `noInterop` option set to false for visibility 

### Test plan

n/a