### PR TITLE
chore(repack-init): hide `cd` log when project exsists

### DIFF
--- a/.changeset/big-singers-shop.md
+++ b/.changeset/big-singers-shop.md
@@ -1,0 +1,5 @@
+---
+"@callstack/repack-init": patch
+---
+
+Hide `cd` log when project exsists

--- a/packages/init/src/index.ts
+++ b/packages/init/src/index.ts
@@ -71,7 +71,7 @@ export default async function run(options: Options) {
 
     spinner.stop('Setup complete.');
 
-    completeSetup(projectName, packageManager);
+    completeSetup(projectName, packageManager, projectExists);
   } catch (error) {
     logger.fatal('Re.Pack setup failed\n\nWhat went wrong:');
 

--- a/packages/init/src/tasks/completeSetup.ts
+++ b/packages/init/src/tasks/completeSetup.ts
@@ -5,11 +5,12 @@ import type { PackageManager } from '../types/pm.js';
 
 export default function completeSetup(
   projectName: string,
-  packageManager: PackageManager
+  packageManager: PackageManager,
+  projectExists: boolean
 ) {
   const nextSteps = dedent`
-    cd ${projectName}
-    ${packageManager.runCommand} install
+    ${projectExists ? '' : `cd ${projectName}`}
+    ${projectExists ? '' : `${packageManager.runCommand} install`}
     ${packageManager.runCommand} start
 
     ${chalk.blue('[ios]')}

--- a/packages/init/src/tasks/completeSetup.ts
+++ b/packages/init/src/tasks/completeSetup.ts
@@ -10,7 +10,7 @@ export default function completeSetup(
 ) {
   const nextSteps = dedent`
     ${projectExists ? '' : `cd ${projectName}`}
-    ${projectExists ? '' : `${packageManager.runCommand} install`}
+    ${packageManager.runCommand} install
     ${packageManager.runCommand} start
 
     ${chalk.blue('[ios]')}


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

When initing Re.Pack in an existing project it doesn't make sense to log `cd` etc.

Before: 

```
┌  RE.PACK INIT
│
◇  Which bundler would you like to use?
│  Rspack
│
◇  Setup complete
│
◇  Next steps ──────╮
│                   │
│  cd myapp         │
│  npm install      │
│  npm start        │
│                   │
│  [ios]            │
│  npx pod-install  │
│  npm run ios      │
│                   │
│  [android]        │
│  npm run android  │
│                   │
├───────────────────╯
│
└  Done.
```

After:

```
┌  RE.PACK INIT
│
◇  Which bundler would you like to use?
│  Rspack
│
◇  Setup complete
│
◇  Next steps ──────╮
│                   │
│  npm start        │
│                   │
│  [ios]            │
│  npx pod-install  │
│  npm run ios      │
│                   │
│  [android]        │
│  npm run android  │
│                   │
├───────────────────╯
│
└  Done.
```