### PR TITLE
feat: expo-modules plugin

### DIFF
--- a/.changeset/weak-birds-change.md
+++ b/.changeset/weak-birds-change.md
@@ -1,0 +1,5 @@
+---
+"@callstack/repack": minor
+---
+
+Add support for Expo Modules through a dedicated optional plugin called @callstack/repack-plugin-expo-modules

--- a/packages/plugin-expo-modules/README.md
+++ b/packages/plugin-expo-modules/README.md
@@ -13,16 +13,16 @@ A toolkit to build your React Native application with Rspack or Webpack.
 [![PRs Welcome][prs-welcome-badge]][prs-welcome]
 [![Code of Conduct][coc-badge]][coc]
 
-`@callstack/repack-plugin-reanimated` is a plugin for `@callstack/repack` that integrates `react-native-reanimated` into your React Native projects.
+`@callstack/repack-plugin-expo-modules` is a plugin for `@callstack/repack` that compliments the integration of Expo Modules into your React Native projects.
 
 ## About
 
-This plugin exists in order to simplify the setup required to get `react-native-reanimated` working with Re.Pack and to minimize the impact on build performance. It looks for relevant keywords like `worklet` inside the source before transforming the file with `babel`.
+This plugin helps and compliments the process of enabling Expo Modules in Re.Pack projects by defining necessary globals that are expected by Expo Modules at runtime. However, it is not sufficient on its own for a complete setup. For comprehensive guidance on using Expo Modules with Re.Pack, please refer to our [official documentation](https://re-pack.dev/).
 
 ## Installation
 
 ```sh
-npm install -D @callstack/repack-plugin-reanimated
+npm install -D @callstack/repack-plugin-expo-modules
 ```
 
 ## Usage
@@ -32,7 +32,7 @@ npm install -D @callstack/repack-plugin-reanimated
 To add the plugin to your Re.Pack configuration, update your `rspack.config.js` or `webpack.config.js` as follows:
 
 ```js
-import { ReanimatedPlugin } from '@callstack/repack-plugin-reanimated';
+import { ExpoModulesPlugin } from "@callstack/repack-plugin-expo-modules";
 
 export default (env) => {
   // ...
@@ -40,39 +40,8 @@ export default (env) => {
     // ...
     plugins: [
       // ...
-      new ReanimatedPlugin(),
+      new ExpoModulesPlugin(),
     ],
-  };
-};
-```
-
-### Loader
-
-The plugin also comes with it's own loader, which you can use on it's own inside `rspack.config.js` or `webpack.config.js` like this:
-
-```js
-export default (env) => {
-  // ...
-  return {
-    // ...
-    module: {
-      rules: [
-        {
-          test: /\.ts$/,
-          use: {
-            loader: '@callstack/repack-plugin-reanimated/loader',
-            options: {
-              babelPlugins: [
-                [
-                  '@babel/plugin-syntax-typescript',
-                  { isTSX: false, allowNamespaces: true },
-                ],
-              ],
-            },
-          },
-        },
-      ],
-    },
   };
 };
 ```
@@ -86,9 +55,9 @@ Check out our website at https://re-pack.dev for more info and documentation or 
 [callstack-readme-with-love]: https://callstack.com/?utm_source=github.com&utm_medium=referral&utm_campaign=react-native-paper&utm_term=readme-with-love
 [build-badge]: https://img.shields.io/github/workflow/status/callstack/repack/CI/main?style=flat-square
 [build]: https://github.com/callstack/repack/actions/workflows/main.yml
-[version-badge]: https://img.shields.io/npm/v/@callstack/repack-plugin-reanimated?style=flat-square
-[version]: https://www.npmjs.com/package/@callstack/repack-plugin-reanimated
-[license-badge]: https://img.shields.io/npm/l/@callstack/repack-plugin-reanimated?style=flat-square
+[version-badge]: https://img.shields.io/npm/v/@callstack/repack-plugin-expo-modules?style=flat-square
+[version]: https://www.npmjs.com/package/@callstack/repack-plugin-expo-modules
+[license-badge]: https://img.shields.io/npm/l/@callstack/repack-plugin-expo-modules?style=flat-square
 [license]: https://github.com/callstack/repack/blob/master/LICENSE
 [prs-welcome-badge]: https://img.shields.io/badge/PRs-welcome-brightgreen.svg?style=flat-square
 [prs-welcome]: ./CONTRIBUTING.md

--- a/packages/plugin-expo-modules/README.md
+++ b/packages/plugin-expo-modules/README.md
@@ -1,0 +1,96 @@
+<p align="center">
+    <img src="https://raw.githubusercontent.com/callstack/repack/HEAD/logo.png">
+</p>
+<p align="center">
+A toolkit to build your React Native application with Rspack or Webpack.
+</p>
+
+---
+
+[![Build Status][build-badge]][build]
+[![Version][version-badge]][version]
+[![MIT License][license-badge]][license]
+[![PRs Welcome][prs-welcome-badge]][prs-welcome]
+[![Code of Conduct][coc-badge]][coc]
+
+`@callstack/repack-plugin-reanimated` is a plugin for `@callstack/repack` that integrates `react-native-reanimated` into your React Native projects.
+
+## About
+
+This plugin exists in order to simplify the setup required to get `react-native-reanimated` working with Re.Pack and to minimize the impact on build performance. It looks for relevant keywords like `worklet` inside the source before transforming the file with `babel`.
+
+## Installation
+
+```sh
+npm install -D @callstack/repack-plugin-reanimated
+```
+
+## Usage
+
+### Plugin
+
+To add the plugin to your Re.Pack configuration, update your `rspack.config.js` or `webpack.config.js` as follows:
+
+```js
+import { ReanimatedPlugin } from '@callstack/repack-plugin-reanimated';
+
+export default (env) => {
+  // ...
+  return {
+    // ...
+    plugins: [
+      // ...
+      new ReanimatedPlugin(),
+    ],
+  };
+};
+```
+
+### Loader
+
+The plugin also comes with it's own loader, which you can use on it's own inside `rspack.config.js` or `webpack.config.js` like this:
+
+```js
+export default (env) => {
+  // ...
+  return {
+    // ...
+    module: {
+      rules: [
+        {
+          test: /\.ts$/,
+          use: {
+            loader: '@callstack/repack-plugin-reanimated/loader',
+            options: {
+              babelPlugins: [
+                [
+                  '@babel/plugin-syntax-typescript',
+                  { isTSX: false, allowNamespaces: true },
+                ],
+              ],
+            },
+          },
+        },
+      ],
+    },
+  };
+};
+```
+
+---
+
+Check out our website at https://re-pack.dev for more info and documentation or our GitHub: https://github.com/callstack/repack.
+
+<!-- badges -->
+
+[callstack-readme-with-love]: https://callstack.com/?utm_source=github.com&utm_medium=referral&utm_campaign=react-native-paper&utm_term=readme-with-love
+[build-badge]: https://img.shields.io/github/workflow/status/callstack/repack/CI/main?style=flat-square
+[build]: https://github.com/callstack/repack/actions/workflows/main.yml
+[version-badge]: https://img.shields.io/npm/v/@callstack/repack-plugin-reanimated?style=flat-square
+[version]: https://www.npmjs.com/package/@callstack/repack-plugin-reanimated
+[license-badge]: https://img.shields.io/npm/l/@callstack/repack-plugin-reanimated?style=flat-square
+[license]: https://github.com/callstack/repack/blob/master/LICENSE
+[prs-welcome-badge]: https://img.shields.io/badge/PRs-welcome-brightgreen.svg?style=flat-square
+[prs-welcome]: ./CONTRIBUTING.md
+[coc-badge]: https://img.shields.io/badge/code%20of-conduct-ff69b4.svg?style=flat-square
+[coc]: https://github.com/callstack/repack/blob/master/CODE_OF_CONDUCT.md

--- a/packages/plugin-expo-modules/package.json
+++ b/packages/plugin-expo-modules/package.json
@@ -1,0 +1,47 @@
+{
+  "name": "@callstack/repack-plugin-expo-modules",
+  "version": "5.0.0-rc.9",
+  "description": "A plugin for @callstack/repack that integrates expo-modules",
+  "author": "Jakub Romańczyk <jakub.romanczyk@callstack.com>",
+  "license": "MIT",
+  "homepage": "https://github.com/callstack/repack",
+  "repository": "github:callstack/repack",
+  "type": "commonjs",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "files": ["dist"],
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
+  },
+  "keywords": [
+    "repack",
+    "re.pack",
+    "plugin",
+    "repack-plugin",
+    "expo-modules",
+    "expo"
+  ],
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org/",
+    "access": "public"
+  },
+  "engineStrict": true,
+  "engines": {
+    "node": ">=18"
+  },
+  "peerDependencies": {
+    "@callstack/repack": "^5.0.0-rc.9"
+  },
+  "devDependencies": {
+    "@callstack/repack": "workspace:*",
+    "@rspack/core": "1.0.8",
+    "@types/node": "^18"
+  },
+  "scripts": {
+    "build": "tsc -p tsconfig.build.json",
+    "typecheck": "tsc --noEmit"
+  }
+}

