### PR TITLE
fix: correct 'postcss-loader' peer dependency version

### DIFF
--- a/.changeset/honest-foxes-hope.md
+++ b/.changeset/honest-foxes-hope.md
@@ -1,0 +1,5 @@
+---
+"@callstack/repack-plugin-nativewind": patch
+---
+
+Fixed incorrect peer dependency version of `postcss-loader`

--- a/packages/plugin-nativewind/package.json
+++ b/packages/plugin-nativewind/package.json
@@ -46,7 +46,7 @@
     "nativewind": ">=4.1.23",
     "react-native-css-interop": ">=0.1.22",
     "postcss": ">=8.4.31",
-    "postcss-loader": ">=8.4.31",
+    "postcss-loader": ">=8.1.1",
     "autoprefixer": ">=10.4.16",
     "tailwindcss": ">=3.4.11"
   },


### PR DESCRIPTION
The last version of `postcss-loader` is 8.1.1