### PR TITLE
fix: don't error on missing `--entry-file` when entry is defined in `rspack/webpack.config.js`

### DIFF
--- a/.changeset/khaki-olives-add.md
+++ b/.changeset/khaki-olives-add.md
@@ -2,4 +2,4 @@
 "@callstack/repack": patch
 ---
 
-Don't error on missing --entry-file when entry is defined in rspack.config.js
+Don't error on missing `--entry-file` when entry is defined in `rspack.config.js` or `webpack.config.js`.

--- a/.changeset/khaki-olives-add.md
+++ b/.changeset/khaki-olives-add.md
@@ -1,0 +1,5 @@
+---
+"@callstack/repack": patch
+---
+
+Don't error on missing --entry-file when entry is defined in rspack.config.js

--- a/packages/repack/src/commands/common/getEnvOptions.ts
+++ b/packages/repack/src/commands/common/getEnvOptions.ts
@@ -16,10 +16,12 @@ export function getEnvOptions(cliOptions: CliOptions): EnvOptions {
       cliOptions.arguments.bundle.minify ?? env.mode === 'production';
 
     const { entryFile } = cliOptions.arguments.bundle;
-    env.entry =
-      path.isAbsolute(entryFile) || entryFile.startsWith('./')
-        ? entryFile
-        : `./${entryFile}`;
+    if (entryFile) {
+      env.entry =
+        path.isAbsolute(entryFile) || entryFile.startsWith('./')
+          ? entryFile
+          : `./${entryFile}`;
+    }
 
     env.bundleFilename = cliOptions.arguments.bundle.bundleOutput;
     env.sourceMapFilename = cliOptions.arguments.bundle.sourcemapOutput;

--- a/packages/repack/src/commands/rspack/bundle.ts
+++ b/packages/repack/src/commands/rspack/bundle.ts
@@ -44,16 +44,16 @@ export async function bundle(
     arguments: { bundle: args },
   };
 
-  if (!args.entryFile) {
-    throw new Error("Option '--entry-file <path>' argument is missing");
-  }
-
   if (args.verbose) {
     process.env[VERBOSE_ENV_KEY] = '1';
   }
 
   const envOptions = getEnvOptions(cliOptions);
   const config = await loadConfig<Configuration>(rspackConfigPath, envOptions);
+
+  if (!args.entryFile && !config.entry) {
+    throw new Error("Option '--entry-file <path>' argument is missing");
+  }
 
   const errorHandler = async (error: Error | null, stats?: Stats) => {
     if (error) {

--- a/packages/repack/src/commands/webpack/bundle.ts
+++ b/packages/repack/src/commands/webpack/bundle.ts
@@ -43,10 +43,6 @@ export async function bundle(
     arguments: { bundle: args },
   };
 
-  if (!args.entryFile) {
-    throw new Error("Option '--entry-file <path>' argument is missing");
-  }
-
   if (args.verbose) {
     process.env[VERBOSE_ENV_KEY] = '1';
   }
@@ -56,6 +52,10 @@ export async function bundle(
     webpackConfigPath,
     envOptions
   );
+
+  if (!args.entryFile && !webpackConfig.entry) {
+    throw new Error("Option '--entry-file <path>' argument is missing");
+  }
 
   const errorHandler = async (error: Error | null, stats?: webpack.Stats) => {
     if (error) {


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

We shouldn't exit with an error if there's no `--entry-file` option passed, because in we have the same value in `rspack.config.js` under `entry`.


