### PR TITLE
docs: add a warning for non-migrated pages

### DIFF
--- a/website/src/5.x/docs/features/code-splitting.md
+++ b/website/src/5.x/docs/features/code-splitting.md
@@ -1,1 +1,7 @@
 # Code splitting
+
+:::warning title="Notice:"
+The documentation for Re.Pack 5 is currently under development and some of the pages aren't ready yet.
+
+Please use [latest stable version of Re.Pack 4.x documentation](https://re-pack.dev/docs/getting-started) for now.
+:::

--- a/website/src/5.x/docs/features/dev-server.md
+++ b/website/src/5.x/docs/features/dev-server.md
@@ -1,1 +1,7 @@
 # DevServer
+
+:::warning title="Notice:"
+The documentation for Re.Pack 5 is currently under development and some of the pages aren't ready yet.
+
+Please use [latest stable version of Re.Pack 4.x documentation](https://re-pack.dev/docs/getting-started) for now.
+:::

--- a/website/src/5.x/docs/features/devtools.md
+++ b/website/src/5.x/docs/features/devtools.md
@@ -1,1 +1,7 @@
 # React Native Devtools
+
+:::warning title="Notice:"
+The documentation for Re.Pack 5 is currently under development and some of the pages aren't ready yet.
+
+Please use [latest stable version of Re.Pack 4.x documentation](https://re-pack.dev/docs/getting-started) for now.
+:::

--- a/website/src/5.x/docs/features/flow-support.md
+++ b/website/src/5.x/docs/features/flow-support.md
@@ -1,1 +1,7 @@
 # Flow language support
+
+:::warning title="Notice:"
+The documentation for Re.Pack 5 is currently under development and some of the pages aren't ready yet.
+
+Please use [latest stable version of Re.Pack 4.x documentation](https://re-pack.dev/docs/getting-started) for now.
+:::

--- a/website/src/5.x/docs/features/module-federation.md
+++ b/website/src/5.x/docs/features/module-federation.md
@@ -1,1 +1,7 @@
 # Module Federation
+
+:::warning title="Notice:"
+The documentation for Re.Pack 5 is currently under development and some of the pages aren't ready yet.
+
+Please use [latest stable version of Re.Pack 4.x documentation](https://re-pack.dev/docs/getting-started) for now.
+:::

--- a/website/src/5.x/docs/features/module-resolution.md
+++ b/website/src/5.x/docs/features/module-resolution.md
@@ -1,1 +1,7 @@
 # Module resolution
+
+:::warning title="Notice:"
+The documentation for Re.Pack 5 is currently under development and some of the pages aren't ready yet.
+
+Please use [latest stable version of Re.Pack 4.x documentation](https://re-pack.dev/docs/getting-started) for now.
+:::

--- a/website/src/5.x/docs/features/reanimated.md
+++ b/website/src/5.x/docs/features/reanimated.md
@@ -1,1 +1,7 @@
 # React Native Reanimated
+
+:::warning title="Notice:"
+The documentation for Re.Pack 5 is currently under development and some of the pages aren't ready yet.
+
+Please use [latest stable version of Re.Pack 4.x documentation](https://re-pack.dev/docs/getting-started) for now.
+:::

--- a/website/src/5.x/docs/getting-started/bundlers.md
+++ b/website/src/5.x/docs/getting-started/bundlers.md
@@ -1,1 +1,7 @@
 # Rspack & webpack
+
+:::warning title="Notice:"
+The documentation for Re.Pack 5 is currently under development and some of the pages aren't ready yet.
+
+Please use [latest stable version of Re.Pack 4.x documentation](https://re-pack.dev/docs/getting-started) for now.
+:::

--- a/website/src/5.x/docs/getting-started/microfrontends.md
+++ b/website/src/5.x/docs/getting-started/microfrontends.md
@@ -1,1 +1,7 @@
 # Micro Frontends
+
+:::warning title="Notice:"
+The documentation for Re.Pack 5 is currently under development and some of the pages aren't ready yet.
+
+Please use [latest stable version of Re.Pack 4.x documentation](https://re-pack.dev/docs/getting-started) for now.
+:::

--- a/website/src/5.x/docs/guides/bundle-analysis.md
+++ b/website/src/5.x/docs/guides/bundle-analysis.md
@@ -1,1 +1,7 @@
 # Bundle analysis
+
+:::warning title="Notice:"
+The documentation for Re.Pack 5 is currently under development and some of the pages aren't ready yet.
+
+Please use [latest stable version of Re.Pack 4.x documentation](https://re-pack.dev/docs/getting-started) for now.
+:::

--- a/website/src/5.x/docs/guides/configuration.md
+++ b/website/src/5.x/docs/guides/configuration.md
@@ -1,1 +1,7 @@
 # Configuration
+
+:::warning title="Notice:"
+The documentation for Re.Pack 5 is currently under development and some of the pages aren't ready yet.
+
+Please use [latest stable version of Re.Pack 4.x documentation](https://re-pack.dev/docs/getting-started) for now.
+:::

--- a/website/src/5.x/docs/guides/debugging.md
+++ b/website/src/5.x/docs/guides/debugging.md
@@ -1,1 +1,7 @@
 # Debugging
+
+:::warning title="Notice:"
+The documentation for Re.Pack 5 is currently under development and some of the pages aren't ready yet.
+
+Please use [latest stable version of Re.Pack 4.x documentation](https://re-pack.dev/docs/getting-started) for now.
+:::

--- a/website/src/5.x/docs/migration-guides/expo.md
+++ b/website/src/5.x/docs/migration-guides/expo.md
@@ -1,1 +1,7 @@
 # Migrating from Expo
+
+:::warning title="Notice:"
+The documentation for Re.Pack 5 is currently under development and some of the pages aren't ready yet.
+
+Please use [latest stable version of Re.Pack 4.x documentation](https://re-pack.dev/docs/getting-started) for now.
+:::

--- a/website/src/5.x/docs/migration-guides/metro.md
+++ b/website/src/5.x/docs/migration-guides/metro.md
@@ -1,1 +1,7 @@
 # Migrating from Metro
+
+:::warning title="Notice:"
+The documentation for Re.Pack 5 is currently under development and some of the pages aren't ready yet.
+
+Please use [latest stable version of Re.Pack 4.x documentation](https://re-pack.dev/docs/getting-started) for now.
+:::

--- a/website/src/5.x/docs/resources/glossary.md
+++ b/website/src/5.x/docs/resources/glossary.md
@@ -1,1 +1,7 @@
 # Glossary of terms
+
+:::warning title="Notice:"
+The documentation for Re.Pack 5 is currently under development and some of the pages aren't ready yet.
+
+Please use [latest stable version of Re.Pack 4.x documentation](https://re-pack.dev/docs/getting-started) for now.
+:::


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

Docs are deployed but they're still empty for some of the pages. This Pull Requests adds a relevant warning which informs visitors what's the status.