### PR TITLE
[BREAKING] feat: internal `SourceMapPlugin`

### DIFF
--- a/.changeset/afraid-lies-explain.md
+++ b/.changeset/afraid-lies-explain.md
@@ -1,0 +1,7 @@
+---
+"@callstack/repack": major
+---
+
+BREAKING: `config.devtool` is now used to control the behaviour of generated sourcemaps. To enable sourcemaps again, please remove `devtool: false` from your config or set it explicitly to one of valid values (e.g. `source-map`).
+
+Introduced a dedicated `SourceMapPlugin` that consolidates sourcemap configuration and improves sourcemap handling by relying on the `devtool` option. The plugin is part of the Repack plugin and does not need to be added separately.

--- a/apps/tester-app/rspack.config.mjs
+++ b/apps/tester-app/rspack.config.mjs
@@ -28,7 +28,6 @@ export default (env) => {
   return {
     mode,
     context,
-    devtool: 'source-map',
     entry: './index.js',
     resolve: {
       ...Repack.getResolveOptions(platform),

--- a/apps/tester-app/rspack.config.mjs
+++ b/apps/tester-app/rspack.config.mjs
@@ -27,8 +27,8 @@ export default (env) => {
 
   return {
     mode,
-    devtool: false,
     context,
+    devtool: 'source-map',
     entry: './index.js',
     resolve: {
       ...Repack.getResolveOptions(platform),

--- a/apps/tester-app/webpack.config.mjs
+++ b/apps/tester-app/webpack.config.mjs
@@ -27,7 +27,6 @@ export default (env) => {
 
   return {
     mode,
-    devtool: false,
     context,
     cache: process.env.USE_CACHE
       ? {

--- a/apps/tester-federation-v2/configs/rspack.host-app.mjs
+++ b/apps/tester-federation-v2/configs/rspack.host-app.mjs
@@ -23,7 +23,6 @@ export default (env) => {
 
   return {
     mode,
-    devtool: false,
     context,
     entry: './src/host/index.js',
     resolve: {

--- a/apps/tester-federation-v2/configs/rspack.mini-app.mjs
+++ b/apps/tester-federation-v2/configs/rspack.mini-app.mjs
@@ -20,7 +20,6 @@ export default (env) => {
 
   return {
     mode,
-    devtool: false,
     context,
     entry: './src/mini/index.js',
     resolve: {

--- a/apps/tester-federation-v2/configs/webpack.host-app.mjs
+++ b/apps/tester-federation-v2/configs/webpack.host-app.mjs
@@ -25,7 +25,6 @@ export default (env) => {
 
   return {
     mode,
-    devtool: false,
     context,
     entry: './src/host/index.js',
     resolve: {

--- a/apps/tester-federation-v2/configs/webpack.mini-app.mjs
+++ b/apps/tester-federation-v2/configs/webpack.mini-app.mjs
@@ -22,7 +22,6 @@ export default (env) => {
 
   return {
     mode,
-    devtool: false,
     context,
     entry: './src/mini/index.js',
     resolve: {

--- a/apps/tester-federation/configs/rspack.host-app.mjs
+++ b/apps/tester-federation/configs/rspack.host-app.mjs
@@ -25,7 +25,6 @@ export default (env) => {
   /** @type {import('@rspack/core').Configuration} */
   const config = {
     mode,
-    devtool: false,
     context,
     entry: './src/host/index.js',
     resolve: {

--- a/apps/tester-federation/configs/rspack.mini-app.mjs
+++ b/apps/tester-federation/configs/rspack.mini-app.mjs
@@ -22,7 +22,6 @@ export default (env) => {
   /** @type {import('@rspack/core').Configuration} */
   const config = {
     mode,
-    devtool: false,
     context,
     entry: './src/mini/index.js',
     resolve: {

--- a/apps/tester-federation/configs/webpack.host-app.mjs
+++ b/apps/tester-federation/configs/webpack.host-app.mjs
@@ -25,7 +25,6 @@ export default (env) => {
 
   return {
     mode,
-    devtool: false,
     context,
     entry: './src/host/index.js',
     resolve: {

--- a/apps/tester-federation/configs/webpack.mini-app.mjs
+++ b/apps/tester-federation/configs/webpack.mini-app.mjs
@@ -22,7 +22,6 @@ export default (env) => {
 
   return {
     mode,
-    devtool: false,
     context,
     entry: './src/mini/index.js',
     resolve: {

--- a/packages/repack/src/commands/common/config/getRepackConfig.ts
+++ b/packages/repack/src/commands/common/config/getRepackConfig.ts
@@ -1,5 +1,6 @@
 export function getRepackConfig() {
   return {
+    devtool: 'source-map',
     output: {
       publicPath: 'noop:///',
     },

--- a/packages/repack/src/plugins/DevelopmentPlugin.ts
+++ b/packages/repack/src/plugins/DevelopmentPlugin.ts
@@ -127,19 +127,6 @@ export class DevelopmentPlugin implements RspackPluginInstance {
       // setup HMR
       new compiler.webpack.HotModuleReplacementPlugin().apply(compiler);
 
-      // setup HMR source maps
-      new compiler.webpack.SourceMapDevToolPlugin({
-        test: /\.hot-update\.js$/,
-        filename: '[file].map',
-        append: `//# sourceMappingURL=[url]?platform=${this.config.platform}`,
-        module: true,
-        columns: true,
-        noSources: false,
-        namespace:
-          compiler.options.output.devtoolNamespace ??
-          compiler.options.output.uniqueName,
-      }).apply(compiler);
-
       // setup React Refresh manually instead of using the official plugin
       // to avoid issues with placement of reactRefreshEntry
       new compiler.webpack.ProvidePlugin({

--- a/packages/repack/src/plugins/RepackPlugin.ts
+++ b/packages/repack/src/plugins/RepackPlugin.ts
@@ -6,6 +6,7 @@ import { LoggerPlugin, type LoggerPluginConfig } from './LoggerPlugin.js';
 import { NativeEntryPlugin } from './NativeEntryPlugin.js';
 import { OutputPlugin, type OutputPluginConfig } from './OutputPlugin/index.js';
 import { RepackTargetPlugin } from './RepackTargetPlugin/index.js';
+import { SourceMapPlugin } from './SourceMapPlugin.js';
 
 /**
  * {@link RepackPlugin} configuration options.
@@ -144,23 +145,7 @@ export class RepackPlugin implements RspackPluginInstance {
       platform: this.config.platform,
     }).apply(compiler);
 
-    if (this.config.sourceMaps) {
-      // TODO Fix sourcemap directory structure
-      // Right now its very messy and not every node module is inside of the node module
-      // like React Devtools backend etc or some symilinked module appear with relative path
-      // We should normalize this through a custom handler and provide an output similar to Metro
-      new compiler.webpack.SourceMapDevToolPlugin({
-        test: /\.(js)?bundle$/,
-        filename: '[file].map',
-        append: `//# sourceMappingURL=[url]?platform=${this.config.platform}`,
-        module: true,
-        columns: true,
-        noSources: false,
-        namespace:
-          compiler.options.output.devtoolNamespace ??
-          compiler.options.output.uniqueName,
-      }).apply(compiler);
-    }
+    new SourceMapPlugin().apply(compiler);
 
     if (this.config.logger) {
       new LoggerPlugin({

--- a/packages/repack/src/plugins/RepackPlugin.ts
+++ b/packages/repack/src/plugins/RepackPlugin.ts
@@ -145,7 +145,7 @@ export class RepackPlugin implements RspackPluginInstance {
       platform: this.config.platform,
     }).apply(compiler);
 
-    new SourceMapPlugin().apply(compiler);
+    new SourceMapPlugin({ platform: this.config.platform }).apply(compiler);
 
     if (this.config.logger) {
       new LoggerPlugin({

--- a/packages/repack/src/plugins/RepackPlugin.ts
+++ b/packages/repack/src/plugins/RepackPlugin.ts
@@ -22,13 +22,6 @@ export interface RepackPluginConfig {
   platform: string;
 
   /**
-   * Whether source maps should be generated. Defaults to `true`.
-   *
-   * Setting this to `false`, disables any source map generation.
-   */
-  sourceMaps?: boolean;
-
-  /**
    * Output options specifying where to save generated bundle, source map and assets.
    *
    * Refer to {@link OutputPluginConfig.output} for more details.
@@ -109,7 +102,6 @@ export class RepackPlugin implements RspackPluginInstance {
    * @param config Plugin configuration options.
    */
   constructor(private config: RepackPluginConfig) {
-    this.config.sourceMaps = this.config.sourceMaps ?? true;
     this.config.logger = this.config.logger ?? true;
   }
 
@@ -145,7 +137,9 @@ export class RepackPlugin implements RspackPluginInstance {
       platform: this.config.platform,
     }).apply(compiler);
 
-    new SourceMapPlugin({ platform: this.config.platform }).apply(compiler);
+    new SourceMapPlugin({
+      platform: this.config.platform,
+    }).apply(compiler);
 
     if (this.config.logger) {
       new LoggerPlugin({

--- a/packages/repack/src/plugins/RepackPlugin.ts
+++ b/packages/repack/src/plugins/RepackPlugin.ts
@@ -22,6 +22,13 @@ export interface RepackPluginConfig {
   platform: string;
 
   /**
+   * Whether source maps should be generated. Defaults to `true`.
+   *
+   * Setting this to `false`, disables any source map generation.
+   */
+  sourceMaps?: boolean;
+
+  /**
    * Output options specifying where to save generated bundle, source map and assets.
    *
    * Refer to {@link OutputPluginConfig.output} for more details.
@@ -102,6 +109,7 @@ export class RepackPlugin implements RspackPluginInstance {
    * @param config Plugin configuration options.
    */
   constructor(private config: RepackPluginConfig) {
+    this.config.sourceMaps = this.config.sourceMaps ?? true;
     this.config.logger = this.config.logger ?? true;
   }
 
@@ -137,9 +145,11 @@ export class RepackPlugin implements RspackPluginInstance {
       platform: this.config.platform,
     }).apply(compiler);
 
-    new SourceMapPlugin({
-      platform: this.config.platform,
-    }).apply(compiler);
+    if (this.config.sourceMaps) {
+      new SourceMapPlugin({
+        platform: this.config.platform,
+      }).apply(compiler);
+    }
 
     if (this.config.logger) {
       new LoggerPlugin({

--- a/packages/repack/src/plugins/SourceMapPlugin.ts
+++ b/packages/repack/src/plugins/SourceMapPlugin.ts
@@ -1,0 +1,70 @@
+import type { Compiler, RspackPluginInstance } from '@rspack/core';
+
+export class SourceMapPlugin implements RspackPluginInstance {
+  apply(compiler: Compiler) {
+    if (!compiler.options.devtool) {
+      return;
+    }
+
+    const platform = compiler.name as string;
+    const format = compiler.options.devtool;
+    const devtoolModuleFilenameTemplate =
+      compiler.options.output.devtoolModuleFilenameTemplate;
+    const devtoolFallbackModuleFilenameTemplate =
+      compiler.options.output.devtoolFallbackModuleFilenameTemplate;
+
+    if (
+      format === 'eval' ||
+      format === 'eval-source-map' ||
+      format === 'eval-cheap-source-map' ||
+      format === 'eval-cheap-module-source-map' ||
+      format === 'eval-nosources-source-map' ||
+      format === 'eval-nosources-cheap-source-map' ||
+      format === 'eval-nosources-cheap-module-source-map'
+    ) {
+      throw new Error(
+        '[RepackSourceMapPlugin] Eval source maps are not supported'
+      );
+    }
+
+    if (
+      format === 'inline-cheap-source-map' ||
+      format === 'inline-cheap-module-source-map' ||
+      format === 'inline-source-map' ||
+      format === 'inline-nosources-cheap-source-map' ||
+      format === 'inline-nosources-cheap-module-source-map' ||
+      format === 'inline-nosources-source-map'
+    ) {
+      throw new Error(
+        '[RepackSourceMapPlugin] Inline source maps are not supported'
+      );
+    }
+
+    const hidden = format.includes('hidden');
+    const cheap = format.includes('cheap');
+    const moduleMaps = format.includes('module');
+    const noSources = format.includes('nosources');
+    const debugIds = format.includes('debugids');
+
+    // TODO Fix sourcemap directory structure
+    // Right now its very messy and not every node module is inside of the node module
+    // like React Devtools backend etc or some symilinked module appear with relative path
+    // We should normalize this through a custom handler and provide an output similar to Metro
+    new compiler.webpack.SourceMapDevToolPlugin({
+      filename: '[file].map',
+      moduleFilenameTemplate: devtoolModuleFilenameTemplate,
+      fallbackModuleFilenameTemplate: devtoolFallbackModuleFilenameTemplate,
+      append: hidden
+        ? false
+        : `//# sourceMappingURL=[url]?platform=${platform}`,
+      module: moduleMaps ? true : !cheap,
+      columns: !cheap,
+      noSources,
+      // TODO verify this
+      namespace:
+        compiler.options.output.devtoolNamespace ??
+        compiler.options.output.uniqueName,
+      debugIds,
+    }).apply(compiler);
+  }
+}

--- a/packages/repack/src/plugins/SourceMapPlugin.ts
+++ b/packages/repack/src/plugins/SourceMapPlugin.ts
@@ -62,7 +62,6 @@ export class SourceMapPlugin implements RspackPluginInstance {
     const cheap = format.includes('cheap');
     const moduleMaps = format.includes('module');
     const noSources = format.includes('nosources');
-    const debugIds = format.includes('debugids');
 
     // TODO Fix sourcemap directory structure
     // Right now its very messy and not every node module is inside of the node module
@@ -80,7 +79,6 @@ export class SourceMapPlugin implements RspackPluginInstance {
       columns: !cheap,
       noSources,
       namespace: devtoolNamespace,
-      debugIds,
     }).apply(compiler);
   }
 }

--- a/packages/repack/src/plugins/SourceMapPlugin.ts
+++ b/packages/repack/src/plugins/SourceMapPlugin.ts
@@ -9,6 +9,7 @@ export class SourceMapPlugin implements RspackPluginInstance {
   constructor(private config: SourceMapPluginConfig = {}) {}
 
   apply(compiler: Compiler) {
+    // if devtool is explicitly set to false, skip generating source maps
     if (!compiler.options.devtool) {
       return;
     }

--- a/packages/repack/src/plugins/SourceMapPlugin.ts
+++ b/packages/repack/src/plugins/SourceMapPlugin.ts
@@ -29,29 +29,14 @@ export class SourceMapPlugin implements RspackPluginInstance {
     const devtoolFallbackModuleFilenameTemplate =
       compiler.options.output.devtoolFallbackModuleFilenameTemplate;
 
-    if (
-      format === 'eval' ||
-      format === 'eval-source-map' ||
-      format === 'eval-cheap-source-map' ||
-      format === 'eval-cheap-module-source-map' ||
-      format === 'eval-nosources-source-map' ||
-      format === 'eval-nosources-cheap-source-map' ||
-      format === 'eval-nosources-cheap-module-source-map'
-    ) {
+    if (format.startsWith('eval')) {
       throw new ConfigurationError(
         '[RepackSourceMapPlugin] Eval source maps are not supported. ' +
           'Please use a different setting for `config.devtool`.'
       );
     }
 
-    if (
-      format === 'inline-cheap-source-map' ||
-      format === 'inline-cheap-module-source-map' ||
-      format === 'inline-source-map' ||
-      format === 'inline-nosources-cheap-source-map' ||
-      format === 'inline-nosources-cheap-module-source-map' ||
-      format === 'inline-nosources-source-map'
-    ) {
+    if (format.startsWith('inline')) {
       throw new ConfigurationError(
         '[RepackSourceMapPlugin] Inline source maps are not supported. ' +
           'Please use a different setting for `config.devtool`.'

--- a/packages/repack/src/plugins/SourceMapPlugin.ts
+++ b/packages/repack/src/plugins/SourceMapPlugin.ts
@@ -69,6 +69,7 @@ export class SourceMapPlugin implements RspackPluginInstance {
     // like React Devtools backend etc or some symilinked module appear with relative path
     // We should normalize this through a custom handler and provide an output similar to Metro
     new compiler.webpack.SourceMapDevToolPlugin({
+      test: /\.([cm]?jsx?|bundle)$/,
       filename: '[file].map',
       moduleFilenameTemplate: devtoolModuleFilenameTemplate,
       fallbackModuleFilenameTemplate: devtoolFallbackModuleFilenameTemplate,

--- a/packages/repack/src/plugins/SourceMapPlugin.ts
+++ b/packages/repack/src/plugins/SourceMapPlugin.ts
@@ -6,8 +6,11 @@ export class SourceMapPlugin implements RspackPluginInstance {
       return;
     }
 
-    const platform = compiler.name as string;
     const format = compiler.options.devtool;
+    // disable builtin sourcemap generation
+    compiler.options.devtool = false;
+
+    const platform = compiler.name as string;
     const devtoolModuleFilenameTemplate =
       compiler.options.output.devtoolModuleFilenameTemplate;
     const devtoolFallbackModuleFilenameTemplate =

--- a/packages/repack/src/plugins/utils/ConfigurationError.ts
+++ b/packages/repack/src/plugins/utils/ConfigurationError.ts
@@ -1,0 +1,13 @@
+import { VERBOSE_ENV_KEY } from '../../env.js';
+
+export class ConfigurationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'ConfigurationError';
+
+    // hide stack trace in non-verbose mode
+    if (!process.env[VERBOSE_ENV_KEY]) {
+      this.stack = undefined;
+    }
+  }
+}

--- a/templates_v5/rspack.config.cjs
+++ b/templates_v5/rspack.config.cjs
@@ -35,11 +35,6 @@ module.exports = (env) => {
 
   return {
     mode,
-    /**
-     * This should be always `false`, since the Source Map configuration is done
-     * by `SourceMapDevToolPlugin`.
-     */
-    devtool: false,
     context,
     entry,
     resolve: {

--- a/templates_v5/rspack.config.mjs
+++ b/templates_v5/rspack.config.mjs
@@ -39,11 +39,6 @@ export default (env) => {
 
   return {
     mode,
-    /**
-     * This should be always `false`, since the Source Map configuration is done
-     * by `SourceMapDevToolPlugin`.
-     */
-    devtool: false,
     context,
     entry,
     resolve: {

--- a/templates_v5/webpack.config.cjs
+++ b/templates_v5/webpack.config.cjs
@@ -46,11 +46,6 @@ module.exports = (env) => {
 
   return {
     mode,
-    /**
-     * This should be always `false`, since the Source Map configuration is done
-     * by `SourceMapDevToolPlugin`.
-     */
-    devtool: false,
     context,
     /**
      * `getInitializationEntries` will return necessary entries with setup and initialization code.

--- a/templates_v5/webpack.config.mjs
+++ b/templates_v5/webpack.config.mjs
@@ -50,11 +50,6 @@ export default (env) => {
 
   return {
     mode,
-    /**
-     * This should be always `false`, since the Source Map configuration is done
-     * by `SourceMapDevToolPlugin`.
-     */
-    devtool: false,
     context,
     entry,
     resolve: {


### PR DESCRIPTION
### Summary

- [x] - consolidated uses of `SourceMapDevToolPlugin` into a separate `SourceMapPlugin`
- [x] - sourcemaps can now be configured through `devtool` option
- [x] - unsupported sourcemap formats cause a configuration error forcing user to change the configuration
- [x] - removed `devtool: false` from all configs and templates since that will essentially disable the sourcemap
- [x] - `devtool: 'source-map'` is now the default (matches existing behaviour)
  
### Test plan

- [x] - tests pass
- [x] - testers work 
