### PR TITLE
fix: use specific swc assumptions instead of general loose mode

### DIFF
--- a/.changeset/khaki-drinks-join.md
+++ b/.changeset/khaki-drinks-join.md
@@ -1,0 +1,5 @@
+---
+"@callstack/repack": patch
+---
+
+Fix swc loader module rules loose mode configuration

--- a/apps/tester-app/ios/Podfile.lock
+++ b/apps/tester-app/ios/Podfile.lock
@@ -1,6 +1,6 @@
 PODS:
   - boost (1.84.0)
-  - callstack-repack (5.0.0-rc.4):
+  - callstack-repack (5.0.0-rc.6):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -1942,7 +1942,7 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   boost: 1dca942403ed9342f98334bf4c3621f011aa7946
-  callstack-repack: 8972107231b7175b8340e84ca0370aa2c735dcc7
+  callstack-repack: 99484a3f899fab09d6dc72bddb20c72f2ba4f948
   DoubleConversion: f16ae600a246532c4020132d54af21d0ddb2a385
   FBLazyVector: be7314029d6ec6b90f0f75ce1195b8130ed9ac4f
   fmt: 10c6e61f4be25dc963c36bd73fc7b1705fe975be
@@ -2005,7 +2005,7 @@ SPEC CHECKSUMS:
   React-utils: 2bcaf4f4dfe361344bce2fae428603d518488630
   ReactCodegen: ae99a130606068ed40d1d9c0d5f25fda142a0647
   ReactCommon: 89c87b343deacc8610b099ac764848f0ce937e3e
-  ReactNativeHost: ac28612b0443705f9aa90563ffb9647f5608613c
+  ReactNativeHost: 40da1d9878e16dd3b647d4c31e5afeb0ed84683d
   ReactTestApp-DevSupport: 4aa6f6bc658a2577bcf896c63c411cb375b89d7d
   ReactTestApp-Resources: 8d72c3deef156833760694a288ff334af4d427d7
   RNCAsyncStorage: 3ad840f7b17b45ca7ebbbb0e80948564a9513315
@@ -2015,6 +2015,6 @@ SPEC CHECKSUMS:
   SwiftyRSA: 8c6dd1ea7db1b8dc4fb517a202f88bb1354bc2c6
   Yoga: f6dc1b6029519815d5516a1241821c6a9074af6d
 
-PODFILE CHECKSUM: 591811811bdab95f1675c6871b0554706bf77020
+PODFILE CHECKSUM: 6d7cbe03444d5e87210979fb32a0eca299d758fe
 
 COCOAPODS: 1.15.2

