### PR TITLE
fix: force container name to be a valid js identifier

### DIFF
--- a/.changeset/pretty-years-sit.md
+++ b/.changeset/pretty-years-sit.md
@@ -2,4 +2,4 @@
 "@callstack/repack": patch
 ---
 
-Force container name to be a valid JS identifier
+Require MF2 container name to be a valid JS identifier

--- a/.changeset/pretty-years-sit.md
+++ b/.changeset/pretty-years-sit.md
@@ -1,5 +1,5 @@
 ---
-"@callstack/repack": minor
+"@callstack/repack": patch
 ---
 
 Force container name to be a valid JS identifier

--- a/.changeset/pretty-years-sit.md
+++ b/.changeset/pretty-years-sit.md
@@ -1,0 +1,5 @@
+---
+"@callstack/repack": minor
+---
+
+Force container name to be a valid JS identifier

--- a/packages/repack/package.json
+++ b/packages/repack/package.json
@@ -82,6 +82,7 @@
     "babel-loader": "^9.2.1",
     "colorette": "^2.0.20",
     "dedent": "^0.7.0",
+    "estree-util-is-identifier-name": "^1.1.0",
     "events": "^3.3.0",
     "execa": "^5.0.0",
     "flow-remove-types": "^2.250.0",

--- a/packages/repack/src/plugins/ModuleFederationPluginV2.ts
+++ b/packages/repack/src/plugins/ModuleFederationPluginV2.ts
@@ -117,7 +117,7 @@ export class ModuleFederationPluginV2 implements RspackPluginInstance {
     if (!isIdentifier(name)) {
       const error = new Error(
         `[ModuleFederationPlugin] The container's name: '${name}' must be a valid JavaScript identifier. ` +
-          'Please correct it to proceed.'
+          'Please correct it to proceed. For more information, see: https://developer.mozilla.org/en-US/docs/Glossary/Identifier'
       );
       // remove the stack trace to make the error more readable
       error.stack = undefined;

--- a/packages/repack/src/plugins/ModuleFederationPluginV2.ts
+++ b/packages/repack/src/plugins/ModuleFederationPluginV2.ts
@@ -1,5 +1,6 @@
 import type { moduleFederationPlugin as MF } from '@module-federation/sdk';
 import type { Compiler, RspackPluginInstance } from '@rspack/core';
+import { name as isIdentifier } from 'estree-util-is-identifier-name';
 import { isRspackCompiler } from './utils/isRspackCompiler.js';
 
 type JsModuleDescriptor = {
@@ -53,7 +54,7 @@ export interface ModuleFederationPluginV2Config
  * import * as Repack from '@callstack/repack';
  *
  * new Repack.plugins.ModuleFederationPlugin({
- *   name: 'host,
+ *   name: 'host',
  * });
  * ```
  *
@@ -62,7 +63,7 @@ export interface ModuleFederationPluginV2Config
  * import * as Repack from '@callstack/repack';
  *
  * new Repack.plugins.ModuleFederationPlugin({
- *   name: 'host,
+ *   name: 'host',
  *   shared: {
  *     react: Repack.Federated.SHARED_REACT,
  *     'react-native': Repack.Federated.SHARED_REACT,
@@ -111,12 +112,25 @@ export class ModuleFederationPluginV2 implements RspackPluginInstance {
     ];
   }
 
+  private validateModuleFederationContainerName(name: string | undefined) {
+    if (!name) return;
+    if (!isIdentifier(name)) {
+      const error = new Error(
+        `[ModuleFederationPlugin] The container's name: '${name}' must be a valid JavaScript identifier. ` +
+          'Please correct it to proceed.'
+      );
+      // remove the stack trace to make the error more readable
+      error.stack = undefined;
+      throw error;
+    }
+  }
+
   private ensureModuleFederationPackageInstalled(context: string) {
     try {
       require.resolve('@module-federation/enhanced', { paths: [context] });
     } catch {
       throw new Error(
-        "ModuleFederationPlugin requires '@module-federation/enhanced' to be present in your project. " +
+        "[ModuleFederationPlugin] Dependency '@module-federation/enhanced' is required, but not found in your project. " +
           'Did you forget to install it?'
       );
     }
@@ -273,6 +287,7 @@ export class ModuleFederationPluginV2 implements RspackPluginInstance {
   }
 
   apply(compiler: Compiler) {
+    this.validateModuleFederationContainerName(this.config.name);
     this.ensureModuleFederationPackageInstalled(compiler.context);
     this.setupIgnoredWarnings(compiler);
 

--- a/packages/repack/src/plugins/__tests__/ModuleFederationPluginV2.test.ts
+++ b/packages/repack/src/plugins/__tests__/ModuleFederationPluginV2.test.ts
@@ -264,14 +264,14 @@ describe('ModuleFederationPlugin', () => {
   });
 
   it('should not throw an error for a valid container name', () => {
-    const invalidContainerNames = [
+    const validContainerNames = [
       'app_name',
       'appName',
       'appName123',
       '$appName',
     ];
 
-    invalidContainerNames.forEach((name) => {
+    validContainerNames.forEach((name) => {
       expect(() => {
         new ModuleFederationPluginV2({ name }).apply(mockCompiler);
       }).not.toThrow();

--- a/packages/repack/src/plugins/__tests__/ModuleFederationPluginV2.test.ts
+++ b/packages/repack/src/plugins/__tests__/ModuleFederationPluginV2.test.ts
@@ -244,4 +244,37 @@ describe('ModuleFederationPlugin', () => {
 
     expect(() => ignoreWarnings[1](warning)).not.toThrow();
   });
+
+  it('should throw an error for an invalid container name', () => {
+    const invalidContainerNames = [
+      'app-name',
+      '123AppName',
+      'app@name',
+      'app name',
+    ];
+
+    invalidContainerNames.forEach((name) => {
+      expect(() => {
+        new ModuleFederationPluginV2({ name }).apply(mockCompiler);
+      }).toThrow(
+        `[ModuleFederationPlugin] The container's name: '${name}' must be a valid JavaScript identifier. ` +
+          'Please correct it to proceed.'
+      );
+    });
+  });
+
+  it('should not throw an error for a valid container name', () => {
+    const invalidContainerNames = [
+      'app_name',
+      'appName',
+      'appName123',
+      '$appName',
+    ];
+
+    invalidContainerNames.forEach((name) => {
+      expect(() => {
+        new ModuleFederationPluginV2({ name }).apply(mockCompiler);
+      }).not.toThrow();
+    });
+  });
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -512,6 +512,9 @@ importers:
       dedent:
         specifier: ^0.7.0
         version: 0.7.0
+      estree-util-is-identifier-name:
+        specifier: ^1.1.0
+        version: 1.1.0
       events:
         specifier: ^3.3.0
         version: 3.3.0
@@ -4228,6 +4231,9 @@ packages:
 
   estree-util-build-jsx@2.2.2:
     resolution: {integrity: sha512-m56vOXcOBuaF+Igpb9OPAy7f9w9OIkb5yhjsZuaPm7HoGi4oTOQi0h2+yZ+AtKklYFZ+rPC4n0wYCJCEU1ONqg==}
+
+  estree-util-is-identifier-name@1.1.0:
+    resolution: {integrity: sha512-OVJZ3fGGt9By77Ix9NhaRbzfbDV/2rx9EP7YIDJTmsZSEc5kYn2vWcNccYyahJL2uAQZK2a5Or2i0wtIKTPoRQ==}
 
   estree-util-is-identifier-name@2.1.0:
     resolution: {integrity: sha512-bEN9VHRyXAUOjkKVQVvArFym08BTWB0aJPppZZr0UNyAqWsLaVfAqP7hbaTJjzHifmB5ebnR8Wm7r7yGN/HonQ==}
@@ -12420,6 +12426,8 @@ snapshots:
       '@types/estree-jsx': 1.0.5
       estree-util-is-identifier-name: 2.1.0
       estree-walker: 3.0.3
+
+  estree-util-is-identifier-name@1.1.0: {}
 
   estree-util-is-identifier-name@2.1.0: {}
 


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

Adding a check in `ModuleFederationPluginV2` to validate that a container's name is a valid JavaScript identifier.

It fixes the following error:

```
✖ [11:12:29.747Z][DevServer]   × Library name base (mini-app) must be a valid identifier when using a var declaring library type. Either use a valid identifier (e. g. mini_app) or use a different library type (e. g. `type: 'global'`, which assign a property on the global scope instead of declaring a variable). Common configuration options that specific library names are 'output.library[.name]', 'entry.xyz.library[.name]', 'ModuleFederationPlugin.name' and 'ModuleFederationPlugin.library[.name]'.
 {
  reqId: 'req-2',
  err: {
    type: 'Error',
    message: "  × Library name base (mini-app) must be a valid identifier when using a var declaring library type. Either use a valid identifier (e. g. mini_app) or use a different library type (e. g. `type: 'global'`, which assign a property on the global scope instead of declaring a variable). Common configuration options that specific library names are 'output.library[.name]', 'entry.xyz.library[.name]', 'ModuleFederationPlugin.name' and 'ModuleFederationPlugin.library[.name]'.\n",
    stack: "Error:   × Library name base (mini-app) must be a valid identifier when using a var declaring library type. Either use a valid identifier (e. g. mini_app) or use a different library type (e. g. `type: 'global'`, which assign a property on the global scope instead of declaring a variable). Common configuration options that specific library names are 'output.library[.name]', 'entry.xyz.library[.name]', 'ModuleFederationPlugin.name' and 'ModuleFederationPlugin.library[.name]'.\n",
    code: 'GenericFailure'
  }
} 
```

<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->

### Test plan

- [x] - added unit test
- [x] - tested manually within `tester-federation-v2` repository:

<img width="2032" alt="Zrzut ekranu 2025-01-22 o 16 27 30" src="https://github.com/user-attachments/assets/27e53188-1662-416d-b0fc-a37700368e87" />

