### PR TITLE
feat: extend list of flow-typed modules

### DIFF
--- a/.changeset/dirty-terms-burn.md
+++ b/.changeset/dirty-terms-burn.md
@@ -1,0 +1,5 @@
+---
+"@callstack/repack": patch
+---
+
+Add `react-native-camera` and `react-native-view-shot` to flow libs

--- a/packages/repack/src/rules/flowTypedModulesLoadingRules.ts
+++ b/packages/repack/src/rules/flowTypedModulesLoadingRules.ts
@@ -21,6 +21,8 @@ export const FLOW_TYPED_MODULES_LOADING_RULES: RuleSetRule = {
     '@react-native-community/datetimepicker',
     'react-native-linear-gradient',
     'react-native-inappbrowser-reborn',
+    'react-native-camera',
+    'react-native-view-shot',
   ]),
   use: {
     loader: '@callstack/repack/flow-loader',


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

Added `react-native-camera` and `react-native-view-shot` to flow libs inside `FLOW_TYPED_MODULES_LOADING_RULES`

### Test plan

n/a
