### PR TITLE
feat: normalise `compiler.name` to compilation target platform

### DIFF
--- a/.changeset/violet-keys-trade.md
+++ b/.changeset/violet-keys-trade.md
@@ -1,0 +1,5 @@
+---
+"@callstack/repack": minor
+---
+
+Normalize compiler.name to always be equal to the target platform across all commands

--- a/packages/repack/src/commands/common/__tests__/loadConfig.test.ts
+++ b/packages/repack/src/commands/common/__tests__/loadConfig.test.ts
@@ -1,0 +1,97 @@
+import type { EnvOptions } from '../../../types.js';
+import { loadConfig } from '../loadConfig.js';
+
+describe('loadConfig', () => {
+  const mockEnvOptions: EnvOptions = {
+    platform: 'ios',
+    mode: 'development',
+    context: '/test/root',
+    entry: 'index.js',
+  };
+
+  beforeEach(() => {
+    jest.resetModules();
+  });
+
+  it('should load and normalize CommonJS config object', async () => {
+    const mockConfig = {
+      entry: './index.js',
+      output: { path: './dist' },
+    };
+
+    jest.doMock('/test/config.js', () => mockConfig, { virtual: true });
+
+    const result = await loadConfig('/test/config.js', mockEnvOptions);
+
+    expect(result).toEqual({
+      ...mockConfig,
+      name: 'ios',
+    });
+  });
+
+  it('should load and normalize ESM config object', async () => {
+    const mockConfig = {
+      entry: './index.js',
+      output: { path: './dist' },
+    };
+
+    jest.doMock(
+      '/test/config.mjs',
+      () => ({
+        default: mockConfig,
+      }),
+      { virtual: true }
+    );
+
+    const result = await loadConfig('/test/config.mjs', mockEnvOptions);
+
+    expect(result).toEqual({
+      ...mockConfig,
+      name: 'ios',
+    });
+  });
+
+  it('should handle function configuration', async () => {
+    const mockConfigFn = jest.fn().mockImplementation((env: EnvOptions) => ({
+      entry: './index.js',
+      mode: env.mode,
+    }));
+
+    jest.doMock('/test/config.js', () => mockConfigFn, { virtual: true });
+
+    const result = await loadConfig('/test/config.js', mockEnvOptions);
+
+    expect(mockConfigFn).toHaveBeenCalledWith(mockEnvOptions, {});
+    expect(result).toEqual({
+      entry: './index.js',
+      mode: 'development',
+      name: 'ios',
+    });
+  });
+
+  it('should handle async function configuration', async () => {
+    const mockConfigFn = jest
+      .fn()
+      .mockImplementation(async (env: EnvOptions) => ({
+        entry: './index.js',
+        mode: env.mode,
+      }));
+
+    jest.doMock('/test/config.js', () => mockConfigFn, { virtual: true });
+
+    const result = await loadConfig('/test/config.js', mockEnvOptions);
+
+    expect(mockConfigFn).toHaveBeenCalledWith(mockEnvOptions, {});
+    expect(result).toEqual({
+      entry: './index.js',
+      mode: 'development',
+      name: 'ios',
+    });
+  });
+
+  it('should throw when config file cannot be loaded', async () => {
+    await expect(
+      loadConfig('/non/existent/config.js', mockEnvOptions)
+    ).rejects.toThrow();
+  });
+});

--- a/packages/repack/src/commands/common/loadConfig.ts
+++ b/packages/repack/src/commands/common/loadConfig.ts
@@ -41,7 +41,7 @@ async function normalizeConfig<C extends ConfigurationObject>(
   // normalize the selected properties
   configObject.name = env.platform;
 
-  // return the original config object
+  // return the normalized config object
   return configObject;
 }
 

--- a/packages/repack/src/commands/common/loadConfig.ts
+++ b/packages/repack/src/commands/common/loadConfig.ts
@@ -1,13 +1,16 @@
 import type { EnvOptions } from '../../types.js';
 
+type ConfigurationObject = {
+  name?: string;
+} & Record<string, any>;
+
 type Configuration<T> =
   | T
   | ((env: EnvOptions, argv: Record<string, any>) => T | Promise<T>);
 
-export async function loadConfig<C extends Record<string, any>>(
-  configFilePath: string,
-  env: EnvOptions
-): Promise<C> {
+async function crossImport<C extends ConfigurationObject>(
+  configFilePath: string
+): Promise<Configuration<C>> {
   let config: Configuration<C>;
 
   try {
@@ -20,9 +23,34 @@ export async function loadConfig<C extends Record<string, any>>(
     config = config.default as Configuration<C>;
   }
 
+  return config;
+}
+
+async function normalizeConfig<C extends ConfigurationObject>(
+  config: Configuration<C>,
+  env: EnvOptions
+): Promise<C> {
+  // normalize the config into object
+  let configObject: C;
   if (typeof config === 'function') {
-    return await config(env, {});
+    configObject = await config(env, {});
+  } else {
+    configObject = config;
   }
 
-  return config;
+  // normalize the selected properties
+  configObject.name = env.platform;
+
+  // return the original config object
+  return configObject;
+}
+
+export async function loadConfig<C extends ConfigurationObject>(
+  configFilePath: string,
+  env: EnvOptions
+): Promise<C> {
+  const config = await crossImport<C>(configFilePath);
+  const normalizedConfig = await normalizeConfig(config, env);
+
+  return normalizedConfig;
 }

--- a/packages/repack/src/commands/rspack/Compiler.ts
+++ b/packages/repack/src/commands/rspack/Compiler.ts
@@ -58,14 +58,10 @@ export class Compiler {
     const webpackEnvOptions = getEnvOptions(this.cliOptions);
     const configs = await Promise.all(
       this.platforms.map(async (platform) => {
-        const env = { ...webpackEnvOptions, platform };
-        const config = await loadConfig<Configuration>(
+        return loadConfig<Configuration>(
           this.cliOptions.config.bundlerConfigPath,
-          env
+          { ...webpackEnvOptions, platform }
         );
-
-        config.name = platform;
-        return config;
       })
     );
 


### PR DESCRIPTION
### Summary

- [x] - normalised `compiler.name` to always be equal to `platform`
- [x] - added tests for `loadConfig` 

`compiler.name` is already utilised by `zephyr-repack-plugin` so it makes to normalize this across the commands. This also opens up a possibility to make `platform` param in configs optional (or remove it altogether later on)

### Test plan

- [x] - new & existing tests pass