--- a/packages/plugin-expo-modules/package.json
+++ b/packages/plugin-expo-modules/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@callstack/repack-plugin-expo-modules",
   "version": "5.0.0-rc.9",
-  "description": "A plugin for @callstack/repack that integrates expo-modules",
+  "description": "A plugin for @callstack/repack that integrates Expo Modules",
   "author": "Jakub Romańczyk <jakub.romanczyk@callstack.com>",
   "license": "MIT",
   "homepage": "https://github.com/callstack/repack",

--- a/packages/plugin-expo-modules/src/index.ts
+++ b/packages/plugin-expo-modules/src/index.ts
@@ -1,0 +1,1 @@
+export { ExpoModulesPlugin } from './plugin.js';

--- a/packages/plugin-expo-modules/src/plugin.ts
+++ b/packages/plugin-expo-modules/src/plugin.ts
@@ -1,5 +1,23 @@
 import type { Compiler, RspackPluginInstance } from '@rspack/core';
 
+interface ExpoModulesPluginOptions {
+  /**
+   * Target application platform (e.g. `ios`, `android`).
+   *
+   * By default, the platform is inferred from `compiler.name` which is set by Re.Pack.
+   */
+  platform?: string;
+}
+
 export class ExpoModulesPlugin implements RspackPluginInstance {
-  apply(_compiler: Compiler) {}
+  constructor(private options: ExpoModulesPluginOptions = {}) {}
+
+  apply(compiler: Compiler) {
+    const platform = this.options.platform ?? compiler.name;
+
+    // expo modules expect this to be defined in runtime
+    new compiler.webpack.DefinePlugin({
+      'process.env.EXPO_OS': JSON.stringify(platform),
+    });
+  }
 }

