### PR TITLE
feat: ship with `babel-loader` as a dependency

### DIFF
--- a/.changeset/unlucky-starfishes-thank.md
+++ b/.changeset/unlucky-starfishes-thank.md
@@ -1,0 +1,5 @@
+---
+"@callstack/repack": minor
+---
+
+Make babel-loader a dependecy

--- a/apps/tester-app/package.json
+++ b/apps/tester-app/package.json
@@ -38,7 +38,6 @@
     "@swc/helpers": "^0.5.13",
     "@types/jest": "^29.5.12",
     "@types/react": "^18.2.51",
-    "babel-loader": "^9.1.3",
     "execa": "^6.1.0",
     "get-port": "^6.1.2",
     "globby": "^13.1.2",

--- a/apps/tester-federation-v2/package.json
+++ b/apps/tester-federation-v2/package.json
@@ -32,7 +32,6 @@
     "@swc/helpers": "^0.5.13",
     "@types/jest": "^29.5.12",
     "@types/react": "^18.2.51",
-    "babel-loader": "^9.1.3",
     "execa": "^6.1.0",
     "get-port": "^6.1.2",
     "globby": "^13.1.2",

--- a/apps/tester-federation/package.json
+++ b/apps/tester-federation/package.json
@@ -39,7 +39,6 @@
     "@swc/helpers": "^0.5.13",
     "@types/jest": "^29.5.12",
     "@types/react": "^18.2.51",
-    "babel-loader": "^9.1.3",
     "execa": "^6.1.0",
     "get-port": "^6.1.2",
     "globby": "^13.1.2",

--- a/packages/init/src/tasks/addDependencies.ts
+++ b/packages/init/src/tasks/addDependencies.ts
@@ -8,7 +8,6 @@ import logger from '../utils/logger.js';
 
 const rspackDependencies = [
   '@rspack/core@1.0.3', // 1.0.4 breaks sourcemaps
-  'babel-loader', // still needed for codegen
   '@swc/helpers',
   '@callstack/repack',
 ];
