### PR TITLE
feat: enable inlining RN entrypoints

### DIFF
--- a/.changeset/gorgeous-nails-watch.md
+++ b/.changeset/gorgeous-nails-watch.md
@@ -1,0 +1,5 @@
+---
+"@callstack/repack": minor
+---
+
+Enable inlining entry modules by making runtime initialization from React renderers a no-op

--- a/packages/repack/src/plugins/RepackTargetPlugin/RepackTargetPlugin.ts
+++ b/packages/repack/src/plugins/RepackTargetPlugin/RepackTargetPlugin.ts
@@ -92,6 +92,14 @@ export class RepackTargetPlugin implements RspackPluginInstance {
       }
     ).apply(compiler);
 
+    // ReactNativePrivateInitializeCore.js is an unnecessary module exisiting in order to make metro happy
+    // it reexports InitializeCore which is included as one of the initial modules running before main entrypoint
+    // making this module noop makes inlining entry modules possible which might improve startup time
+    new compiler.webpack.NormalModuleReplacementPlugin(
+      /react-native.*?([/\\]+)Libraries[/\\]ReactPrivate[/\\]ReactNativePrivateInitializeCore\.js$/,
+      require.resolve('../../modules/EmptyModule.js')
+    ).apply(compiler);
+
     // ReactNativeTypes.js is flow type only module
     new compiler.webpack.NormalModuleReplacementPlugin(
       /react-native.*?([/\\]+)Libraries[/\\]Renderer[/\\]shims[/\\]ReactNativeTypes\.js$/,


### PR DESCRIPTION
### Summary

Looking over the RN codebase I've found that `ReactNativePrivateInitializeCore` reexports `InitializeCore`. Inside commit history we can find [attempts at making this module a noop](https://github.com/facebook/react-native/commit/b14b34b232b4873137ea3f3c7a90f86b9013885a) but ultimately it was always reverted because of issues at metro. 

We're not using metro and this isn't an issue with webpack/rspack so no reason why not to try it, especially since this allows for inlining entrypoints for faster startup (before webpack bailed out of this optimization because `InitializeCore` was used in other places)

### Test plan

- [x] - testers work
