### PR TITLE
docs: use `5.x` as version in dev mode

### DIFF
--- a/website/rspress.config.ts
+++ b/website/rspress.config.ts
@@ -21,7 +21,7 @@ export default defineConfig({
     codeHighlighter: 'prism',
   },
   multiVersion: {
-    default: '4.x',
+    default: process.env.NODE_ENV === 'development' ? '5.x' : '4.x', // for dev we use 5.x while working on it
     versions: ['2.x', '3.x', '4.x', '5.x'],
   },
   route: {


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

As we intensively work on docs currently switching every time to `5.x` is annoying so in development mode I switched to `5.x` by default. 

### Test plan

Deployed version should use `4.x`