### PR TITLE
feat: add nativewind dependencies check

### DIFF
--- a/.changeset/six-mugs-peel.md
+++ b/.changeset/six-mugs-peel.md
@@ -1,0 +1,5 @@
+---
+"@callstack/repack-plugin-nativewind": minor
+---
+
+Add required dependencies check to NativeWind plugin.

--- a/packages/plugin-nativewind/README.md
+++ b/packages/plugin-nativewind/README.md
@@ -32,11 +32,13 @@ First, follow these steps from the official [NativeWind installation guide](http
 3. [Configure Babel plugin](https://www.nativewind.dev/getting-started/react-native#5-configure-babel-plugin)
 4. (Optional) [Setup TypeScript support](https://www.nativewind.dev/getting-started/react-native#7-setup-typescript-support)
 
-Then install the Re.Pack NativeWind plugin:
+Then install the Re.Pack NativeWind plugin and it's dependencies:
 
 ```sh
-npm install -D @callstack/repack-plugin-nativewind
+npm install -D @callstack/repack-plugin-nativewind postcss postcss-loader autoprefixer
 ```
+
+These additional dependencies (`postcss`, `postcss-loader`, and `autoprefixer`) are required for processing Tailwind CSS with Webpack/Rspack, as specified in the [official Tailwind CSS Rspack guide](https://tailwindcss.com/docs/guides/rspack). They enable PostCSS processing and autoprefixing of CSS styles in your build pipeline.
 
 ## Usage
 

--- a/packages/plugin-nativewind/package.json
+++ b/packages/plugin-nativewind/package.json
@@ -42,9 +42,13 @@
     "dedent": "^0.7.0"
   },
   "peerDependencies": {
-    "@callstack/repack": "^5.0.0-rc.7",
+    "@callstack/repack": ">=5.0.0-rc.7",
     "nativewind": ">=4.1.23",
-    "react-native-css-interop": ">=0.1.22"
+    "react-native-css-interop": ">=0.1.22",
+    "postcss": ">=8.4.31",
+    "postcss-loader": ">=8.4.31",
+    "autoprefixer": ">=10.4.16",
+    "tailwindcss": ">=3.4.11"
   },
   "devDependencies": {
     "@callstack/repack": "workspace:*",

--- a/packages/plugin-nativewind/src/plugin.ts
+++ b/packages/plugin-nativewind/src/plugin.ts
@@ -6,7 +6,19 @@ import type {
   SwcLoaderOptions,
 } from '@rspack/core';
 
+interface NativeWindPluginOptions {
+  /**
+   * Whether to check if the required dependencies are installed in the project.
+   * If not, an error will be thrown. Defaults to `true`.
+   */
+  checkDependencies?: boolean;
+}
+
 export class NativeWindPlugin implements RspackPluginInstance {
+  constructor(private options: NativeWindPluginOptions = {}) {
+    this.options.checkDependencies = this.options.checkDependencies ?? true;
+  }
+
   private configureSwcLoaderForNativeWind(
     swcOptions: SwcLoaderOptions = {}
   ): SwcLoaderOptions {
@@ -82,7 +94,9 @@ export class NativeWindPlugin implements RspackPluginInstance {
   }
 
   apply(compiler: Compiler) {
-    this.ensureNativewindDependenciesInstalled(compiler.context);
+    if (this.options.checkDependencies) {
+      this.ensureNativewindDependenciesInstalled(compiler.context);
+    }
 
     /**
      * First, we need to process the CSS files using PostCSS.

--- a/packages/plugin-nativewind/src/plugin.ts
+++ b/packages/plugin-nativewind/src/plugin.ts
@@ -55,7 +55,35 @@ export class NativeWindPlugin implements RspackPluginInstance {
     return this.configureSwcLoaderForNativeWind(ruleOptionsField);
   }
 
+  private ensureDependencyInstalled(context: string, dependency: string) {
+    try {
+      require.resolve(dependency, { paths: [context] });
+    } catch {
+      throw new Error(
+        `[RepackNativeWindPlugin] ${dependency} is required but not found in your project. ` +
+          'Did you forget to install it?'
+      );
+    }
+  }
+
+  private ensureNativewindDependenciesInstalled(context: string) {
+    const dependencies = [
+      'nativewind',
+      'react-native-css-interop',
+      'postcss',
+      'postcss-loader',
+      'tailwindcss',
+      'autoprefixer',
+    ];
+
+    dependencies.forEach((dependency) => {
+      this.ensureDependencyInstalled(context, dependency);
+    });
+  }
+
   apply(compiler: Compiler) {
+    this.ensureNativewindDependenciesInstalled(compiler.context);
+
     /**
      * First, we need to process the CSS files using PostCSS.
      * The PostCSS loader will use Tailwind CSS to generate the necessary utility classes

--- a/packages/plugin-nativewind/src/plugin.ts
+++ b/packages/plugin-nativewind/src/plugin.ts
@@ -71,10 +71,13 @@ export class NativeWindPlugin implements RspackPluginInstance {
     try {
       require.resolve(dependency, { paths: [context] });
     } catch {
-      throw new Error(
-        `[RepackNativeWindPlugin] ${dependency} is required but not found in your project. ` +
+      const error = new Error(
+        `[RepackNativeWindPlugin] Dependency named '${dependency}' is required but not found in your project. ` +
           'Did you forget to install it?'
       );
+      // remove the stack trace to make the error more readable
+      error.stack = undefined;
+      throw error;
     }
   }
 


### PR DESCRIPTION
### Summary

Added a check for dependencies that are required by NativeWind integration. The check can be disabled through `checkDependencies: false` flag passed inside plugin options.

On top of that:
- [x] - added `postcss`, `postcss-loader`, `tailwindcss` and `autoprefixer` as peerDependecies
- [x] - updated `README.md` with the dependencies above

### Test plan

- [x] testers work