--- a/packages/plugin-expo-modules/src/plugin.ts
+++ b/packages/plugin-expo-modules/src/plugin.ts
@@ -1,0 +1,5 @@
+import type { Compiler, RspackPluginInstance } from '@rspack/core';
+
+export class ExpoModulesPlugin implements RspackPluginInstance {
+  apply(_compiler: Compiler) {}
+}

--- a/packages/plugin-expo-modules/tsconfig.build.json
+++ b/packages/plugin-expo-modules/tsconfig.build.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src",
+    "paths": {}
+  }
+}

--- a/packages/plugin-expo-modules/tsconfig.json
+++ b/packages/plugin-expo-modules/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDirs": ["src", "../repack/src", "../dev-server/src"],
+    "paths": {
+      "@callstack/repack": ["../repack/src/index.ts"],
+      "@callstack/repack/*": ["../repack/src/*"],
+      "@callstack/repack-dev-server": ["../dev-server/src/index.ts"],
+      "@callstack/repack-dev-server/*": ["../dev-server/src/*"],
+      "@react-native/dev-middleware": [
+        "../dev-server/node_modules/@react-native/dev-middleware/dist"
+      ]
+    }
+  },
+  "include": ["src/**/*"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -455,6 +455,18 @@ importers:
         specifier: ^17.7.2
         version: 17.7.2
 
+  packages/plugin-expo-modules:
+    devDependencies:
+      '@callstack/repack':
+        specifier: workspace:*
+        version: link:../repack
+      '@rspack/core':
+        specifier: 1.0.8
+        version: 1.0.8(@swc/helpers@0.5.15)
+      '@types/node':
+        specifier: ^18
+        version: 18.19.41
+
   packages/plugin-nativewind:
     dependencies:
       dedent:


### PR DESCRIPTION
### Summary

Added expo-modules plugin package that fills the gap for integrating expo-modules with Re.Pack - for now the plugin only defines the `EXPO_OS` env var in runtime which is normally set by `babel-preset-expo`. 

### Test plan

- [x] - no `EXPO_OS` warning present in runtime after adding the plugin