@@ -16,7 +15,6 @@ const rspackDependencies = [
 const webpackDependencies = [
   'webpack',
   'terser-webpack-plugin',
-  'babel-loader',
   '@callstack/repack',
 ];
 

--- a/packages/repack/package.json
+++ b/packages/repack/package.json
@@ -79,6 +79,7 @@
     "@callstack/repack-dev-server": "workspace:*",
     "@discoveryjs/json-ext": "^0.5.7",
     "@rspack/plugin-react-refresh": "1.0.0",
+    "babel-loader": "^9.2.1",
     "colorette": "^2.0.20",
     "dedent": "^0.7.0",
     "events": "^3.3.0",

--- a/packages/repack/src/plugins/BabelPlugin.ts
+++ b/packages/repack/src/plugins/BabelPlugin.ts
@@ -1,0 +1,21 @@
+import type { Compiler, RspackPluginInstance } from '@rspack/core';
+
+/**
+ * Plugin that adds babel-loader fallback to resolveLoader configuration.
+ * This ensures babel-loader can be resolved regardless of the package manager used,
+ * as some package managers (like pnpm) require loaders to be direct dependencies
+ * rather than allowing them to be resolved through nested dependencies.
+ *
+ * @category Webpack Plugin
+ */
+export class BabelPlugin implements RspackPluginInstance {
+  apply(compiler: Compiler) {
+    compiler.options.resolveLoader = {
+      ...compiler.options.resolveLoader,
+      fallback: {
+        ...compiler.options.resolveLoader?.fallback,
+        'babel-loader': require.resolve('babel-loader'),
+      },
+    };
+  }
+}

--- a/packages/repack/src/plugins/RepackPlugin.ts
+++ b/packages/repack/src/plugins/RepackPlugin.ts
@@ -1,5 +1,6 @@
 import type { Compiler, RspackPluginInstance } from '@rspack/core';
 import type { DevServerOptions } from '../types.js';
+import { BabelPlugin } from './BabelPlugin.js';
 import { DevelopmentPlugin } from './DevelopmentPlugin.js';
 import { LoggerPlugin, type LoggerPluginConfig } from './LoggerPlugin.js';
 import { NativeEntryPlugin } from './NativeEntryPlugin.js';
@@ -150,6 +151,8 @@ export class RepackPlugin implements RspackPluginInstance {
     new compiler.webpack.DefinePlugin({
       __DEV__: JSON.stringify(this.config.mode === 'development'),
     }).apply(compiler);
+
+    new BabelPlugin().apply(compiler);
 
     new OutputPlugin({
       platform: this.config.platform,

--- a/packages/repack/src/plugins/index.ts
+++ b/packages/repack/src/plugins/index.ts
@@ -1,6 +1,7 @@
 export * from './DevelopmentPlugin.js';
 export * from './LoggerPlugin.js';
 export * from './ManifestPlugin.js';
+export * from './BabelPlugin.js';
 export * from './OutputPlugin/index.js';
 export * from './RepackTargetPlugin/index.js';
 export * from './ModuleFederationPlugin.js';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -111,9 +111,6 @@ importers:
       '@types/react':
         specifier: ^18.2.51
         version: 18.3.3
-      babel-loader:
-        specifier: ^9.1.3
-        version: 9.1.3(@babel/core@7.25.2)(webpack@5.94.0)
       execa:
         specifier: ^6.1.0
         version: 6.1.0
@@ -202,9 +199,6 @@ importers:
       '@types/react':
         specifier: ^18.2.51
         version: 18.3.3
-      babel-loader:
-        specifier: ^9.1.3
-        version: 9.1.3(@babel/core@7.25.2)(webpack@5.94.0)
       execa:
         specifier: ^6.1.0
         version: 6.1.0
@@ -284,9 +278,6 @@ importers:
       '@types/react':
         specifier: ^18.2.51
         version: 18.3.3
-      babel-loader:
-        specifier: ^9.1.3
-        version: 9.1.3(@babel/core@7.25.2)(webpack@5.94.0)
       execa:
         specifier: ^6.1.0
         version: 6.1.0
@@ -3197,13 +3188,6 @@ packages:
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     peerDependencies:
       '@babel/core': ^7.8.0
-
-  babel-loader@9.1.3:
-    resolution: {integrity: sha512-xG3ST4DglodGf8qSwv0MdeWLhrDsw/32QMdTO5T1ZIp9gQur0HkCyFs7Awskr10JKXFXwpAhiCuYX5oGXnRGbw==}
-    engines: {node: '>= 14.15.0'}
-    peerDependencies:
-      '@babel/core': ^7.12.0
-      webpack: '>=5'
 
   babel-loader@9.2.1:
     resolution: {integrity: sha512-fqe8naHt46e0yIdkjUZYqddSXfej3AHajX+CSO5X7oy0EmPc6o5Xh+RClNoHjnieWz9AW4kZxW9yyFMhVB1QLA==}
@@ -11068,13 +11052,6 @@ snapshots:
       slash: 3.0.0
     transitivePeerDependencies:
       - supports-color
-
-  babel-loader@9.1.3(@babel/core@7.25.2)(webpack@5.94.0):
-    dependencies:
-      '@babel/core': 7.25.2
-      find-cache-dir: 4.0.0
-      schema-utils: 4.2.0
-      webpack: 5.94.0
 
   babel-loader@9.2.1(@babel/core@7.25.2)(webpack@5.94.0):
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -448,6 +448,9 @@ importers:
       '@rspack/plugin-react-refresh':
         specifier: 1.0.0
         version: 1.0.0(react-refresh@0.14.2)
+      babel-loader:
+        specifier: ^9.2.1
+        version: 9.2.1(@babel/core@7.25.2)(webpack@5.94.0)
       colorette:
         specifier: ^2.0.20
         version: 2.0.20
@@ -3197,6 +3200,13 @@ packages:
 
   babel-loader@9.1.3:
     resolution: {integrity: sha512-xG3ST4DglodGf8qSwv0MdeWLhrDsw/32QMdTO5T1ZIp9gQur0HkCyFs7Awskr10JKXFXwpAhiCuYX5oGXnRGbw==}
+    engines: {node: '>= 14.15.0'}
+    peerDependencies:
+      '@babel/core': ^7.12.0
+      webpack: '>=5'
+
+  babel-loader@9.2.1:
+    resolution: {integrity: sha512-fqe8naHt46e0yIdkjUZYqddSXfej3AHajX+CSO5X7oy0EmPc6o5Xh+RClNoHjnieWz9AW4kZxW9yyFMhVB1QLA==}
     engines: {node: '>= 14.15.0'}
     peerDependencies:
       '@babel/core': ^7.12.0
@@ -11060,6 +11070,13 @@ snapshots:
       - supports-color
 
   babel-loader@9.1.3(@babel/core@7.25.2)(webpack@5.94.0):
+    dependencies:
+      '@babel/core': 7.25.2
+      find-cache-dir: 4.0.0
+      schema-utils: 4.2.0
+      webpack: 5.94.0
+
+  babel-loader@9.2.1(@babel/core@7.25.2)(webpack@5.94.0):
     dependencies:
       '@babel/core': 7.25.2
       find-cache-dir: 4.0.0

--- a/website/src/5.x/api/plugins/internal.md
+++ b/website/src/5.x/api/plugins/internal.md
@@ -1,7 +1,15 @@
 # Internal plugins
 
 ## OutputPlugin
+
 ## LoggerPlugin
+
 ## NativeEntryPlugin
+
 ## DevelopmentPlugin
+
 ## RepackTargetPlugin
+
+## BabelPlugin
+
+Plugin that adds `babel-loader` fallback to resolveLoader configuration. This ensures babel-loader can be resolved regardless of the package manager used, as some package managers (like `pnpm`) require loaders to be direct dependencies rather than allowing them to be resolved through nested dependencies.

--- a/website/src/5.x/docs/getting-started/quick-start.mdx
+++ b/website/src/5.x/docs/getting-started/quick-start.mdx
@@ -95,9 +95,9 @@ If the [automatic installation](#installation) didn't work for any reason, or yo
 
 Install required dependencies in your project:
 
-<PackageManagerTabs command="install -D webpack terser-webpack-plugin babel-loader @callstack/repack" />
+<PackageManagerTabs command="install -D webpack terser-webpack-plugin @callstack/repack" />
 
-This will install latest versions of Webpack, Re.Pack and dependencies used in Webpack config: `terser-webpack-plugin` for minification and `babel-loader` for transpiling the code.
+This will install latest versions of Webpack, Re.Pack and dependencies used in Webpack config: `terser-webpack-plugin` for minification.
 
 If you already have Webpack or Re.Pack installed, you might want to check the [compatibility table](#compatibility-with-webpack) to ensure all dependencies are ok.
 


### PR DESCRIPTION
### Summary

instead of installing `babel-loader` as a separate dependency, it is now marked as a dependency of Re.Pack so it can be available in all configurations. `BabelPlugin` ensures that it's available in all kinds of setups (like pnpm) where `babel-loader` might be needed as a direct dependency of a project. 

- [x] - add `babel-loader` as dependecy
- [x] - add `BabelPlugin`
- [x] - added docs for BabelPlugin

### Test plan

n/a
