### PR TITLE
fix: decouple init & module error handling from runtime module

### DIFF
--- a/.changeset/pink-pants-vanish.md
+++ b/.changeset/pink-pants-vanish.md
@@ -1,0 +1,5 @@
+---
+"@callstack/repack": patch
+---
+
+Decouple init & module error handling from load script runtime module inside RepackTargetPlugin

--- a/apps/tester-app/webpack.config.mjs
+++ b/apps/tester-app/webpack.config.mjs
@@ -1,6 +1,7 @@
 import { createRequire } from 'node:module';
 import path from 'node:path';
 import * as Repack from '@callstack/repack';
+import { ReanimatedPlugin } from '@callstack/repack-plugin-reanimated';
 import TerserPlugin from 'terser-webpack-plugin';
 
 const dirname = Repack.getDirname(import.meta.url);
@@ -196,6 +197,7 @@ export default (env) => {
           },
         ],
       }),
+      new ReanimatedPlugin(),
       // new Repack.plugins.ChunksToHermesBytecodePlugin({
       //   enabled: mode === 'production' && !devServer,
       //   test: /\.(js)?bundle$/,

--- a/packages/repack/src/modules/ScriptManager/Script.ts
+++ b/packages/repack/src/modules/ScriptManager/Script.ts
@@ -4,7 +4,7 @@ import {
   NormalizedScriptLocatorHTTPMethod,
   NormalizedScriptLocatorSignatureVerificationMode,
 } from './NativeScriptManager.js';
-import type { ScriptLocator, WebpackContext } from './types.js';
+import type { ScriptLocator } from './types.js';
 
 /**
  * Representation of a Script to load and execute, used by {@link ScriptManager}.
@@ -24,7 +24,7 @@ export class Script {
    * @param scriptId Id of the script.
    */
   static getDevServerURL(scriptId: string) {
-    return (webpackContext: WebpackContext) =>
+    return (webpackContext: WebpackRequire) =>
       `${webpackContext.p}${webpackContext.u(scriptId)}`;
   }
 
@@ -34,7 +34,7 @@ export class Script {
    * @param scriptId Id of the script.
    */
   static getFileSystemURL(scriptId: string) {
-    return (webpackContext: WebpackContext) =>
+    return (webpackContext: WebpackRequire) =>
       webpackContext.u(`file:///${scriptId}`);
   }
 
@@ -55,7 +55,7 @@ export class Script {
       return url;
     }
 
-    return (webpackContext: WebpackContext) => webpackContext.u(url);
+    return (webpackContext: WebpackRequire) => webpackContext.u(url);
   }
 
   /**

--- a/packages/repack/src/modules/ScriptManager/Script.ts
+++ b/packages/repack/src/modules/ScriptManager/Script.ts
@@ -24,7 +24,7 @@ export class Script {
    * @param scriptId Id of the script.
    */
   static getDevServerURL(scriptId: string) {
-    return (webpackContext: WebpackRequire) =>
+    return (webpackContext: RepackRuntimeGlobals.WebpackRequire) =>
       `${webpackContext.p}${webpackContext.u(scriptId)}`;
   }
 
