### PR TITLE
feat: make `getResolveOptions` callable without platform

### DIFF
--- a/.changeset/old-kings-build.md
+++ b/.changeset/old-kings-build.md
@@ -1,0 +1,5 @@
+---
+"@callstack/repack": minor
+---
+
+`getResolveOptions` can be now called without any params and the `platform` extensions will be resolved automatically. This makes `getResolveOptions` useful when used in static configs where `platform` variable isn't exposed.

--- a/apps/tester-app/rspack.config.mjs
+++ b/apps/tester-app/rspack.config.mjs
@@ -1,5 +1,4 @@
 // @ts-check
-import { createRequire } from 'node:module';
 import path from 'node:path';
 import * as Repack from '@callstack/repack';
 import { NativeWindPlugin } from '@callstack/repack-plugin-nativewind';
@@ -7,7 +6,6 @@ import { ReanimatedPlugin } from '@callstack/repack-plugin-reanimated';
 import { RsdoctorRspackPlugin } from '@rsdoctor/rspack-plugin';
 
 const dirname = Repack.getDirname(import.meta.url);
-const { resolve } = createRequire(import.meta.url);
 
 /** @type {(env: import('@callstack/repack').EnvOptions) => import('@rspack/core').Configuration} */
 export default (env) => {
@@ -18,7 +16,6 @@ export default (env) => {
     bundleFilename = undefined,
     sourceMapFilename = undefined,
     assetsPath = undefined,
-    reactNativePath = resolve('react-native'),
   } = env;
   if (!platform) {
     throw new Error('Missing platform');
@@ -29,10 +26,7 @@ export default (env) => {
     context,
     entry: './index.js',
     resolve: {
-      ...Repack.getResolveOptions(platform),
-      alias: {
-        'react-native': reactNativePath,
-      },
+      ...Repack.getResolveOptions(),
     },
     output: {
       uniqueName: 'tester-app',

--- a/apps/tester-app/webpack.config.mjs
+++ b/apps/tester-app/webpack.config.mjs
@@ -1,4 +1,3 @@
-import { createRequire } from 'node:module';
 import path from 'node:path';
 import * as Repack from '@callstack/repack';
 import { NativeWindPlugin } from '@callstack/repack-plugin-nativewind';
@@ -6,7 +5,6 @@ import { ReanimatedPlugin } from '@callstack/repack-plugin-reanimated';
 import TerserPlugin from 'terser-webpack-plugin';
 
 const dirname = Repack.getDirname(import.meta.url);
-const { resolve } = createRequire(import.meta.url);
 
 export default (env) => {
   const {
@@ -17,7 +15,6 @@ export default (env) => {
     bundleFilename = undefined,
     sourceMapFilename = undefined,
     assetsPath = undefined,
-    reactNativePath = resolve('react-native'),
   } = env;
 
   if (!platform) {
@@ -35,10 +32,7 @@ export default (env) => {
       : undefined,
     entry,
     resolve: {
-      ...Repack.getResolveOptions(platform),
-      alias: {
-        'react-native': reactNativePath,
-      },
+      ...Repack.getResolveOptions(),
     },
     output: {
       uniqueName: 'tester-app',

--- a/apps/tester-federation-v2/configs/rspack.host-app.mjs
+++ b/apps/tester-federation-v2/configs/rspack.host-app.mjs
@@ -25,7 +25,7 @@ export default (env) => {
     context,
     entry: './src/host/index.js',
     resolve: {
-      ...Repack.getResolveOptions(platform),
+      ...Repack.getResolveOptions(),
     },
     output: {
       path: path.join(dirname, 'build/host-app/[platform]'),

--- a/apps/tester-federation-v2/configs/rspack.mini-app.mjs
+++ b/apps/tester-federation-v2/configs/rspack.mini-app.mjs
@@ -22,7 +22,7 @@ export default (env) => {
     context,
     entry: './src/mini/index.js',
     resolve: {
-      ...Repack.getResolveOptions(platform),
+      ...Repack.getResolveOptions(),
     },
     output: {
       path: path.join(dirname, 'build/mini-app/[platform]'),

--- a/apps/tester-federation-v2/configs/webpack.host-app.mjs
+++ b/apps/tester-federation-v2/configs/webpack.host-app.mjs
@@ -27,7 +27,7 @@ export default (env) => {
     context,
     entry: './src/host/index.js',
     resolve: {
-      ...Repack.getResolveOptions(platform),
+      ...Repack.getResolveOptions(),
     },
     output: {
       path: path.join(dirname, 'build/host-app/[platform]'),

--- a/apps/tester-federation-v2/configs/webpack.mini-app.mjs
+++ b/apps/tester-federation-v2/configs/webpack.mini-app.mjs
@@ -24,7 +24,7 @@ export default (env) => {
     context,
     entry: './src/mini/index.js',
     resolve: {
-      ...Repack.getResolveOptions(platform),
+      ...Repack.getResolveOptions(),
     },
     output: {
       path: path.join(dirname, 'build/mini-app/[platform]'),

--- a/apps/tester-federation/configs/rspack.host-app.mjs
+++ b/apps/tester-federation/configs/rspack.host-app.mjs
@@ -27,7 +27,7 @@ export default (env) => {
     context,
     entry: './src/host/index.js',
     resolve: {
-      ...Repack.getResolveOptions(platform),
+      ...Repack.getResolveOptions(),
     },
     output: {
       path: path.join(dirname, 'build/host-app/[platform]'),

--- a/apps/tester-federation/configs/rspack.mini-app.mjs
+++ b/apps/tester-federation/configs/rspack.mini-app.mjs
@@ -24,7 +24,7 @@ export default (env) => {
     context,
     entry: './src/mini/index.js',
     resolve: {
-      ...Repack.getResolveOptions(platform),
+      ...Repack.getResolveOptions(),
     },
     output: {
       path: path.join(dirname, 'build/mini-app/[platform]'),

--- a/apps/tester-federation/configs/webpack.host-app.mjs
+++ b/apps/tester-federation/configs/webpack.host-app.mjs
@@ -27,7 +27,7 @@ export default (env) => {
     context,
     entry: './src/host/index.js',
     resolve: {
-      ...Repack.getResolveOptions(platform),
+      ...Repack.getResolveOptions(),
     },
     output: {
       path: path.join(dirname, 'build/host-app/[platform]'),

--- a/apps/tester-federation/configs/webpack.mini-app.mjs
+++ b/apps/tester-federation/configs/webpack.mini-app.mjs
@@ -24,7 +24,7 @@ export default (env) => {
     context,
     entry: './src/mini/index.js',
     resolve: {
-      ...Repack.getResolveOptions(platform),
+      ...Repack.getResolveOptions(),
     },
     output: {
       path: path.join(dirname, 'build/mini-app/[platform]'),

--- a/packages/repack/src/commands/common/config/normalizeConfig.ts
+++ b/packages/repack/src/commands/common/config/normalizeConfig.ts
@@ -23,6 +23,13 @@ function normalizeOutputPath(
     .replaceAll('[platform]', platform);
 }
 
+function normalizeResolveExtensions(
+  extensions: string[],
+  platform: string
+): string[] {
+  return extensions.map((ext) => ext.replaceAll('[platform]', platform));
+}
+
 export function normalizeConfig<C extends ConfigurationObject>(
   config: C,
   platform: string
@@ -47,6 +54,14 @@ export function normalizeConfig<C extends ConfigurationObject>(
   /* unset public path if it's using the deprecated `getPublicPath` function */
   if (config.output?.publicPath === 'DEPRECATED_GET_PUBLIC_PATH') {
     config.output.publicPath = undefined;
+  }
+
+  /* normalize resolve extensions by resolving [platform] placeholder */
+  if (config.resolve?.extensions) {
+    config.resolve.extensions = normalizeResolveExtensions(
+      config.resolve.extensions,
+      config.name
+    );
   }
 
   /* return the normalized config object */

--- a/packages/repack/src/commands/types.ts
+++ b/packages/repack/src/commands/types.ts
@@ -65,7 +65,8 @@ type ConfigKeys =
   | 'devServer'
   | 'entry'
   | 'optimization'
-  | 'output';
+  | 'output'
+  | 'resolve';
 
 export type ConfigurationObject = Partial<Record<ConfigKeys, any>>;
 

--- a/packages/repack/src/utils/__tests__/getResolveOptions.test.ts
+++ b/packages/repack/src/utils/__tests__/getResolveOptions.test.ts
@@ -1,0 +1,51 @@
+import { getResolveOptions } from '../getResolveOptions.js';
+
+const resolveOptionsObject = {
+  extensions: expect.any(Array),
+  aliasFields: expect.any(Array),
+  conditionNames: expect.any(Array),
+  exportsFields: expect.any(Array),
+  importsFields: expect.any(Array),
+  extensionAlias: expect.any(Object),
+};
+
+describe('getResolveOptions', () => {
+  it('should accept both platform and options parameters', () => {
+    const result = getResolveOptions('ios', { enablePackageExports: true });
+    expect(result).toBeDefined();
+    expect(result).toMatchObject(resolveOptionsObject);
+  });
+
+  it('should accept just platform parameter', () => {
+    const result = getResolveOptions('ios');
+    expect(result).toBeDefined();
+    expect(result).toMatchObject(resolveOptionsObject);
+  });
+
+  it('should accept just options parameter', () => {
+    const result = getResolveOptions({ enablePackageExports: true });
+    expect(result).toBeDefined();
+    expect(result).toMatchObject(resolveOptionsObject);
+  });
+
+  it('should work with no parameters', () => {
+    const result = getResolveOptions();
+    expect(result).toBeDefined();
+    expect(result).toMatchObject(resolveOptionsObject);
+  });
+
+  it('should use [platform] placeholder when no platform provided', () => {
+    const result = getResolveOptions();
+    expect(result).toBeDefined();
+    expect(result.extensions).toContain('.[platform].js');
+    expect(result.extensions).not.toContain('.ios.js');
+    expect(result.extensions).not.toContain('.android.js');
+  });
+
+  it('should use actual platform value when provided', () => {
+    const result = getResolveOptions('ios');
+    expect(result).toBeDefined();
+    expect(result.extensions).toContain('.ios.js');
+    expect(result.extensions).not.toContain('.[platform].js');
+  });
+});

--- a/packages/repack/src/utils/getResolveOptions.ts
+++ b/packages/repack/src/utils/getResolveOptions.ts
@@ -1,5 +1,15 @@
 import { SCALABLE_ASSETS, SCALABLE_RESOLUTIONS } from './assetExtensions.js';
 
+interface GetResolveOptionsResult {
+  mainFields: string[];
+  aliasFields: string[];
+  conditionNames: string[];
+  exportsFields: string[];
+  extensions: string[];
+  extensionAlias: Record<string, string[]>;
+  importsFields: string[];
+}
+
 /**
  * {@link getResolveOptions} additional options.
  */
@@ -47,9 +57,28 @@ export interface ResolveOptions {
  * ```
  */
 
-export function getResolveOptions(platform: string, options?: ResolveOptions) {
-  const preferNativePlatform = options?.preferNativePlatform ?? true;
-  const enablePackageExports = options?.enablePackageExports ?? false;
+export function getResolveOptions(
+  options?: ResolveOptions
+): GetResolveOptionsResult;
+
+export function getResolveOptions(
+  platform: string,
+  options?: ResolveOptions
+): GetResolveOptionsResult;
+
+export function getResolveOptions(
+  platformOrOptions: unknown,
+  options?: ResolveOptions
+): GetResolveOptionsResult {
+  // if platform is undefined, use '[platform]' as placeholder
+  const _platform =
+    typeof platformOrOptions === 'string' ? platformOrOptions : '[platform]';
+  const _options = (
+    typeof platformOrOptions === 'object' ? platformOrOptions : options
+  ) as ResolveOptions | undefined;
+
+  const preferNativePlatform = _options?.preferNativePlatform ?? true;
+  const enablePackageExports = _options?.enablePackageExports ?? false;
 
   let extensions = ['.js', '.jsx', '.ts', '.tsx', '.json'];
 
@@ -68,7 +97,7 @@ export function getResolveOptions(platform: string, options?: ResolveOptions) {
     conditionNames = [];
     exportsFields = [];
     extensions = extensions.flatMap((ext) => {
-      const platformExt = `.${platform}${ext}`;
+      const platformExt = `.${_platform}${ext}`;
       const nativeExt = `.native${ext}`;
 
       if (preferNativePlatform) {

--- a/templates_v5/rspack.config.cjs
+++ b/templates_v5/rspack.config.cjs
@@ -37,22 +37,7 @@ module.exports = (env) => {
     context,
     entry,
     resolve: {
-      /**
-       * `getResolveOptions` returns additional resolution configuration for React Native.
-       * If it's removed, you won't be able to use `<file>.<platform>.<ext>` (eg: `file.ios.js`)
-       * convention and some 3rd-party libraries that specify `react-native` field
-       * in their `package.json` might not work correctly.
-       */
-      ...Repack.getResolveOptions(platform),
-
-      /**
-       * Uncomment this to ensure all `react-native*` imports will resolve to the same React Native
-       * dependency. You might need it when using workspaces/monorepos or unconventional project
-       * structure. For simple/typical project you won't need it.
-       */
-      // alias: {
-      //   'react-native': reactNativePath,
-      // },
+      ...Repack.getResolveOptions(),
     },
     module: {
       /**

--- a/templates_v5/rspack.config.mjs
+++ b/templates_v5/rspack.config.mjs
@@ -41,22 +41,7 @@ export default (env) => {
     context,
     entry,
     resolve: {
-      /**
-       * `getResolveOptions` returns additional resolution configuration for React Native.
-       * If it's removed, you won't be able to use `<file>.<platform>.<ext>` (eg: `file.ios.js`)
-       * convention and some 3rd-party libraries that specify `react-native` field
-       * in their `package.json` might not work correctly.
-       */
-      ...Repack.getResolveOptions(platform),
-
-      /**
-       * Uncomment this to ensure all `react-native*` imports will resolve to the same React Native
-       * dependency. You might need it when using workspaces/monorepos or unconventional project
-       * structure. For simple/typical project you won't need it.
-       */
-      // alias: {
-      //   'react-native': reactNativePath,
-      // },
+      ...Repack.getResolveOptions(),
     },
     module: {
       rules: [

--- a/templates_v5/webpack.config.cjs
+++ b/templates_v5/webpack.config.cjs
@@ -46,29 +46,9 @@ module.exports = (env) => {
   return {
     mode,
     context,
-    /**
-     * `getInitializationEntries` will return necessary entries with setup and initialization code.
-     * If you don't want to use Hot Module Replacement, set `hmr` option to `false`. By default,
-     * HMR will be enabled in development mode.
-     */
     entry,
     resolve: {
-      /**
-       * `getResolveOptions` returns additional resolution configuration for React Native.
-       * If it's removed, you won't be able to use `<file>.<platform>.<ext>` (eg: `file.ios.js`)
-       * convention and some 3rd-party libraries that specify `react-native` field
-       * in their `package.json` might not work correctly.
-       */
-      ...Repack.getResolveOptions(platform),
-
-      /**
-       * Uncomment this to ensure all `react-native*` imports will resolve to the same React Native
-       * dependency. You might need it when using workspaces/monorepos or unconventional project
-       * structure. For simple/typical project you won't need it.
-       */
-      // alias: {
-      //   'react-native': reactNativePath,
-      // },
+      ...Repack.getResolveOptions(),
     },
     optimization: {
       /** Configure minimizer to process the bundle. */

--- a/templates_v5/webpack.config.mjs
+++ b/templates_v5/webpack.config.mjs
@@ -52,22 +52,7 @@ export default (env) => {
     context,
     entry,
     resolve: {
-      /**
-       * `getResolveOptions` returns additional resolution configuration for React Native.
-       * If it's removed, you won't be able to use `<file>.<platform>.<ext>` (eg: `file.ios.js`)
-       * convention and some 3rd-party libraries that specify `react-native` field
-       * in their `package.json` might not work correctly.
-       */
-      ...Repack.getResolveOptions(platform),
-
-      /**
-       * Uncomment this to ensure all `react-native*` imports will resolve to the same React Native
-       * dependency. You might need it when using workspaces/monorepos or unconventional project
-       * structure. For simple/typical project you won't need it.
-       */
-      // alias: {
-      //   'react-native': reactNativePath,
-      // },
+      ...Repack.getResolveOptions(),
     },
     optimization: {
       /** Configure minimizer to process the bundle. */


### PR DESCRIPTION
### Summary

`getResolveOptions` can be now called without any params and the `platform` extensions will be resolved automatically. This makes `getResolveOptions` useful when used in static configs where `platform` variable isn't exposed.

- [x] - added overload to `getResolveOptions` making it possible to be called without any params
- [x] - added tests for `getResolveOptions` which test the new behaviour and ensure backwards-compatibility of changes
- [x] - removed redundant platform argument from configs and templates 

### Test plan

- [x] - tests pass
- [x] - testers work 
