### PR TITLE
fix(cli): deprecate --webpackConfig option

### DIFF
--- a/.changeset/dirty-boats-type.md
+++ b/.changeset/dirty-boats-type.md
@@ -1,0 +1,5 @@
+---
+"@callstack/repack": patch
+---
+
+Deprecate `--webpackConfig` in `start` command and make deprecation warning more informative

--- a/packages/repack/src/commands/options.ts
+++ b/packages/repack/src/commands/options.ts
@@ -67,7 +67,8 @@ export const startCommandOptions = [
   },
   {
     name: '--webpackConfig <path>',
-    description: 'Path to a bundler config file, e.g webpack.config.js',
+    description:
+      '[DEPRECATED] Path to a bundler config file, e.g webpack.config.js. Please use --config instead.',
     parse: (val: string) => path.resolve(val),
   },
 ];

--- a/packages/repack/src/commands/rspack/bundle.ts
+++ b/packages/repack/src/commands/rspack/bundle.ts
@@ -28,6 +28,14 @@ export async function bundle(
   cliConfig: Config,
   args: BundleArguments
 ) {
+  if (args.webpackConfig) {
+    console.warn(
+      'Warning: `--webpackConfig` option is deprecated and will be removed in the next major version. ' +
+        'Please use `--config` instead.'
+    );
+    args.config = args.webpackConfig;
+  }
+
   const rspackConfigPath = getRspackConfigFilePath(
     cliConfig.root,
     args.config ?? args.webpackConfig

--- a/packages/repack/src/commands/rspack/start.ts
+++ b/packages/repack/src/commands/rspack/start.ts
@@ -37,10 +37,15 @@ export async function start(
   cliConfig: Config,
   args: StartArguments
 ) {
-  const rspackConfigPath = getRspackConfigFilePath(
-    cliConfig.root,
-    args.config ?? args.webpackConfig
-  );
+  if (args.webpackConfig) {
+    console.warn(
+      'Warning: `--webpackConfig` option is deprecated and will be removed in the next major version. ' +
+        'Please use `--config` instead.'
+    );
+    args.config = args.webpackConfig;
+  }
+
+  const rspackConfigPath = getRspackConfigFilePath(cliConfig.root, args.config);
   const { reversePort, ...restArgs } = args;
 
   const serverProtocol = args.https ? 'https' : 'http';

--- a/packages/repack/src/commands/webpack/bundle.ts
+++ b/packages/repack/src/commands/webpack/bundle.ts
@@ -27,9 +27,17 @@ export async function bundle(
   cliConfig: Config,
   args: BundleArguments
 ) {
+  if (args.webpackConfig) {
+    console.warn(
+      'Warning: `--webpackConfig` option is deprecated and will be removed in the next major version. ' +
+        'Please use `--config` instead.'
+    );
+    args.config = args.webpackConfig;
+  }
+
   const webpackConfigPath = getWebpackConfigFilePath(
     cliConfig.root,
-    args.config ?? args.webpackConfig
+    args.config
   );
 
   const cliOptions: BundleCliOptions = {

--- a/packages/repack/src/commands/webpack/start.ts
+++ b/packages/repack/src/commands/webpack/start.ts
@@ -37,10 +37,15 @@ import type { HMRMessageBody } from './types.js';
  * @category CLI command
  */
 export async function start(_: string[], config: Config, args: StartArguments) {
-  const webpackConfigPath = getWebpackConfigFilePath(
-    config.root,
-    args.config ?? args.webpackConfig
-  );
+  if (args.webpackConfig) {
+    console.warn(
+      'Warning: `--webpackConfig` option is deprecated and will be removed in the next major version. ' +
+        'Please use `--config` instead.'
+    );
+    args.config = args.webpackConfig;
+  }
+
+  const webpackConfigPath = getWebpackConfigFilePath(config.root, args.config);
   const { reversePort, ...restArgs } = args;
 
   const serverProtocol = args.https ? 'https' : 'http';

--- a/website/src/5.x/api/cli/start.mdx
+++ b/website/src/5.x/api/cli/start.mdx
@@ -110,8 +110,9 @@ Path to a bundler config file, e.g webpack.config.js.
 ### `--webpackConfig`
 
 - Type: `path`
+- Deprecated: Use [`--config`](#--config) instead
 
-Alias for [`--config`](#--config) option.
+Path to a bundler config file, e.g webpack.config.js.
 
 ### `-h`, `--help`
 


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

Sync `start`'s `--webpackConfig` option with `bundle`'s to be also deprecated, also adds a warning when using and fallbacks to `--config`.