### PR TITLE
[BREAKING] feat: remove `entryName` option from plugins

### DIFF
--- a/.changeset/yellow-frogs-melt.md
+++ b/.changeset/yellow-frogs-melt.md
@@ -1,0 +1,5 @@
+---
+"@callstack/repack": major
+---
+
+BREAKING CHANGES: Removed `entryName` config option from `DevelopmentPlugin`, `OutputPlugin` and `RepackPlugin` - it is now obtained automatically from configuration

--- a/packages/repack/src/plugins/DevelopmentPlugin.ts
+++ b/packages/repack/src/plugins/DevelopmentPlugin.ts
@@ -12,7 +12,6 @@ type PackageJSON = { version: string };
  * {@link DevelopmentPlugin} configuration options.
  */
 export interface DevelopmentPluginConfig {
-  entryName?: string;
   platform: string;
   devServer?: DevServerOptions;
 }
@@ -143,7 +142,7 @@ export class DevelopmentPlugin implements RspackPluginInstance {
           }
         );
       } else {
-        if (!this.config.entryName) {
+        if (!('main' in compiler.options.entry)) {
           // Add dev entries as global entries
           for (const entry of devEntries) {
             new compiler.webpack.EntryPlugin(compiler.context, entry, {
@@ -158,25 +157,21 @@ export class DevelopmentPlugin implements RspackPluginInstance {
             );
           }
 
-          const entries =
-            compiler.options.entry[this.config.entryName].import ?? [];
+          const entries = compiler.options.entry.main.import ?? [];
           const scriptManagerEntryIndex = entries.findIndex((entry) =>
             entry.includes('InitializeScriptManager')
           );
 
           if (scriptManagerEntryIndex !== -1) {
             // Insert devEntries after 'InitializeScriptManager'
-            compiler.options.entry[this.config.entryName].import = [
+            compiler.options.entry.main.import = [
               ...entries.slice(0, scriptManagerEntryIndex + 1),
               ...devEntries,
               ...entries.slice(scriptManagerEntryIndex + 1),
             ];
           } else {
             // 'InitializeScriptManager' entry not found, insert devEntries before the normal entries
-            compiler.options.entry[this.config.entryName].import = [
-              ...devEntries,
-              ...entries,
-            ];
+            compiler.options.entry.main.import = [...devEntries, ...entries];
           }
         }
       }

--- a/packages/repack/src/plugins/NativeEntryPlugin.ts
+++ b/packages/repack/src/plugins/NativeEntryPlugin.ts
@@ -9,10 +9,6 @@ import { isRspackCompiler } from './utils/isRspackCompiler.js';
 
 export interface NativeEntryPluginConfig {
   /**
-   * Name of the chunk that is the first to load on the device.
-   */
-  entryName: string;
-  /**
    * Absolute location to JS file with initialization logic for React Native.
    * Useful if you want to built for out-of-tree platforms.
    */
@@ -40,6 +36,10 @@ export class NativeEntryPlugin implements RspackPluginInstance {
   }
 
   apply(compiler: Compiler) {
+    if ('main' in compiler.options.entry) {
+      return;
+    }
+
     const reactNativePath = this.getReactNativePath(
       compiler.options.resolve.alias?.['react-native']
     );
@@ -89,14 +89,16 @@ export class NativeEntryPlugin implements RspackPluginInstance {
       );
     } else {
       const prependEntries = (entryConfig: EntryStaticNormalized) => {
-        if (!(this.config.entryName in entryConfig)) {
+        // temporary placeholder for entry name
+        // removed in PR that removes workaround for reordering entries
+        if (!('main' in entryConfig)) {
           throw new Error(
-            `Entry '${this.config.entryName}' does not exist in the entry configuration`
+            `Entry 'main' does not exist in the entry configuration`
           );
         }
-        entryConfig[this.config.entryName].import = [
+        entryConfig.main.import = [
           ...entries,
-          ...(entryConfig[this.config.entryName].import ?? []),
+          ...(entryConfig.main.import ?? []),
         ];
         return entryConfig;
       };

--- a/packages/repack/src/plugins/OutputPlugin/config.ts
+++ b/packages/repack/src/plugins/OutputPlugin/config.ts
@@ -22,7 +22,6 @@ const configSchema: Schema = {
     context: { type: 'string' },
     platform: { type: 'string' },
     enabled: { type: 'boolean' },
-    entryName: { type: 'string' },
     output: {
       type: 'object',
       properties: {

--- a/packages/repack/src/plugins/OutputPlugin/types.ts
+++ b/packages/repack/src/plugins/OutputPlugin/types.ts
@@ -70,9 +70,6 @@ export interface OutputPluginConfig {
    */
   enabled?: boolean;
 
-  /** The entry chunk name, `main` by default. */
-  entryName?: string;
-
   /**
    * Output options specifying where to save generated bundle, source map and assets.
    */


### PR DESCRIPTION
### Summary

#### Breaking changes:
- [x] - Remove `entryName` config option from `DevelopmentPlugin` - it is now obtained automatically from configuration
- [x] - Remove `entryName` config option from `OutputPlugin` - it is now obtained automatically from configuration
- [x] - Remove `entryName` config option from `RepackPlugin`

#### Other changes:
- [x] - Remove `entryName` config option from `NativeEntryPlugin` - it is now obtained automatically from configuration

### Test plan

- [x] - tests pass
- [x] - testers work