@@ -34,7 +34,7 @@ export class Script {
    * @param scriptId Id of the script.
    */
   static getFileSystemURL(scriptId: string) {
-    return (webpackContext: WebpackRequire) =>
+    return (webpackContext: RepackRuntimeGlobals.WebpackRequire) =>
       webpackContext.u(`file:///${scriptId}`);
   }
 
@@ -55,7 +55,8 @@ export class Script {
       return url;
     }
 
-    return (webpackContext: WebpackRequire) => webpackContext.u(url);
+    return (webpackContext: RepackRuntimeGlobals.WebpackRequire) =>
+      webpackContext.u(url);
   }
 
   /**

--- a/packages/repack/src/modules/ScriptManager/__tests__/ScriptManager.test.ts
+++ b/packages/repack/src/modules/ScriptManager/__tests__/ScriptManager.test.ts
@@ -21,11 +21,10 @@ jest.mock('../NativeScriptManager', () => ({
 
 globalThis.__webpack_require__ = {
   i: [],
+  l: () => {},
   u: (id: string) => `${id}.chunk.bundle`,
   p: () => '',
   repack: {
-    loadScript: jest.fn(),
-    loadHotUpdate: jest.fn(),
     shared: { scriptManager: undefined },
   },
 };

--- a/packages/repack/src/modules/ScriptManager/federated.ts
+++ b/packages/repack/src/modules/ScriptManager/federated.ts
@@ -13,7 +13,10 @@ export namespace Federated {
   export type URLResolver = (
     scriptId: string,
     caller?: string
-  ) => string | ((webpackContext: WebpackRequire) => string) | undefined;
+  ) =>
+    | string
+    | ((webpackContext: RepackRuntimeGlobals.WebpackRequire) => string)
+    | undefined;
 
   /**
    * @deprecated
@@ -205,7 +208,7 @@ export namespace Federated {
           );
 
           if (url.includes('[ext]')) {
-            return (webpackContext: WebpackRequire) =>
+            return (webpackContext: RepackRuntimeGlobals.WebpackRequire) =>
               webpackContext.u(url.replace(/\[ext\]/g, ''));
           }
 

--- a/packages/repack/src/modules/ScriptManager/federated.ts
+++ b/packages/repack/src/modules/ScriptManager/federated.ts
@@ -1,5 +1,4 @@
 import { ScriptManager } from './ScriptManager.js';
-import type { WebpackContext } from './types.js';
 
 /**
  * Namespace for runtime utilities for Module Federation.
@@ -14,7 +13,7 @@ export namespace Federated {
   export type URLResolver = (
     scriptId: string,
     caller?: string
-  ) => string | ((webpackContext: WebpackContext) => string) | undefined;
+  ) => string | ((webpackContext: WebpackRequire) => string) | undefined;
 
   /**
    * @deprecated
@@ -206,7 +205,7 @@ export namespace Federated {
           );
 
           if (url.includes('[ext]')) {
-            return (webpackContext: WebpackContext) =>
+            return (webpackContext: WebpackRequire) =>
               webpackContext.u(url.replace(/\[ext\]/g, ''));
           }
 

--- a/packages/repack/src/modules/ScriptManager/getWebpackContext.ts
+++ b/packages/repack/src/modules/ScriptManager/getWebpackContext.ts
@@ -1,10 +1,8 @@
-import type { WebpackContext } from './types.js';
-
 /**
  * Get Webpack runtime context form current JavaScript scope.
  *
  * __You likely don't need to use it.__
  */
