### PR TITLE
feat: use own ReactRefreshLoader in all environments

### DIFF
--- a/.changeset/pink-years-remain.md
+++ b/.changeset/pink-years-remain.md
@@ -1,0 +1,5 @@
+---
+"@callstack/repack": minor
+---
+
+Use own custom ReactRefreshLoader in all configurations (Rspack & webpack)

--- a/packages/repack/package.json
+++ b/packages/repack/package.json
@@ -11,6 +11,7 @@
     "./commands/*": "./commands/*.js",
     "./assets-loader": "./dist/loaders/assetsLoader/index.js",
     "./flow-loader": "./dist/loaders/flowLoader/index.js",
+    "./react-refresh-loader": "./dist/loaders/reactRefreshLoader/index.js",
     "./mf/*": "./mf/*.js",
     "./package.json": "./package.json"
   },

--- a/packages/repack/src/loaders/reactRefreshLoader/reactRefreshLoader.ts
+++ b/packages/repack/src/loaders/reactRefreshLoader/reactRefreshLoader.ts
@@ -10,17 +10,21 @@ const reactRefreshFooter = dedent(`
     $ReactRefreshRuntime$.register(type, __webpack_module__.id + "_" + id);
   }
 
-  Promise.resolve().then(function() {
-    $ReactRefreshRuntime$.refresh(__webpack_module__.id, __webpack_module__.hot);
-  });
+  if (typeof setImmediate !== "undefined") {
+    Promise.resolve().then(function() {
+      $ReactRefreshRuntime$.refresh(__webpack_module__.id, __webpack_module__.hot);
+    });
+  }
 `);
 
 export const raw = false;
 
 /**
- * This loader is used in Webpack configuration as a fallback loader for 'builtin:react-refresh-loader' from Rspack.
- * Thanks to this loader, which mimics the one written in Rust, we can utilize "@rspack/plugin-react-refresh" in Webpack as well,
- * instead of relying on "@pmmmwh/react-refresh-webpack-plugin".
+ * This loader adds React Refresh signatures to the source files, which enables Hot Module Replacement (HMR)
+ * for React components. It appends necessary runtime code to register and refresh React components.
+ *
+ * Works the same as 'builtin:react-refresh-loader' from '@rspack/plugin-react-refresh'
+ * but accounts for React Native runtime specifics.
  *
  * Reference implementation: https://github.com/web-infra-dev/rspack/blob/main/crates/rspack_loader_react_refresh/src/lib.rs
  */

--- a/packages/repack/src/plugins/DevelopmentPlugin.ts
+++ b/packages/repack/src/plugins/DevelopmentPlugin.ts
@@ -179,16 +179,6 @@ export class DevelopmentPlugin implements RspackPluginInstance {
         }
       );
 
-      // React Refresh requires setImmediate to be defined
-      // but in React Native it happens during InitializeCore so we need
-      // to shim it here to prevent ReferenceError
-      // TODO (jbroma): add this check to reactRefreshLoader
-      new compiler.webpack.EntryPlugin(
-        compiler.context,
-        'data:text/javascript,globalThis.setImmediate = globalThis.setImmediate || function(){ /* noop */ };',
-        { name: undefined }
-      ).apply(compiler);
-
       if (!isRspackCompiler(compiler)) {
         // In Webpack, Module Federation Container entry gets injected during the compilation's make phase,
         // similar to how dynamic entries work. This means the federation entry is added after our development entries.

--- a/packages/repack/src/plugins/DevelopmentPlugin.ts
+++ b/packages/repack/src/plugins/DevelopmentPlugin.ts
@@ -107,17 +107,6 @@ export class DevelopmentPlugin implements RspackPluginInstance {
       // setup HMR
       new compiler.webpack.HotModuleReplacementPlugin().apply(compiler);
 
-      // add react-refresh-loader fallback for compatibility with Webpack
-      compiler.options.resolveLoader = {
-        ...compiler.options.resolveLoader,
-        fallback: {
-          ...compiler.options.resolveLoader?.fallback,
-          'builtin:react-refresh-loader': require.resolve(
-            '../loaders/reactRefreshLoader'
-          ),
-        },
-      };
-
       // setup HMR source maps
       new compiler.webpack.SourceMapDevToolPlugin({
         test: /\.hot-update\.js$/,
@@ -161,7 +150,7 @@ export class DevelopmentPlugin implements RspackPluginInstance {
       compiler.options.module.rules.unshift({
         include: /\.([cm]js|[jt]sx?|flow)$/i,
         exclude: /node_modules/i,
-        use: 'builtin:react-refresh-loader',
+        use: '@callstack/repack/react-refresh-loader',
       });
 
       const devEntries = [

--- a/website/src/5.x/api/loaders/react-refresh-loader.md
+++ b/website/src/5.x/api/loaders/react-refresh-loader.md
@@ -1,16 +1,24 @@
 # ReactRefreshLoader
 
-The `ReactRefreshLoader` is a fallback loader for Webpack that provides React Refresh functionality, mimicking the behavior of Rspack's built-in `builtin:react-refresh-loader`.
+The `ReactRefreshLoader` enables [React Fast Refresh](https://reactnative.dev/docs/fast-refresh) for React components in React Native applications.
+
+:::info
+This loader is automatically added to your configuration when Hot Module Replacement (HMR) is enabled. By default, it's configured to process all JavaScript and TypeScript files outside of the `node_modules` directory. You don't need to add it manually to your configuration unless you need to enable React Refresh for some of the node modules.
+:::
+
+:::details
+The loader works similarly to Rspack's `builtin:react-refresh-loader` from `@rspack/plugin-react-refresh`, but is specifically tailored to account for React Native runtime specifics. It appends necessary runtime code to register and refresh React components, ensuring proper HMR functionality in a React Native environment.
+:::
 
 ## Example
 
-```js title=webpack.config.cjs
+```js title=rspack.config.cjs
 module.exports = {
   module: {
     rules: [
       {
-        test: /\.[jt]sx?$/,
-        exclude: /node_modules/,
+        test: /\.jsx?$/,
+        include: [/node_modules\/react-native/]
         use: {
           loader: "@callstack/repack/react-refresh-loader",
         },


### PR DESCRIPTION
### Summary

This PR standardises the React Refresh loader implementation by using our custom loader in both Webpack and Rspack configurations, improving compatibility and reliability of Hot Module Replacement (HMR).

- [x] - Added new export path for React Refresh loader in package.json
- [x] - Added setImmediate availability check in React Refresh runtime code
- [x] - Removed Webpack-specific fallback loader configuration
- [x] - Updated documentation to reflect the unified loader approach
- [x] - Removed now redundant `setImmediate` shim injection

### Test plan

- [x] - testers work
