### PR TITLE
perf: do 'lazy' comparison in 'checkIfCacheDataOutdated'

### DIFF
--- a/.changeset/tricky-keys-kneel.md
+++ b/.changeset/tricky-keys-kneel.md
@@ -1,0 +1,5 @@
+---
+"@callstack/repack": minor
+---
+
+Optimize 'checkIfCacheDataOutdated' to do as few comparisons as possible

--- a/packages/repack/src/modules/ScriptManager/Script.ts
+++ b/packages/repack/src/modules/ScriptManager/Script.ts
@@ -213,15 +213,13 @@ export class Script {
       'method' | 'url' | 'query' | 'headers' | 'body'
     >
   ) {
-    const diffs = [
-      cachedData.method !== this.locator.method,
-      cachedData.url !== this.locator.url,
-      cachedData.query !== this.locator.query,
-      !shallowEqual(cachedData.headers, this.locator.headers),
-      cachedData.body !== this.locator.body,
-    ];
-
-    return diffs.some((diff) => diff);
+    return (
+      cachedData.method !== this.locator.method ||
+      cachedData.url !== this.locator.url ||
+      cachedData.query !== this.locator.query ||
+      !shallowEqual(cachedData.headers, this.locator.headers) ||
+      cachedData.body !== this.locator.body
+    );
   }
 
   /**


### PR DESCRIPTION
Simplifies comparison with cached data. Also does not 'precompute' it before doing the comparison, so expression terminates on first difference.

### Summary

Not sure if it is a real problem as the code might be called infrequently. I was just bugged by the eager version.

### Test plan

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