--- a/apps/tester-app/rspack.config.mjs
+++ b/apps/tester-app/rspack.config.mjs
@@ -61,15 +61,17 @@ export default (env) => {
           type: 'javascript/auto',
           use: {
             loader: 'builtin:swc-loader',
-            /** @type {import('@rspack/core').SwcLoaderOptions} */
             options: {
               env: {
-                loose: true,
                 targets: {
                   'react-native': '0.74',
                 },
               },
               jsc: {
+                assumptions: {
+                  setPublicClassFields: true,
+                  privateFieldsAsProperties: true,
+                },
                 externalHelpers: true,
                 transform: {
                   react: {

--- a/apps/tester-federation-v2/ios/Podfile.lock
+++ b/apps/tester-federation-v2/ios/Podfile.lock
@@ -1,6 +1,6 @@
 PODS:
   - boost (1.84.0)
-  - callstack-repack (5.0.0-rc.4):
+  - callstack-repack (5.0.0-rc.6):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -1895,7 +1895,7 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   boost: 1dca942403ed9342f98334bf4c3621f011aa7946
-  callstack-repack: 8972107231b7175b8340e84ca0370aa2c735dcc7
+  callstack-repack: 99484a3f899fab09d6dc72bddb20c72f2ba4f948
   DoubleConversion: f16ae600a246532c4020132d54af21d0ddb2a385
   FBLazyVector: be7314029d6ec6b90f0f75ce1195b8130ed9ac4f
   fmt: 10c6e61f4be25dc963c36bd73fc7b1705fe975be
@@ -1959,13 +1959,13 @@ SPEC CHECKSUMS:
   React-utils: 2bcaf4f4dfe361344bce2fae428603d518488630
   ReactCodegen: ae99a130606068ed40d1d9c0d5f25fda142a0647
   ReactCommon: 89c87b343deacc8610b099ac764848f0ce937e3e
-  ReactNativeHost: ac28612b0443705f9aa90563ffb9647f5608613c
+  ReactNativeHost: 40da1d9878e16dd3b647d4c31e5afeb0ed84683d
   ReactTestApp-DevSupport: 4aa6f6bc658a2577bcf896c63c411cb375b89d7d
   RNScreens: e389d6a6a66a4f0d3662924ecae803073ccce8ec
   SocketRocket: d4aabe649be1e368d1318fdf28a022d714d65748
   SwiftyRSA: 8c6dd1ea7db1b8dc4fb517a202f88bb1354bc2c6
   Yoga: f6dc1b6029519815d5516a1241821c6a9074af6d
 
-PODFILE CHECKSUM: a2fe66c9f356ead5b62cb5a645336db60f03a64d
+PODFILE CHECKSUM: 3d5c18eefbf70d38fbbfe81a262195cadac1f5dd
 
 COCOAPODS: 1.15.2

--- a/apps/tester-federation-v2/rspack.config.host-app.mjs
+++ b/apps/tester-federation-v2/rspack.config.host-app.mjs
@@ -50,37 +50,22 @@ export default (env) => {
       rules: [
         Repack.REACT_NATIVE_LOADING_RULES,
         Repack.NODE_MODULES_LOADING_RULES,
-        /* repack is symlinked to a local workspace */
+        Repack.FLOW_TYPED_MODULES_LOADING_RULES,
         {
           test: /\.[jt]sx?$/,
           type: 'javascript/auto',
-          include: [/repack[/\\]dist/],
+          exclude: [/node_modules/],
           use: {
             loader: 'builtin:swc-loader',
             options: {
               env: {
-                loose: true,
-                targets: { 'react-native': '0.74' },
-              },
-              jsc: { externalHelpers: true },
-            },
-          },
-        },
-        /* codebase rules */
-        {
-          test: /\.[jt]sx?$/,
-          type: 'javascript/auto',
-          exclude: [/node_modules/, /repack[/\\]dist/],
-          use: {
-            loader: 'builtin:swc-loader',
-            /** @type {import('@rspack/core').SwcLoaderOptions} */
-            options: {
-              sourceMaps: true,
-              env: {
-                loose: true,
                 targets: { 'react-native': '0.74' },
               },
               jsc: {
+                assumptions: {
+                  setPublicClassFields: true,
+                  privateFieldsAsProperties: true,
+                },
                 externalHelpers: true,
                 transform: {
                   react: {

--- a/apps/tester-federation-v2/rspack.config.mini-app.mjs
+++ b/apps/tester-federation-v2/rspack.config.mini-app.mjs
@@ -49,37 +49,22 @@ export default (env) => {
       rules: [
         Repack.REACT_NATIVE_LOADING_RULES,
         Repack.NODE_MODULES_LOADING_RULES,
-        /* repack is symlinked to a local workspace */
+        Repack.FLOW_TYPED_MODULES_LOADING_RULES,
         {
           test: /\.[jt]sx?$/,
           type: 'javascript/auto',
-          include: [/repack[/\\]dist/],
+          exclude: [/node_modules/],
           use: {
             loader: 'builtin:swc-loader',
             options: {
               env: {
-                loose: true,
-                targets: { 'react-native': '0.74' },
-              },
-              jsc: { externalHelpers: true },
-            },
-          },
-        },
-        /* codebase rules */
-        {
-          test: /\.[jt]sx?$/,
-          type: 'javascript/auto',
-          exclude: [/node_modules/, /repack[/\\]dist/],
-          use: {
-            loader: 'builtin:swc-loader',
-            /** @type {import('@rspack/core').SwcLoaderOptions} */
-            options: {
-              sourceMaps: true,
-              env: {
-                loose: true,
                 targets: { 'react-native': '0.74' },
               },
               jsc: {
+                assumptions: {
+                  setPublicClassFields: true,
+                  privateFieldsAsProperties: true,
+                },
                 externalHelpers: true,
                 transform: {
                   react: {

--- a/apps/tester-federation/ios/Podfile.lock
+++ b/apps/tester-federation/ios/Podfile.lock
@@ -1,6 +1,6 @@
 PODS:
   - boost (1.84.0)
-  - callstack-repack (5.0.0-rc.4):
+  - callstack-repack (5.0.0-rc.6):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -1919,7 +1919,7 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   boost: 1dca942403ed9342f98334bf4c3621f011aa7946
-  callstack-repack: 8972107231b7175b8340e84ca0370aa2c735dcc7
+  callstack-repack: 99484a3f899fab09d6dc72bddb20c72f2ba4f948
   DoubleConversion: f16ae600a246532c4020132d54af21d0ddb2a385
   FBLazyVector: be7314029d6ec6b90f0f75ce1195b8130ed9ac4f
   fmt: 10c6e61f4be25dc963c36bd73fc7b1705fe975be
@@ -1983,7 +1983,7 @@ SPEC CHECKSUMS:
   React-utils: 2bcaf4f4dfe361344bce2fae428603d518488630
   ReactCodegen: ae99a130606068ed40d1d9c0d5f25fda142a0647
   ReactCommon: 89c87b343deacc8610b099ac764848f0ce937e3e
-  ReactNativeHost: ac28612b0443705f9aa90563ffb9647f5608613c
+  ReactNativeHost: 40da1d9878e16dd3b647d4c31e5afeb0ed84683d
   ReactTestApp-DevSupport: 4aa6f6bc658a2577bcf896c63c411cb375b89d7d
   RNCAsyncStorage: 3ad840f7b17b45ca7ebbbb0e80948564a9513315
   RNScreens: e389d6a6a66a4f0d3662924ecae803073ccce8ec
@@ -1991,6 +1991,6 @@ SPEC CHECKSUMS:
   SwiftyRSA: 8c6dd1ea7db1b8dc4fb517a202f88bb1354bc2c6
   Yoga: f6dc1b6029519815d5516a1241821c6a9074af6d
 
-PODFILE CHECKSUM: 4c9029e45ee3e3768bd4a64f9850e265c1f11ced
+PODFILE CHECKSUM: 16a059e985a55bc49163512a311428a48f715334
 
 COCOAPODS: 1.15.2

--- a/apps/tester-federation/rspack.config.host-app.mjs
+++ b/apps/tester-federation/rspack.config.host-app.mjs
@@ -56,37 +56,21 @@ export default (env) => {
         Repack.REACT_NATIVE_LOADING_RULES,
         Repack.NODE_MODULES_LOADING_RULES,
         Repack.FLOW_TYPED_MODULES_LOADING_RULES,
-        /* repack is symlinked to a local workspace */
         {
           test: /\.[jt]sx?$/,
           type: 'javascript/auto',
-          include: [/repack[/\\]dist/],
+          exclude: [/node_modules/],
           use: {
             loader: 'builtin:swc-loader',
             options: {
               env: {
-                loose: true,
-                targets: { 'react-native': '0.74' },
-              },
-              jsc: { externalHelpers: true },
-            },
-          },
-        },
-        /* codebase rules */
-        {
-          test: /\.[jt]sx?$/,
-          type: 'javascript/auto',
-          exclude: [/node_modules/, /repack[/\\]dist/],
-          use: {
-            loader: 'builtin:swc-loader',
-            /** @type {import('@rspack/core').SwcLoaderOptions} */
-            options: {
-              sourceMaps: true,
-              env: {
-                loose: true,
                 targets: { 'react-native': '0.74' },
               },
               jsc: {
+                assumptions: {
+                  setPublicClassFields: true,
+                  privateFieldsAsProperties: true,
+                },
                 externalHelpers: true,
                 transform: {
                   react: {

--- a/apps/tester-federation/rspack.config.mini-app.mjs
+++ b/apps/tester-federation/rspack.config.mini-app.mjs
@@ -55,37 +55,21 @@ export default (env) => {
         Repack.REACT_NATIVE_LOADING_RULES,
         Repack.NODE_MODULES_LOADING_RULES,
         Repack.FLOW_TYPED_MODULES_LOADING_RULES,
-        /* repack is symlinked to a local workspace */
         {
           test: /\.[jt]sx?$/,
           type: 'javascript/auto',
-          include: [/repack[/\\]dist/],
+          exclude: [/node_modules/],
           use: {
             loader: 'builtin:swc-loader',
             options: {
               env: {
-                loose: true,
-                targets: { 'react-native': '0.74' },
-              },
-              jsc: { externalHelpers: true },
-            },
-          },
-        },
-        /* codebase rules */
-        {
-          test: /\.[jt]sx?$/,
-          type: 'javascript/auto',
-          exclude: [/node_modules/, /repack[/\\]dist/],
-          use: {
-            loader: 'builtin:swc-loader',
-            /** @type {import('@rspack/core').SwcLoaderOptions} */
-            options: {
-              sourceMaps: true,
-              env: {
-                loose: true,
                 targets: { 'react-native': '0.74' },
               },
               jsc: {
+                assumptions: {
+                  setPublicClassFields: true,
+                  privateFieldsAsProperties: true,
+                },
                 externalHelpers: true,
                 transform: {
                   react: {

--- a/packages/repack/src/rules/nodeModulesLoadingRules.ts
+++ b/packages/repack/src/rules/nodeModulesLoadingRules.ts
@@ -5,12 +5,14 @@ const makeSwcLoaderConfig = (syntax: 'js' | 'ts', jsx: boolean) => ({
   loader: 'builtin:swc-loader',
   options: {
     env: {
-      loose: true,
       targets: { 'react-native': '0.74' },
     },
     jsc: {
+      assumptions: {
+        setPublicClassFields: true,
+        privateFieldsAsProperties: true,
+      },
       externalHelpers: true,
-      loose: true,
       parser:
         syntax === 'js'
           ? { syntax: 'ecmascript', jsx: jsx }

--- a/packages/repack/src/rules/reactNativeLoadingRules.ts
+++ b/packages/repack/src/rules/reactNativeLoadingRules.ts
@@ -23,15 +23,17 @@ export const REACT_NATIVE_LOADING_RULES: RuleSetRule = {
       loader: 'builtin:swc-loader',
       options: {
         env: {
-          loose: true,
           targets: { 'react-native': '0.74' },
         },
         jsc: {
+          assumptions: {
+            setPublicClassFields: true,
+            privateFieldsAsProperties: true,
+          },
           // helpers alter the order of execution and cause weird issues with reanimated
           // this is very likely an SWC issue
           // TODO - investigate and reenable helpers in the future
           externalHelpers: false,
-          loose: true,
           parser: {
             syntax: 'ecmascript',
             jsx: true,

--- a/templates_v5/rspack.config.cjs
+++ b/templates_v5/rspack.config.cjs
@@ -104,12 +104,15 @@ module.exports = (env) => {
             loader: 'builtin:swc-loader',
             options: {
               env: {
-                loose: true,
                 targets: {
                   'react-native': '0.74',
                 },
               },
               jsc: {
+                assumptions: {
+                  setPublicClassFields: true,
+                  privateFieldsAsProperties: true,
+                },
                 externalHelpers: true,
                 transform: {
                   react: {

--- a/templates_v5/rspack.config.mjs
+++ b/templates_v5/rspack.config.mjs
@@ -102,12 +102,15 @@ export default (env) => {
             /** @type {import('@rspack/core').SwcLoaderOptions} */
             options: {
               env: {
-                loose: true,
                 targets: {
                   'react-native': '0.74',
                 },
               },
               jsc: {
+                assumptions: {
+                  setPublicClassFields: true,
+                  privateFieldsAsProperties: true,
+                },
                 externalHelpers: true,
                 transform: {
                   react: {


### PR DESCRIPTION
### Summary

before too many loose mode transformations were enabled, being not spec compliant with `@react-native/babel-preset` - now only the default ones are provided with the config - making the compiled code more strict and spec compliant.

### Test plan

- [x] - all testers work
