### PR TITLE
Add cssInterop options to the Nativewind plugin

### DIFF
--- a/.changeset/tasty-feet-refuse.md
+++ b/.changeset/tasty-feet-refuse.md
@@ -1,0 +1,5 @@
+---
+"@callstack/repack-plugin-nativewind": minor
+---
+
+Add cssInteropOptions to Nativewind plugin.

--- a/apps/tester-app/rspack.config.mjs
+++ b/apps/tester-app/rspack.config.mjs
@@ -199,7 +199,7 @@ export default (env) => {
       // }),
       process.env.RSDOCTOR && new RsdoctorRspackPlugin(),
       new ReanimatedPlugin(),
-      new NativeWindPlugin(),
+      new NativeWindPlugin({ cssInteropOptions: { inlineRem: 16 } }),
     ].filter(Boolean),
   };
 };

--- a/packages/plugin-nativewind/src/loader.ts
+++ b/packages/plugin-nativewind/src/loader.ts
@@ -1,10 +1,13 @@
 import type { LoaderContext } from '@rspack/core';
 import dedent from 'dedent';
-import { cssToReactNativeRuntime } from 'react-native-css-interop/css-to-rn';
+import {
+  type CssToReactNativeRuntimeOptions,
+  cssToReactNativeRuntime,
+} from 'react-native-css-interop/css-to-rn';
 import { stringify } from './utils.js';
 
-// biome-ignore lint/suspicious/noEmptyInterface: placeholder for options
-interface NativeWindLoaderOptions {}
+interface NativeWindLoaderOptions
+  extends Omit<CssToReactNativeRuntimeOptions, 'cache'> {}
 
 export const raw = false;
 
@@ -16,7 +19,8 @@ export default function nativeWindLoader(
   const callback = this.async();
 
   try {
-    const jsCss = cssToReactNativeRuntime(source);
+    const options = this.getOptions();
+    const jsCss = cssToReactNativeRuntime(source, options);
     const code = dedent`
       import { StyleSheet } from "nativewind";
       StyleSheet.registerCompiled((${stringify(jsCss)}));

--- a/packages/plugin-nativewind/src/plugin.ts
+++ b/packages/plugin-nativewind/src/plugin.ts
@@ -5,6 +5,7 @@ import type {
   RuleSetUseItem,
   SwcLoaderOptions,
 } from '@rspack/core';
+import type { CssToReactNativeRuntimeOptions } from 'react-native-css-interop/css-to-rn';
 
 interface NativeWindPluginOptions {
   /**
@@ -12,6 +13,11 @@ interface NativeWindPluginOptions {
    * If not, an error will be thrown. Defaults to `true`.
    */
   checkDependencies?: boolean;
+
+  /**
+   * Custom cssToReactNativeRuntime options.
+   */
+  cssInteropOptions?: Omit<CssToReactNativeRuntimeOptions, 'cache'>;
 }
 
 export class NativeWindPlugin implements RspackPluginInstance {
@@ -113,7 +119,10 @@ export class NativeWindPlugin implements RspackPluginInstance {
     compiler.options.module.rules.push({
       test: /\.css$/,
       use: [
-        { loader: '@callstack/repack-plugin-nativewind/loader' },
+        {
+          loader: '@callstack/repack-plugin-nativewind/loader',
+          options: this.options.cssInteropOptions,
+        },
         {
           loader: 'postcss-loader',
           options: {


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

Introduces a new `cssToReactNativeRuntimeOptions` option (name suggestions are welcome) that forwards directly to `cssToReactNativeRuntime` allowing configurations like `inlineRem` and `selectorPrefix`

### Test plan

- [x] testers work
