### PR TITLE
refactor: normalise plugin names and error formatting

### DIFF
--- a/.changeset/strange-beans-glow.md
+++ b/.changeset/strange-beans-glow.md
@@ -1,0 +1,5 @@
+---
+"@callstack/repack": patch
+---
+
+Add consitent plugin naming and error message formatting

--- a/packages/repack/src/plugins/ChunksToHermesBytecodePlugin/ChunksToHermesBytecodePlugin.ts
+++ b/packages/repack/src/plugins/ChunksToHermesBytecodePlugin/ChunksToHermesBytecodePlugin.ts
@@ -70,12 +70,12 @@ interface ChunksToHermesBytecodePluginConfig {
  * @category Webpack Plugin
  */
 export class ChunksToHermesBytecodePlugin implements RspackPluginInstance {
-  private readonly name = 'RepackChunksToHermesBytecodePlugin';
-
   constructor(private config: ChunksToHermesBytecodePluginConfig) {}
 
   apply(compiler: Compiler) {
-    const logger = compiler.getInfrastructureLogger(this.name);
+    const logger = compiler.getInfrastructureLogger(
+      'RepackChunksToHermesBytecodePlugin'
+    );
 
     if (!this.config.enabled) {
       logger.debug('Skipping hermes compilation');
@@ -101,7 +101,7 @@ export class ChunksToHermesBytecodePlugin implements RspackPluginInstance {
       this.config.hermesCLIPath || getHermesCLIPath(reactNativePath);
 
     compiler.hooks.assetEmitted.tapPromise(
-      { name: this.name, stage: 10 },
+      { name: 'RepackChunksToHermesBytecodePlugin', stage: 10 },
       async (file, { outputPath }) => {
         const shouldTransformAsset =
           compiler.webpack.ModuleFilenameHelpers.matchObject(

--- a/packages/repack/src/plugins/ChunksToHermesBytecodePlugin/ChunksToHermesBytecodePlugin.ts
+++ b/packages/repack/src/plugins/ChunksToHermesBytecodePlugin/ChunksToHermesBytecodePlugin.ts
@@ -70,7 +70,7 @@ interface ChunksToHermesBytecodePluginConfig {
  * @category Webpack Plugin
  */
 export class ChunksToHermesBytecodePlugin implements RspackPluginInstance {
-  private readonly name = 'ChunksToHermesBytecodePlugin';
+  private readonly name = 'RepackChunksToHermesBytecodePlugin';
 
   constructor(private config: ChunksToHermesBytecodePluginConfig) {}
 

--- a/packages/repack/src/plugins/ChunksToHermesBytecodePlugin/utils/composeSourceMaps.ts
+++ b/packages/repack/src/plugins/ChunksToHermesBytecodePlugin/utils/composeSourceMaps.ts
@@ -46,7 +46,7 @@ export const composeSourceMaps = async ({
   } catch (error) {
     const message = (error as Error).toString();
     throw new Error(
-      `ChunksToHermesBytecodePlugin: Failed to compose source maps. Reason:\n${message})`
+      `[RepackChunksToHermesBytecodePlugin] Failed to compose source maps. Reason:\n${message})`
     );
   }
 };

--- a/packages/repack/src/plugins/ChunksToHermesBytecodePlugin/utils/getHermesCLIPath.ts
+++ b/packages/repack/src/plugins/ChunksToHermesBytecodePlugin/utils/getHermesCLIPath.ts
@@ -27,7 +27,8 @@ export const getHermesCLIPath = (reactNativePath: string): string => {
 
   if (!osBin) {
     throw new Error(
-      'ChunksToHermesBytecodePlugin: OS not recognized. Please set hermesCLIPath to the path of a working Hermes compiler.'
+      '[RepackChunksToHermesBytecodePlugin] OS not recognized. ' +
+        'Please set hermesCLIPath to the path of a working Hermes compiler.'
     );
   }
 

--- a/packages/repack/src/plugins/ChunksToHermesBytecodePlugin/utils/transformBundleToHermesBytecode.ts
+++ b/packages/repack/src/plugins/ChunksToHermesBytecodePlugin/utils/transformBundleToHermesBytecode.ts
@@ -49,7 +49,7 @@ export const transformBundleToHermesBytecode = async ({
   } catch (error) {
     const message = (error as Error).toString();
     throw new Error(
-      `ChunksToHermesBytecodePlugin: Failed to transform bundle ${bundlePath}. Reason:\n${message})`
+      `[RepackChunksToHermesBytecodePlugin] Failed to transform bundle ${bundlePath}. Reason:\n${message})`
     );
   }
 };

--- a/packages/repack/src/plugins/CodeSigningPlugin/CodeSigningPlugin.ts
+++ b/packages/repack/src/plugins/CodeSigningPlugin/CodeSigningPlugin.ts
@@ -44,8 +44,7 @@ export class CodeSigningPlugin implements RspackPluginInstance {
    * @param compiler Webpack compiler instance.
    */
   apply(compiler: Compiler) {
-    const pluginName = CodeSigningPlugin.name;
-    const logger = compiler.getInfrastructureLogger(pluginName);
+    const logger = compiler.getInfrastructureLogger('RepackCodeSigningPlugin');
 
     if (this.config.enabled === false) {
       return;
@@ -53,7 +52,7 @@ export class CodeSigningPlugin implements RspackPluginInstance {
 
     if (typeof compiler.options.output.filename === 'function') {
       throw new Error(
-        'CodeSigningPlugin does not support dynamic output filename. Please use static filename instead.'
+        '[RepackCodeSigningPlugin] Dynamic output filename is not supported. Please use static filename instead.'
       );
     }
     /**
@@ -76,14 +75,14 @@ export class CodeSigningPlugin implements RspackPluginInstance {
       ? this.config.excludeChunks
       : [this.config.excludeChunks as RegExp];
 
-    compiler.hooks.emit.tap(pluginName, (compilation) => {
+    compiler.hooks.emit.tap('RepackCodeSigningPlugin', (compilation) => {
       compilation.chunks.forEach((chunk) => {
         chunk.files.forEach((file) => this.chunkFilenames.add(file));
       });
     });
 
     compiler.hooks.assetEmitted.tapPromise(
-      { name: pluginName, stage: 20 },
+      { name: 'RepackCodeSigningPlugin', stage: 20 },
       async (file, { outputPath, content, compilation }) => {
         const mainBundleName = compilation.outputOptions.filename as string;
         if (!this.shouldSignFile(file, mainBundleName, excludedChunks)) {

--- a/packages/repack/src/plugins/CodegenPlugin.ts
+++ b/packages/repack/src/plugins/CodegenPlugin.ts
@@ -64,7 +64,7 @@ export class CodegenPlugin implements RspackPluginInstance {
       });
     } catch {
       throw new Error(
-        "CodegenPlugin requires '@react-native/babel-preset' to be present in your project. " +
+        "[RepackCodegenPlugin] Codegen requires '@react-native/babel-preset' to be present in your project. " +
           'Did you forget to install it?'
       );
     }
@@ -77,7 +77,7 @@ export class CodegenPlugin implements RspackPluginInstance {
       });
     } catch {
       throw new Error(
-        "CodegenPlugin requires 'babel-plugin-syntax-hermes-parser' to be present in your project. " +
+        "[RepackCodegenPlugin] Codegen requires 'babel-plugin-syntax-hermes-parser' to be present in your project. " +
           'Did you forget to install it?'
       );
     }

--- a/packages/repack/src/plugins/DevelopmentPlugin.ts
+++ b/packages/repack/src/plugins/DevelopmentPlugin.ts
@@ -160,7 +160,7 @@ export class DevelopmentPlugin implements RspackPluginInstance {
       ];
 
       compiler.hooks.entryOption.tap(
-        { name: 'DevelopmentPlugin' },
+        { name: 'RepackDevelopmentPlugin' },
         (_, entryNormalized) => {
           // combine entries for all declared and MF entrypoints
           const entrypoints = [
@@ -184,7 +184,7 @@ export class DevelopmentPlugin implements RspackPluginInstance {
         // similar to how dynamic entries work. This means the federation entry is added after our development entries.
         // We need to reorder dependencies to ensure federation entry is placed before development entries.
         compiler.hooks.make.tap(
-          { name: 'DevelopmentPlugin', stage: 1000 },
+          { name: 'RepackDevelopmentPlugin', stage: 1000 },
           (compilation) => {
             for (const entry of compilation.entries.values()) {
               moveElementBefore(entry.dependencies, {

--- a/packages/repack/src/plugins/LoggerPlugin.ts
+++ b/packages/repack/src/plugins/LoggerPlugin.ts
@@ -139,7 +139,7 @@ export class LoggerPlugin implements RspackPluginInstance {
     }
 
     compiler.hooks.infrastructureLog.tap(
-      'LoggerPlugin',
+      'RepackLoggerPlugin',
       (issuer, type, args) => {
         const entry = this.createEntry(issuer, type, args);
         if (entry) {
@@ -149,7 +149,7 @@ export class LoggerPlugin implements RspackPluginInstance {
       }
     );
 
-    compiler.hooks.thisCompilation.tap('LoggerPlugin', (compilation) => {
+    compiler.hooks.thisCompilation.tap('RepackLoggerPlugin', (compilation) => {
       compilation.hooks.log.intercept({
         call: (issuer, { time, type, args }) => {
           const entry = this.createEntry(issuer, type, args, time);
@@ -160,7 +160,7 @@ export class LoggerPlugin implements RspackPluginInstance {
       });
     });
 
-    compiler.hooks.done.tap('LoggerPlugin', (stats) => {
+    compiler.hooks.done.tap('RepackLoggerPlugin', (stats) => {
       if (this.config.devServerEnabled) {
         const { time, errors, warnings } = stats.toJson({
           all: false,

--- a/packages/repack/src/plugins/ManifestPlugin.ts
+++ b/packages/repack/src/plugins/ManifestPlugin.ts
@@ -10,8 +10,8 @@ export class ManifestPlugin implements RspackPluginInstance {
    * @param compiler Webpack compiler instance.
    */
   apply(compiler: Compiler) {
-    compiler.hooks.compilation.tap('ManifestPlugin', (compilation) => {
-      compilation.hooks.afterProcessAssets.tap('ManifestPlugin', () => {
+    compiler.hooks.compilation.tap('RepackManifestPlugin', (compilation) => {
+      compilation.hooks.afterProcessAssets.tap('RepackManifestPlugin', () => {
         for (const chunk of compilation.chunks) {
           const manifest = {
             id: chunk.id,

--- a/packages/repack/src/plugins/ModuleFederationPlugin.ts
+++ b/packages/repack/src/plugins/ModuleFederationPlugin.ts
@@ -98,9 +98,11 @@ export class ModuleFederationPlugin implements RspackPluginInstance {
   }
 
   apply(compiler: Compiler) {
-    const logger = compiler.getInfrastructureLogger('ModuleFederationPlugin');
+    const logger = compiler.getInfrastructureLogger(
+      'RepackModuleFederationPlugin'
+    );
 
-    compiler.hooks.beforeCompile.tap('ModuleFederationPlugin', () => {
+    compiler.hooks.beforeCompile.tap('RepackModuleFederationPlugin', () => {
       logger.warn(
         'Notice: ModuleFederationPlugin currently points to ModuleFederationPluginV1. ' +
           'Re.Pack 5 introduced ModuleFederationPluginV2, which addresses many previous limitations. ' +

--- a/packages/repack/src/plugins/ModuleFederationPluginV2.ts
+++ b/packages/repack/src/plugins/ModuleFederationPluginV2.ts
@@ -116,7 +116,7 @@ export class ModuleFederationPluginV2 implements RspackPluginInstance {
     if (!name) return;
     if (!isIdentifier(name)) {
       const error = new Error(
-        `[ModuleFederationPlugin] The container's name: '${name}' must be a valid JavaScript identifier. ` +
+        `[RepackModuleFederationPlugin] The container's name: '${name}' must be a valid JavaScript identifier. ` +
           'Please correct it to proceed. For more information, see: https://developer.mozilla.org/en-US/docs/Glossary/Identifier'
       );
       // remove the stack trace to make the error more readable
@@ -130,7 +130,7 @@ export class ModuleFederationPluginV2 implements RspackPluginInstance {
       require.resolve('@module-federation/enhanced', { paths: [context] });
     } catch {
       throw new Error(
-        "[ModuleFederationPlugin] Dependency '@module-federation/enhanced' is required, but not found in your project. " +
+        "[RepackModuleFederationPlugin] Dependency '@module-federation/enhanced' is required, but not found in your project. " +
           'Did you forget to install it?'
       );
     }

--- a/packages/repack/src/plugins/NativeEntryPlugin.ts
+++ b/packages/repack/src/plugins/NativeEntryPlugin.ts
@@ -60,7 +60,7 @@ export class NativeEntryPlugin implements RspackPluginInstance {
     ];
 
     compiler.hooks.entryOption.tap(
-      { name: 'NativeEntryPlugin', before: 'DevelopmentPlugin' },
+      { name: 'RepackNativeEntryPlugin', before: 'RepackDevelopmentPlugin' },
       (_, entry) => {
         if (typeof entry === 'function') {
           throw new Error(
@@ -87,7 +87,7 @@ export class NativeEntryPlugin implements RspackPluginInstance {
       // similar to how dynamic entries work. This means the federation entry is added after our native entries.
       // We need to reorder dependencies to ensure federation entry is placed before native entries.
       compiler.hooks.make.tap(
-        { name: 'NativeEntryPlugin', stage: 1000 },
+        { name: 'RepackNativeEntryPlugin', stage: 1000 },
         (compilation) => {
           for (const entry of compilation.entries.values()) {
             moveElementBefore(entry.dependencies, {

--- a/packages/repack/src/plugins/__tests__/ModuleFederationPluginV2.test.ts
+++ b/packages/repack/src/plugins/__tests__/ModuleFederationPluginV2.test.ts
@@ -257,7 +257,7 @@ describe('ModuleFederationPlugin', () => {
       expect(() => {
         new ModuleFederationPluginV2({ name }).apply(mockCompiler);
       }).toThrow(
-        `[ModuleFederationPlugin] The container's name: '${name}' must be a valid JavaScript identifier. ` +
+        `[RepackModuleFederationPlugin] The container's name: '${name}' must be a valid JavaScript identifier. ` +
           'Please correct it to proceed.'
       );
     });


### PR DESCRIPTION
### Summary

- [x] - every plugin registers with Rspack/webpack API using `Repack<plugin>` convention
- [x] - every plugin reports errors with the plugi name in front in brackets 

### Test plan

n/a
