### PR TITLE
fix: loading of 2nd level MF2 remotes

### DIFF
--- a/.changeset/curvy-lamps-kneel.md
+++ b/.changeset/curvy-lamps-kneel.md
@@ -1,0 +1,5 @@
+---
+"@callstack/repack": patch
+---
+
+Fix loading of 2nd level Module Federation 2 remotes

--- a/packages/repack/src/modules/FederationRuntimePlugins/CorePlugin.ts
+++ b/packages/repack/src/modules/FederationRuntimePlugins/CorePlugin.ts
@@ -27,6 +27,14 @@ const RepackCorePlugin: () => FederationRuntimePlugin = () => ({
       console.error(`Failed to load remote entry: ${entryGlobalName}`);
     }
   },
+  generatePreloadAssets: async () => {
+    // noop for compatibility
+    return Promise.resolve({
+      cssAssets: [],
+      jsAssetsWithoutEntry: [],
+      entryAssets: [],
+    });
+  },
 });
 
 export default RepackCorePlugin;

--- a/packages/repack/src/plugins/ModuleFederationPluginV2.ts
+++ b/packages/repack/src/plugins/ModuleFederationPluginV2.ts
@@ -265,14 +265,6 @@ export class ModuleFederationPluginV2 implements RspackPluginInstance {
 
     const ModuleFederationPlugin = this.getModuleFederationPlugin(compiler);
 
-    const libraryConfig = this.config.exposes
-      ? {
-          name: this.config.name,
-          type: 'self',
-          ...this.config.library,
-        }
-      : undefined;
-
     const sharedConfig = this.adaptSharedDependencies(
       this.config.shared ?? this.getDefaultSharedDependencies()
     );
@@ -284,9 +276,12 @@ export class ModuleFederationPluginV2 implements RspackPluginInstance {
       this.config.runtimePlugins
     );
 
+    // NOTE: we keep the default library config since it's the most compatible
+    // Default library config uses 'externalType': 'script' and 'type': 'var'
+    // var works identical to 'self' since declaring var in a global scope is
+    // equal to assigning to the globalObject (normalized by Re.Pack to 'self')
     const config: MF.ModuleFederationPluginOptions = {
       ...this.config,
-      library: libraryConfig,
       shared: sharedConfig,
       shareStrategy: shareStrategyConfig,
       runtimePlugins: runtimePluginsConfig,


### PR DESCRIPTION
### Summary

If the library config is not set to `script`, MF2 will not handle 2nd level remotes correctly (as in remotes of remotes). This can be currently observed in the super app showcase where it fails to load `AccountScreen` inside of any of the MiniApps.

Setting library type to `script` results in `preloadAssets` flow being trigger, so to counter this I've added a noop handler inside `generatePreloadAssets` hook. This is not needed anyways since when this method is called the assets (chunks of the remote) are already loaded into the container variable in the global scope. Setting this to a noop avoids a flow which is tailored for the browser environment (with `document` object present)

This should most likely be fixed in MF2 core itself but the solution to a [similar issue](https://github.com/module-federation/core/issues/2537#issuecomment-2559731822) boils down to using `script` as a workaround for now. 

### Test plan

- [x] - 2nd level remotes load in super app showcase
