### PR TITLE
fix: install latest version of rspack with init

### DIFF
--- a/.changeset/brown-lemons-fix.md
+++ b/.changeset/brown-lemons-fix.md
@@ -1,0 +1,5 @@
+---
+"@callstack/repack": patch
+---
+
+Install latest version of `@rspack/core` with repack-init

--- a/packages/init/src/tasks/addDependencies.ts
+++ b/packages/init/src/tasks/addDependencies.ts
@@ -7,7 +7,7 @@ import ora, { type Ora } from 'ora';
 import logger from '../utils/logger.js';
 
 const rspackDependencies = [
-  '@rspack/core@1.0.3', // 1.0.4 breaks sourcemaps
+  '@rspack/core',
   '@swc/helpers',
   '@callstack/repack',
 ];


### PR DESCRIPTION
### Summary

before the version of `@rspack/core` was locked at 1.0.3 to make source maps work, this was fixed long time ago upstream so there is no reason to keep it locked anymore.

### Test plan

n/a