-export function getWebpackContext(): WebpackContext {
+export function getWebpackContext(): WebpackRequire {
   return __webpack_require__;
 }

--- a/packages/repack/src/modules/ScriptManager/getWebpackContext.ts
+++ b/packages/repack/src/modules/ScriptManager/getWebpackContext.ts
@@ -3,6 +3,6 @@
  *
  * __You likely don't need to use it.__
  */
-export function getWebpackContext(): WebpackRequire {
+export function getWebpackContext(): RepackRuntimeGlobals.WebpackRequire {
   return __webpack_require__;
 }

--- a/packages/repack/src/modules/ScriptManager/types.ts
+++ b/packages/repack/src/modules/ScriptManager/types.ts
@@ -1,27 +1,3 @@
-type ModuleExports = Record<string | number | symbol, any>;
-
-type ModuleObject = {
-  id: number;
-  loaded: boolean;
-  error?: any;
-  exports: ModuleExports;
-};
-
-export interface WebpackContext {
-  i: ((options: {
-    id: number;
-    factory: (
-      moduleObject: ModuleObject,
-      moduleExports: ModuleExports,
-      webpackRequire: WebpackContext
-    ) => void;
-    module: ModuleObject;
-    require: WebpackContext;
-  }) => void)[];
-  p: () => string;
-  u: (id: string) => string;
-}
-
 /**
  * Interface specifying how to fetch a script.
  * It represents the output of {@link ScriptLocatorResolver} function used by {@link ScriptManager}.
@@ -38,7 +14,7 @@ export interface ScriptLocator {
    *
    * **Passing query params might lead to unexpected results. To pass query params use `query` field.**
    */
-  url: string | ((webpackContext: WebpackContext) => string);
+  url: string | ((webpackContext: typeof __webpack_require__) => string);
 
   /**
    * Query params to append when building the final URL.

--- a/packages/repack/src/plugins/RepackTargetPlugin/InitRuntimeModule.ts
+++ b/packages/repack/src/plugins/RepackTargetPlugin/InitRuntimeModule.ts
@@ -1,19 +1,32 @@
-import { RuntimeModule, Template } from '@rspack/core';
+import type {
+  Compiler,
+  RuntimeModule as RuntimeModuleType,
+} from '@rspack/core';
 
 interface InitRuntimeModuleConfig {
   globalObject: string;
 }
 
-export class InitRuntimeModule extends RuntimeModule {
-  constructor(private config: InitRuntimeModuleConfig) {
-    super('repack/init', RuntimeModule.STAGE_BASIC);
-  }
+export const makeInitRuntimeModule = (
+  compiler: Compiler,
+  moduleConfig: InitRuntimeModuleConfig
+): RuntimeModuleType => {
+  const Template = compiler.webpack.Template;
+  const RuntimeModule = compiler.webpack.RuntimeModule;
 
-  generate() {
-    return Template.asString([
-      Template.getFunctionContent(
-        require('./implementation/init.js')
-      ).replaceAll('$globalObject$', this.config.globalObject),
-    ]);
-  }
-}
+  const InitRuntimeModule = class extends RuntimeModule {
+    constructor(private config: InitRuntimeModuleConfig) {
+      super('repack/init', RuntimeModule.STAGE_BASIC);
+    }
+
+    generate() {
+      return Template.asString([
+        Template.getFunctionContent(
+          require('./implementation/init.js')
+        ).replaceAll('$globalObject$', this.config.globalObject),
+      ]);
+    }
+  };
+
+  return new InitRuntimeModule(moduleConfig);
+};

--- a/packages/repack/src/plugins/RepackTargetPlugin/InitRuntimeModule.ts
+++ b/packages/repack/src/plugins/RepackTargetPlugin/InitRuntimeModule.ts
@@ -1,0 +1,19 @@
+import { RuntimeModule, Template } from '@rspack/core';
+
+interface InitRuntimeModuleConfig {
+  globalObject: string;
+}
+
+export class InitRuntimeModule extends RuntimeModule {
+  constructor(private config: InitRuntimeModuleConfig) {
+    super('repack/init', RuntimeModule.STAGE_BASIC);
+  }
+
+  generate() {
+    return Template.asString([
+      Template.getFunctionContent(
+        require('./implementation/init.js')
+      ).replaceAll('$globalObject$', this.config.globalObject),
+    ]);
+  }
+}

--- a/packages/repack/src/plugins/RepackTargetPlugin/InitRuntimeModule.ts
+++ b/packages/repack/src/plugins/RepackTargetPlugin/InitRuntimeModule.ts
@@ -7,6 +7,8 @@ interface InitRuntimeModuleConfig {
   globalObject: string;
 }
 
+// runtime module class is generated dynamically based on the compiler instance
+// this way it's compatible with both webpack and rspack
 export const makeInitRuntimeModule = (
   compiler: Compiler,
   moduleConfig: InitRuntimeModuleConfig

--- a/packages/repack/src/plugins/RepackTargetPlugin/LoadScriptRuntimeModule.ts
+++ b/packages/repack/src/plugins/RepackTargetPlugin/LoadScriptRuntimeModule.ts
@@ -1,0 +1,21 @@
+import { RuntimeGlobals, RuntimeModule, Template } from '@rspack/core';
+
+interface LoadScriptRuntimeModuleConfig {
+  chunkId: string | number | undefined;
+  hmrEnabled: boolean;
+}
+
+export class LoadScriptRuntimeModule extends RuntimeModule {
+  constructor(private config: LoadScriptRuntimeModuleConfig) {
+    super('repack/load script', RuntimeModule.STAGE_BASIC);
+  }
+
+  generate() {
+    return Template.asString([
+      Template.getFunctionContent(require('./implementation/loadScript.js'))
+        .replaceAll('$caller$', `'${this.config.chunkId?.toString()}'`)
+        .replaceAll('$hmrEnabled$', `${this.config.hmrEnabled}`)
+        .replaceAll('$loadScript$', RuntimeGlobals.loadScript),
+    ]);
+  }
+}

--- a/packages/repack/src/plugins/RepackTargetPlugin/LoadScriptRuntimeModule.ts
+++ b/packages/repack/src/plugins/RepackTargetPlugin/LoadScriptRuntimeModule.ts
@@ -8,6 +8,8 @@ interface LoadScriptRuntimeModuleConfig {
   hmrEnabled: boolean;
 }
 
+// runtime module class is generated dynamically based on the compiler instance
+// this way it's compatible with both webpack and rspack
 export const makeLoadScriptRuntimeModule = (
   compiler: Compiler,
   moduleConfig: LoadScriptRuntimeModuleConfig

--- a/packages/repack/src/plugins/RepackTargetPlugin/LoadScriptRuntimeModule.ts
+++ b/packages/repack/src/plugins/RepackTargetPlugin/LoadScriptRuntimeModule.ts
@@ -1,21 +1,35 @@
-import { RuntimeGlobals, RuntimeModule, Template } from '@rspack/core';
+import type {
+  Compiler,
+  RuntimeModule as RuntimeModuleType,
+} from '@rspack/core';
 
 interface LoadScriptRuntimeModuleConfig {
   chunkId: string | number | undefined;
   hmrEnabled: boolean;
 }
 
-export class LoadScriptRuntimeModule extends RuntimeModule {
-  constructor(private config: LoadScriptRuntimeModuleConfig) {
-    super('repack/load script', RuntimeModule.STAGE_BASIC);
-  }
+export const makeLoadScriptRuntimeModule = (
+  compiler: Compiler,
+  moduleConfig: LoadScriptRuntimeModuleConfig
+): RuntimeModuleType => {
+  const Template = compiler.webpack.Template;
+  const RuntimeGlobals = compiler.webpack.RuntimeGlobals;
+  const RuntimeModule = compiler.webpack.RuntimeModule;
 
-  generate() {
-    return Template.asString([
-      Template.getFunctionContent(require('./implementation/loadScript.js'))
-        .replaceAll('$caller$', `'${this.config.chunkId?.toString()}'`)
-        .replaceAll('$hmrEnabled$', `${this.config.hmrEnabled}`)
-        .replaceAll('$loadScript$', RuntimeGlobals.loadScript),
-    ]);
-  }
-}
+  const LoadScriptRuntimeModule = class extends RuntimeModule {
+    constructor(private config: LoadScriptRuntimeModuleConfig) {
+      super('repack/load script', RuntimeModule.STAGE_BASIC);
+    }
+
+    generate() {
+      return Template.asString([
+        Template.getFunctionContent(require('./implementation/loadScript.js'))
+          .replaceAll('$caller$', `'${this.config.chunkId?.toString()}'`)
+          .replaceAll('$hmrEnabled$', `${this.config.hmrEnabled}`)
+          .replaceAll('$loadScript$', RuntimeGlobals.loadScript),
+      ]);
+    }
+  };
+
+  return new LoadScriptRuntimeModule(moduleConfig);
+};

--- a/packages/repack/src/plugins/RepackTargetPlugin/ModuleErrorHandlerRuntimeModule.ts
+++ b/packages/repack/src/plugins/RepackTargetPlugin/ModuleErrorHandlerRuntimeModule.ts
@@ -1,0 +1,24 @@
+import { RuntimeGlobals, RuntimeModule, Template } from '@rspack/core';
+
+interface ModuleErrorHandlerRuntimeModuleConfig {
+  globalObject: string;
+}
+
+export class ModuleErrorHandlerRuntimeModule extends RuntimeModule {
+  constructor(private config: ModuleErrorHandlerRuntimeModuleConfig) {
+    super('repack/module error handler', RuntimeModule.STAGE_BASIC);
+  }
+
+  generate() {
+    return Template.asString([
+      Template.getFunctionContent(
+        require('./implementation/moduleErrorHandler.js')
+      )
+        .replaceAll('$globalObject$', this.config.globalObject)
+        .replaceAll(
+          '$interceptModuleExecution$',
+          RuntimeGlobals.interceptModuleExecution
+        ),
+    ]);
+  }
+}

--- a/packages/repack/src/plugins/RepackTargetPlugin/ModuleErrorHandlerRuntimeModule.ts
+++ b/packages/repack/src/plugins/RepackTargetPlugin/ModuleErrorHandlerRuntimeModule.ts
@@ -7,6 +7,8 @@ interface ModuleErrorHandlerRuntimeModuleConfig {
   globalObject: string;
 }
 
+// runtime module class is generated dynamically based on the compiler instance
+// this way it's compatible with both webpack and rspack
 export const makeModuleErrorHandlerRuntimeModule = (
   compiler: Compiler,
   moduleConfig: ModuleErrorHandlerRuntimeModuleConfig

--- a/packages/repack/src/plugins/RepackTargetPlugin/ModuleErrorHandlerRuntimeModule.ts
+++ b/packages/repack/src/plugins/RepackTargetPlugin/ModuleErrorHandlerRuntimeModule.ts
@@ -1,24 +1,38 @@
-import { RuntimeGlobals, RuntimeModule, Template } from '@rspack/core';
+import type {
+  Compiler,
+  RuntimeModule as RuntimeModuleType,
+} from '@rspack/core';
 
 interface ModuleErrorHandlerRuntimeModuleConfig {
   globalObject: string;
 }
 
-export class ModuleErrorHandlerRuntimeModule extends RuntimeModule {
-  constructor(private config: ModuleErrorHandlerRuntimeModuleConfig) {
-    super('repack/module error handler', RuntimeModule.STAGE_BASIC);
-  }
+export const makeModuleErrorHandlerRuntimeModule = (
+  compiler: Compiler,
+  moduleConfig: ModuleErrorHandlerRuntimeModuleConfig
+): RuntimeModuleType => {
+  const Template = compiler.webpack.Template;
+  const RuntimeGlobals = compiler.webpack.RuntimeGlobals;
+  const RuntimeModule = compiler.webpack.RuntimeModule;
 
-  generate() {
-    return Template.asString([
-      Template.getFunctionContent(
-        require('./implementation/moduleErrorHandler.js')
-      )
-        .replaceAll('$globalObject$', this.config.globalObject)
-        .replaceAll(
-          '$interceptModuleExecution$',
-          RuntimeGlobals.interceptModuleExecution
-        ),
-    ]);
-  }
-}
+  const ModuleErrorHandlerRuntimeModule = class extends RuntimeModule {
+    constructor(private config: ModuleErrorHandlerRuntimeModuleConfig) {
+      super('repack/module error handler', RuntimeModule.STAGE_BASIC);
+    }
+
+    generate() {
+      return Template.asString([
+        Template.getFunctionContent(
+          require('./implementation/moduleErrorHandler.js')
+        )
+          .replaceAll('$globalObject$', this.config.globalObject)
+          .replaceAll(
+            '$interceptModuleExecution$',
+            RuntimeGlobals.interceptModuleExecution
+          ),
+      ]);
+    }
+  };
+
+  return new ModuleErrorHandlerRuntimeModule(moduleConfig);
+};

--- a/packages/repack/src/plugins/RepackTargetPlugin/RepackTargetPlugin.ts
+++ b/packages/repack/src/plugins/RepackTargetPlugin/RepackTargetPlugin.ts
@@ -84,9 +84,9 @@ export class RepackTargetPlugin implements RspackPluginInstance {
         const context = path.dirname(request);
         resource.request = request;
         resource.context = context;
-        // @ts-ignore
+        // @ts-expect-error incomplete rspack types
         resource.createData.resource = request;
-        // @ts-ignore
+        // @ts-expect-error incomplete rspack types
         resource.createData.context = context;
       }
     ).apply(compiler);

--- a/packages/repack/src/plugins/RepackTargetPlugin/implementation/init.ts
+++ b/packages/repack/src/plugins/RepackTargetPlugin/implementation/init.ts
@@ -1,10 +1,7 @@
-const $globalObject$ = {} as Record<string, any>;
-const $hmrEnabled$ = false;
+var $globalObject$: Record<string, any>;
 
 module.exports = function () {
   var repackRuntime: RepackRuntime = {
-    loadScript,
-    loadHotUpdate,
     shared: ($globalObject$.__repack__ && $globalObject$.__repack__.shared) ||
       (__webpack_require__.repack && __webpack_require__.repack.shared) || {
         scriptManager: undefined,
@@ -12,93 +9,4 @@ module.exports = function () {
   };
 
   __webpack_require__.repack = $globalObject$.__repack__ = repackRuntime;
-
-  // intercept module factory calls to forward errors to global.ErrorUtils
-  // aligned with `guardedLoadModule` behaviour in Metro
-  // https://github.com/facebook/metro/blob/a4cb0b0e483748ef9f1c760cb60c57e3a84c1afd/packages/metro-runtime/src/polyfills/require.js#L329
-  __webpack_require__.i.push(function (options) {
-    var originalFactory = options.factory;
-    options.factory = function (moduleObject, moduleExports, webpackRequire) {
-      try {
-        originalFactory.call(this, moduleObject, moduleExports, webpackRequire);
-      } catch (e) {
-        if ($globalObject$.ErrorUtils) {
-          // exposed as global early on, part of `@react-native/js-polyfills` error-guard
-          // https://github.com/facebook/react-native/blob/4dac99cf6d308e804efc098b37f5c24c1eb611cf/packages/polyfills/error-guard.js#L121
-          $globalObject$.ErrorUtils.reportFatalError(e);
-        } else {
-          // error happened before ErrorUtils was initialized
-          // at this point in runtime we can only rethrow the error
-          throw e;
-        }
-      }
-    };
-  });
-
-  function loadScript(
-    name: string,
-    caller: string | undefined,
-    done: (event?: LoadScriptEvent) => void,
-    referenceUrl: string
-  ) {
-    if (repackRuntime.shared.scriptManager) {
-      repackRuntime.shared.scriptManager
-        .loadScript(name, caller, __webpack_require__, referenceUrl)
-        .then(function () {
-          done();
-          return;
-        })
-        .catch(function (reason) {
-          console.error('[RepackRuntime] Loading script failed:', reason);
-          done({ type: 'exec', target: { src: name } });
-        });
-    } else {
-      console.error('[RepackRuntime] Script manager was not provided');
-      done({ type: 'exec', target: { src: name } });
-    }
-  }
-
-  function loadHotUpdate(url: string, done: (event?: LoadScriptEvent) => void) {
-    if (!$hmrEnabled$) {
-      console.error('[RepackRuntime] Loading HMR update chunks is disabled');
-      done({ type: 'disabled', target: { src: url } });
-      return;
-    }
-
-    (
-      fetch(url).then(function (response) {
-        if (!response.ok) {
-          console.error(
-            '[RepackRuntime] Loading HMR update failed:',
-            response.statusText
-          );
-          done({ type: response.statusText, target: { src: url } });
-          return;
-        }
-
-        return response.text();
-      }) as Promise<string | undefined>
-    )
-      .then(function (script?: string) {
-        if (script) {
-          if (repackRuntime.shared.scriptManager) {
-            repackRuntime.shared.scriptManager.unstable_evaluateScript(
-              script,
-              url
-            );
-          } else {
-            eval(script);
-          }
-        }
-
-        return;
-      })
-      .catch(function (reason) {
-        console.error(
-          '[RepackRuntime] Loading HMR update chunk failed:',
-          reason
-        );
-        done({ type: 'exec', target: { src: url } });
-      });
-  }
 };

--- a/packages/repack/src/plugins/RepackTargetPlugin/implementation/init.ts
+++ b/packages/repack/src/plugins/RepackTargetPlugin/implementation/init.ts
@@ -1,7 +1,7 @@
 var $globalObject$: Record<string, any>;
 
 module.exports = function () {
-  var repackRuntime: RepackRuntime = {
+  var repackRuntime: RepackRuntimeGlobals.RepackRuntimeObject = {
     shared: ($globalObject$.__repack__ && $globalObject$.__repack__.shared) ||
       (__webpack_require__.repack && __webpack_require__.repack.shared) || {
         scriptManager: undefined,

--- a/packages/repack/src/plugins/RepackTargetPlugin/implementation/loadScript.ts
+++ b/packages/repack/src/plugins/RepackTargetPlugin/implementation/loadScript.ts
@@ -1,12 +1,12 @@
 var $caller$: string;
 var $hmrEnabled$: boolean;
-var $loadScript$: WebpackLoadScript;
+var $loadScript$: RepackRuntimeGlobals.WebpackLoadScript;
 
 module.exports = function () {
   function loadScriptHandler(
     name: string,
     caller: string | undefined,
-    done: (event?: LoadScriptEvent) => void,
+    done: (event?: RepackRuntimeGlobals.LoadScriptEvent) => void,
     referenceUrl: string
   ) {
     if (__webpack_require__.repack.shared.scriptManager) {
@@ -28,7 +28,7 @@ module.exports = function () {
 
   function loadHotUpdateHandler(
     url: string,
-    done: (event?: LoadScriptEvent) => void
+    done: (event?: RepackRuntimeGlobals.LoadScriptEvent) => void
   ) {
     if (!$hmrEnabled$) {
       console.error('[RepackRuntime] Loading HMR update chunks is disabled');
@@ -75,7 +75,7 @@ module.exports = function () {
 
   $loadScript$ = function loadScript(
     url: string,
-    done: (event?: LoadScriptEvent) => void,
+    done: (event?: RepackRuntimeGlobals.LoadScriptEvent) => void,
     key?: string,
     chunkId?: string
   ) {

--- a/packages/repack/src/plugins/RepackTargetPlugin/implementation/moduleErrorHandler.ts
+++ b/packages/repack/src/plugins/RepackTargetPlugin/implementation/moduleErrorHandler.ts
@@ -1,0 +1,26 @@
+var $globalObject$: Record<string, any>;
+var $interceptModuleExecution$: WebpackModuleExecutionInterceptor;
+
+module.exports = function () {
+  // intercept module factory calls to forward errors to global.ErrorUtils
+  // aligned with `guardedLoadModule` behaviour in Metro
+  // https://github.com/facebook/metro/blob/a4cb0b0e483748ef9f1c760cb60c57e3a84c1afd/packages/metro-runtime/src/polyfills/require.js#L329
+  $interceptModuleExecution$.push(function (options) {
+    var originalFactory = options.factory;
+    options.factory = function (moduleObject, moduleExports, webpackRequire) {
+      try {
+        originalFactory.call(this, moduleObject, moduleExports, webpackRequire);
+      } catch (e) {
+        if ($globalObject$.ErrorUtils) {
+          // exposed as global early on, part of `@react-native/js-polyfills` error-guard
+          // https://github.com/facebook/react-native/blob/4dac99cf6d308e804efc098b37f5c24c1eb611cf/packages/polyfills/error-guard.js#L121
+          $globalObject$.ErrorUtils.reportFatalError(e);
+        } else {
+          // error happened before ErrorUtils was initialized
+          // at this point in runtime we can only rethrow the error
+          throw e;
+        }
+      }
+    };
+  });
+};

--- a/packages/repack/src/plugins/RepackTargetPlugin/implementation/moduleErrorHandler.ts
+++ b/packages/repack/src/plugins/RepackTargetPlugin/implementation/moduleErrorHandler.ts
@@ -1,5 +1,5 @@
 var $globalObject$: Record<string, any>;
-var $interceptModuleExecution$: WebpackModuleExecutionInterceptor;
+var $interceptModuleExecution$: RepackRuntimeGlobals.WebpackModuleExecutionInterceptor;
 
 module.exports = function () {
   // intercept module factory calls to forward errors to global.ErrorUtils

--- a/packages/repack/src/types/runtime-globals.d.ts
+++ b/packages/repack/src/types/runtime-globals.d.ts
@@ -1,52 +1,84 @@
-declare interface LoadScriptEvent {
-  type: 'load' | string;
-  target?: { src: string };
-}
+declare namespace RepackRuntimeGlobals {
+  declare interface HMRInfo {
+    type: string;
+    chain: Array<string | number>;
+    error?: Error;
+    moduleId: string | number;
+  }
 
-declare interface RepackRuntime {
-  shared: {
-    scriptManager?: import('../modules/ScriptManager/ScriptManager.js').ScriptManager;
+  declare interface HotApi {
+    status():
+      | 'idle'
+      | 'check'
+      | 'prepare'
+      | 'ready'
+      | 'dispose'
+      | 'apply'
+      | 'abort'
+      | 'fail';
+    check(autoPlay: boolean): Promise<Array<string | number>>;
+    apply(options: {
+      ignoreUnaccepted?: boolean;
+      ignoreDeclined?: boolean;
+      ignoreErrored?: boolean;
+      onDeclined?: (info: HMRInfo) => void;
+      onUnaccepted?: (info: HMRInfo) => void;
+      onAccepted?: (info: HMRInfo) => void;
+      onDisposed?: (info: HMRInfo) => void;
+      onErrored?: (info: HMRInfo) => void;
+    }): Promise<Array<string | number>>;
+  }
+
+  declare interface LoadScriptEvent {
+    type: 'load' | string;
+    target?: { src: string };
+  }
+
+  declare interface RepackRuntimeObject {
+    shared: {
+      scriptManager?: import('../modules/ScriptManager/ScriptManager.js').ScriptManager;
+    };
+  }
+
+  declare type ModuleExports = Record<string | number | symbol, any>;
+
+  declare type ModuleObject = {
+    id: number;
+    loaded: boolean;
+    error?: any;
+    exports: ModuleExports;
+  };
+
+  declare type WebpackModuleExecutionInterceptor = ((options: {
+    id: number;
+    factory: (
+      moduleObject: ModuleObject,
+      moduleExports: ModuleExports,
+      webpackRequire: WebpackRequire
+    ) => void;
+    module: ModuleObject;
+    require: WebpackRequire;
+  }) => void)[];
+
+  declare type WebpackLoadScript = (
+    url: string,
+    done: (event?: LoadScriptEvent) => void,
+    key?: string,
+    chunkId?: string
+  ) => void;
+
+  declare type WebpackPublicPath = () => string;
+
+  declare type WebpackGetChunkScriptFilename = (id: string) => string;
+
+  declare type WebpackRequire = {
+    i: WebpackModuleExecutionInterceptor;
+    l: WebpackLoadScript;
+    p: WebpackPublicPath;
+    u: WebpackGetChunkScriptFilename;
+    repack: RepackRuntimeObject;
   };
 }
-
-declare type ModuleExports = Record<string | number | symbol, any>;
-
-declare type ModuleObject = {
-  id: number;
-  loaded: boolean;
-  error?: any;
-  exports: ModuleExports;
-};
-
-declare type WebpackModuleExecutionInterceptor = ((options: {
-  id: number;
-  factory: (
-    moduleObject: ModuleObject,
-    moduleExports: ModuleExports,
-    webpackRequire: WebpackRequire
-  ) => void;
-  module: ModuleObject;
-  require: WebpackRequire;
-}) => void)[];
-
-declare type WebpackLoadScript = (
-  url: string,
-  done: (event?: LoadScriptEvent) => void,
-  key?: string,
-  chunkId?: string
-) => void;
-
-declare type WebpackPublicPath = () => string;
-
-declare type WebpackGetChunkScriptFilename = (id: string) => string;
-
-declare type WebpackRequire = {
-  i: WebpackModuleExecutionInterceptor;
-  l: WebpackLoadScript;
-  p: WebpackPublicPath;
-  u: WebpackGetChunkScriptFilename;
-  repack: RepackRuntime;
-};
 
 declare var __DEV__: boolean;
 declare var __PUBLIC_PROTOCOL__: string;
@@ -58,39 +90,9 @@ declare var __REACT_NATIVE_MINOR_VERSION__: number;
 declare var __REACT_NATIVE_PATCH_VERSION__: number;
 declare var __webpack_public_path__: string;
 declare var __webpack_hash__: string;
-declare var __repack__: RepackRuntime;
-declare var __webpack_require__: WebpackRequire;
-
-declare interface HMRInfo {
-  type: string;
-  chain: Array<string | number>;
-  error?: Error;
-  moduleId: string | number;
-}
-
-declare interface HotApi {
-  status():
-    | 'idle'
-    | 'check'
-    | 'prepare'
-    | 'ready'
-    | 'dispose'
-    | 'apply'
-    | 'abort'
-    | 'fail';
-  check(autoPlay: boolean): Promise<Array<string | number>>;
-  apply(options: {
-    ignoreUnaccepted?: boolean;
-    ignoreDeclined?: boolean;
-    ignoreErrored?: boolean;
-    onDeclined?: (info: HMRInfo) => void;
-    onUnaccepted?: (info: HMRInfo) => void;
-    onAccepted?: (info: HMRInfo) => void;
-    onDisposed?: (info: HMRInfo) => void;
-    onErrored?: (info: HMRInfo) => void;
-  }): Promise<Array<string | number>>;
-}
+declare var __repack__: RepackRuntimeGlobals.RepackRuntimeObject;
+declare var __webpack_require__: RepackRuntimeGlobals.WebpackRequire;
 
 declare interface NodeModule {
-  hot?: HotApi;
+  hot?: RepackRuntimeGlobals.HotApi;
 }

--- a/packages/repack/src/types/runtime-globals.d.ts
+++ b/packages/repack/src/types/runtime-globals.d.ts
@@ -1,22 +1,52 @@
-/// <reference lib="DOM" />
-
 declare interface LoadScriptEvent {
   type: 'load' | string;
   target?: { src: string };
 }
 
 declare interface RepackRuntime {
-  loadScript: (
-    name: string,
-    caller: string | undefined,
-    done: (event?: LoadScriptEvent) => void,
-    referenceUrl: string
-  ) => void;
-  loadHotUpdate: (url: string, done: (event?: LoadScriptEvent) => void) => void;
   shared: {
     scriptManager?: import('../modules/ScriptManager/ScriptManager.js').ScriptManager;
   };
 }
+
+declare type ModuleExports = Record<string | number | symbol, any>;
+
+declare type ModuleObject = {
+  id: number;
+  loaded: boolean;
+  error?: any;
+  exports: ModuleExports;
+};
+
+declare type WebpackModuleExecutionInterceptor = ((options: {
+  id: number;
+  factory: (
+    moduleObject: ModuleObject,
+    moduleExports: ModuleExports,
+    webpackRequire: WebpackRequire
+  ) => void;
+  module: ModuleObject;
+  require: WebpackRequire;
+}) => void)[];
+
+declare type WebpackLoadScript = (
+  url: string,
+  done: (event?: LoadScriptEvent) => void,
+  key?: string,
+  chunkId?: string
+) => void;
+
+declare type WebpackPublicPath = () => string;
+
+declare type WebpackGetChunkScriptFilename = (id: string) => string;
+
+declare type WebpackRequire = {
+  i: WebpackModuleExecutionInterceptor;
+  l: WebpackLoadScript;
+  p: WebpackPublicPath;
+  u: WebpackGetChunkScriptFilename;
+  repack: RepackRuntime;
+};
 
 declare var __DEV__: boolean;
 declare var __PUBLIC_PROTOCOL__: string;
@@ -29,10 +59,7 @@ declare var __REACT_NATIVE_PATCH_VERSION__: number;
 declare var __webpack_public_path__: string;
 declare var __webpack_hash__: string;
 declare var __repack__: RepackRuntime;
-declare var __webpack_require__: import('../modules/ScriptManager/types.js').WebpackContext & {
-  x?: Function;
-  repack: RepackRuntime;
-};
+declare var __webpack_require__: WebpackRequire;
 
 declare interface HMRInfo {
   type: string;


### PR DESCRIPTION
### Summary

partial solution to #866

In some cases `loadScript` runtime module might not get injected into the bundle. Since all of the logic for Repack runtime lives there, it might cause undefined behaviour like failing to process EarlyJS errors or failure to initialise Repack global object. 

This PR separates the `loadScript` part into it's own runtime module, and makes `init` and `moduleErrorHandler` parts separate runtime modules.

Previously in Rspack there was no way to add runtime modules - we could only edit existing ones and we were forced to concatenate init & load script modules into one. This is no longer the case so we can split them into separate entities.

The types injected into the global scope were also reworked - now most types are hidden behind a `RepackRuntimeGlobals` namespace to prevent polluting the global typescript scope

### Test plan

- [x] - testers work
