### PR TITLE
feat: make `platform` optional for `assetsLoader`

### DIFF
--- a/apps/tester-app/rspack.config.mjs
+++ b/apps/tester-app/rspack.config.mjs
@@ -73,10 +73,7 @@ export default (env) => {
             path.join(context, 'src/assetsTest/inlineAssets'),
             path.join(context, 'src/assetsTest/remoteAssets'),
           ],
-          use: {
-            loader: '@callstack/repack/assets-loader',
-            options: { platform },
-          },
+          use: '@callstack/repack/assets-loader',
         },
         {
           test: /\.svg$/,
@@ -95,10 +92,7 @@ export default (env) => {
             Repack.ASSET_EXTENSIONS.filter((ext) => ext !== 'svg')
           ),
           include: [path.join(context, 'src/assetsTest/localAssets')],
-          use: {
-            loader: '@callstack/repack/assets-loader',
-            options: { platform },
-          },
+          use: '@callstack/repack/assets-loader',
         },
         {
           test: Repack.getAssetExtensionsRegExp(
@@ -107,7 +101,7 @@ export default (env) => {
           include: [path.join(context, 'src/assetsTest/inlineAssets')],
           use: {
             loader: '@callstack/repack/assets-loader',
-            options: { platform, inline: true },
+            options: { inline: true },
           },
         },
         {
@@ -118,7 +112,6 @@ export default (env) => {
           use: {
             loader: '@callstack/repack/assets-loader',
             options: {
-              platform,
               remote: {
                 enabled: true,
                 publicPath: 'http://localhost:9999/remote-assets',

--- a/apps/tester-app/webpack.config.mjs
+++ b/apps/tester-app/webpack.config.mjs
@@ -66,10 +66,7 @@ export default (env) => {
             path.join(context, 'src/assetsTest/inlineAssets'),
             path.join(context, 'src/assetsTest/remoteAssets'),
           ],
-          use: {
-            loader: '@callstack/repack/assets-loader',
-            options: { platform },
-          },
+          use: '@callstack/repack/assets-loader',
         },
         {
           test: /\.svg$/,
@@ -88,10 +85,7 @@ export default (env) => {
             Repack.ASSET_EXTENSIONS.filter((ext) => ext !== 'svg')
           ),
           include: [path.join(context, 'src/assetsTest/localAssets')],
-          use: {
-            loader: '@callstack/repack/assets-loader',
-            options: { platform },
-          },
+          use: '@callstack/repack/assets-loader',
         },
         {
           test: Repack.getAssetExtensionsRegExp(
@@ -100,7 +94,7 @@ export default (env) => {
           include: [path.join(context, 'src/assetsTest/inlineAssets')],
           use: {
             loader: '@callstack/repack/assets-loader',
-            options: { platform, inline: true },
+            options: { inline: true },
           },
         },
         {
@@ -111,7 +105,6 @@ export default (env) => {
           use: {
             loader: '@callstack/repack/assets-loader',
             options: {
-              platform,
               remote: {
                 enabled: true,
                 publicPath: 'http://localhost:9999/remote-assets',

--- a/apps/tester-federation-v2/configs/rspack.host-app.mjs
+++ b/apps/tester-federation-v2/configs/rspack.host-app.mjs
@@ -63,10 +63,7 @@ export default (env) => {
         },
         {
           test: Repack.getAssetExtensionsRegExp(Repack.ASSET_EXTENSIONS),
-          use: {
-            loader: '@callstack/repack/assets-loader',
-            options: { platform },
-          },
+          use: '@callstack/repack/assets-loader',
         },
       ],
     },

--- a/apps/tester-federation-v2/configs/rspack.mini-app.mjs
+++ b/apps/tester-federation-v2/configs/rspack.mini-app.mjs
@@ -62,7 +62,7 @@ export default (env) => {
           test: Repack.getAssetExtensionsRegExp(Repack.ASSET_EXTENSIONS),
           use: {
             loader: '@callstack/repack/assets-loader',
-            options: { platform, inline: true },
+            options: { inline: true },
           },
         },
       ],

--- a/apps/tester-federation-v2/configs/webpack.host-app.mjs
+++ b/apps/tester-federation-v2/configs/webpack.host-app.mjs
@@ -42,10 +42,7 @@ export default (env) => {
         },
         {
           test: Repack.getAssetExtensionsRegExp(Repack.ASSET_EXTENSIONS),
-          use: {
-            loader: '@callstack/repack/assets-loader',
-            options: { platform },
-          },
+          use: '@callstack/repack/assets-loader',
         },
       ],
     },

--- a/apps/tester-federation-v2/configs/webpack.mini-app.mjs
+++ b/apps/tester-federation-v2/configs/webpack.mini-app.mjs
@@ -41,7 +41,7 @@ export default (env) => {
           test: Repack.getAssetExtensionsRegExp(Repack.ASSET_EXTENSIONS),
           use: {
             loader: '@callstack/repack/assets-loader',
-            options: { platform, inline: true },
+            options: { inline: true },
           },
         },
       ],

--- a/apps/tester-federation/configs/rspack.host-app.mjs
+++ b/apps/tester-federation/configs/rspack.host-app.mjs
@@ -65,10 +65,7 @@ export default (env) => {
         },
         {
           test: Repack.getAssetExtensionsRegExp(Repack.ASSET_EXTENSIONS),
-          use: {
-            loader: '@callstack/repack/assets-loader',
-            options: { platform },
-          },
+          use: '@callstack/repack/assets-loader',
         },
       ],
     },

--- a/apps/tester-federation/configs/rspack.mini-app.mjs
+++ b/apps/tester-federation/configs/rspack.mini-app.mjs
@@ -64,7 +64,7 @@ export default (env) => {
           test: Repack.getAssetExtensionsRegExp(Repack.ASSET_EXTENSIONS),
           use: {
             loader: '@callstack/repack/assets-loader',
-            options: { platform, inline: true },
+            options: { inline: true },
           },
         },
       ],

--- a/apps/tester-federation/configs/webpack.host-app.mjs
+++ b/apps/tester-federation/configs/webpack.host-app.mjs
@@ -42,10 +42,7 @@ export default (env) => {
         },
         {
           test: Repack.getAssetExtensionsRegExp(Repack.ASSET_EXTENSIONS),
-          use: {
-            loader: '@callstack/repack/assets-loader',
-            options: { platform },
-          },
+          use: '@callstack/repack/assets-loader',
         },
       ],
     },

--- a/apps/tester-federation/configs/webpack.mini-app.mjs
+++ b/apps/tester-federation/configs/webpack.mini-app.mjs
@@ -41,7 +41,7 @@ export default (env) => {
           test: Repack.getAssetExtensionsRegExp(Repack.ASSET_EXTENSIONS),
           use: {
             loader: '@callstack/repack/assets-loader',
-            options: { platform, inline: true },
+            options: { inline: true },
           },
         },
       ],

--- a/packages/repack/src/loaders/assetsLoader/assetsLoader.ts
+++ b/packages/repack/src/loaders/assetsLoader/assetsLoader.ts
@@ -25,7 +25,10 @@ export default async function repackAssetsLoader(
   this.cacheable();
   const callback = this.async();
   const logger = this.getLogger('repackAssetsLoader');
+  const options = getOptions(this);
+
   const isDev = !!this._compiler.options.devServer;
+  const platform = options.platform ?? (this._compiler.options.name as string);
 
   const readDirAsync: AsyncFS['readdir'] = util.promisify(this.fs.readdir);
   const readFileAsync: AsyncFS['readFile'] = util.promisify(this.fs.readFile);
@@ -33,8 +36,6 @@ export default async function repackAssetsLoader(
   logger.debug(`Processing asset ${this.resourcePath}`);
 
   try {
-    const options = getOptions(this);
-
     // defaults
     const scalableAssetExtensions =
       options.scalableAssetExtensions ?? SCALABLE_ASSETS;
@@ -58,7 +59,7 @@ export default async function repackAssetsLoader(
       .relative(this.rootContext, resourceAbsoluteDirname)
       .replace(new RegExp(`^[\\.\\${path.sep}]+`), '');
     const resourceExtensionType = path.extname(resourcePath).replace(/^\./, '');
-    const suffixPattern = `(@\\d+(\\.\\d+)?x)?(\\.(${options.platform}|native))?\\.${resourceExtensionType}$`;
+    const suffixPattern = `(@\\d+(\\.\\d+)?x)?(\\.(${platform}|native))?\\.${resourceExtensionType}$`;
     const resourceFilename = path
       .basename(resourcePath)
       .replace(new RegExp(suffixPattern), '');
@@ -82,7 +83,7 @@ export default async function repackAssetsLoader(
       resourceExtensionType,
       scalableAssetExtensions,
       scalableAssetResolutions,
-      options.platform,
+      platform,
       readDirAsync
     );
 
@@ -125,11 +126,7 @@ export default async function repackAssetsLoader(
 
         let destination: string;
 
-        if (
-          !isDev &&
-          !options.remote?.enabled &&
-          options.platform === 'android'
-        ) {
+        if (!isDev && !options.remote?.enabled && platform === 'android') {
           // found font family
           if (
             testXml.test(resourceNormalizedFilename) &&
@@ -210,7 +207,7 @@ export default async function repackAssetsLoader(
     logger.debug(
       `Resolved request ${this.resourcePath}`,
       JSON.stringify({
-        platform: options.platform,
+        platform: platform,
         rootContext: this.rootContext,
         resourceNormalizedFilename,
         resourceFilename,

--- a/packages/repack/src/loaders/assetsLoader/options.ts
+++ b/packages/repack/src/loaders/assetsLoader/options.ts
@@ -3,7 +3,7 @@ import { validate } from 'schema-utils';
 
 // Note: publicPath could be obtained from webpack config in the future
 export interface AssetLoaderOptions {
-  platform: string;
+  platform?: string;
   scalableAssetExtensions?: string[];
   scalableAssetResolutions?: string[];
   inline?: boolean;
@@ -26,7 +26,6 @@ type Schema = Parameters<typeof validate>[0];
 
 export const optionsSchema: Schema = {
   type: 'object',
-  required: ['platform'],
   properties: {
     platform: {
       type: 'string',

--- a/templates_v5/rspack.config.cjs
+++ b/templates_v5/rspack.config.cjs
@@ -96,22 +96,9 @@ module.exports = (env) => {
             },
           },
         },
-        /**
-         * This loader handles all static assets (images, video, audio and others), so that you can
-         * use (reference) them inside your application.
-         *
-         * If you want to handle specific asset type manually, filter out the extension
-         * from `ASSET_EXTENSIONS`, for example:
-         * ```
-         * Repack.ASSET_EXTENSIONS.filter((ext) => ext !== 'svg')
-         * ```
-         */
         {
-          test: Repack.getAssetExtensionsRegExp(Repack.ASSET_EXTENSIONS),
-          use: {
-            loader: '@callstack/repack/assets-loader',
-            options: { platform },
-          },
+          test: Repack.getAssetExtensionsRegExp(),
+          use: '@callstack/repack/assets-loader',
         },
       ],
     },

--- a/templates_v5/rspack.config.mjs
+++ b/templates_v5/rspack.config.mjs
@@ -93,22 +93,9 @@ export default (env) => {
             },
           },
         },
-        /**
-         * This loader handles all static assets (images, video, audio and others), so that you can
-         * use (reference) them inside your application.
-         *
-         * If you want to handle specific asset type manually, filter out the extension
-         * from `ASSET_EXTENSIONS`, for example:
-         * ```
-         * Repack.ASSET_EXTENSIONS.filter((ext) => ext !== 'svg')
-         * ```
-         */
         {
-          test: Repack.getAssetExtensionsRegExp(Repack.ASSET_EXTENSIONS),
-          use: {
-            loader: '@callstack/repack/assets-loader',
-            options: { platform },
-          },
+          test: Repack.getAssetExtensionsRegExp(),
+          use: '@callstack/repack/assets-loader',
         },
       ],
     },

--- a/templates_v5/webpack.config.cjs
+++ b/templates_v5/webpack.config.cjs
@@ -125,22 +125,9 @@ module.exports = (env) => {
           exclude: /node_modules/,
           use: 'babel-loader',
         },
-        /**
-         * This loader handles all static assets (images, video, audio and others), so that you can
-         * use (reference) them inside your application.
-         *
-         * If you want to handle specific asset type manually, filter out the extension
-         * from `ASSET_EXTENSIONS`, for example:
-         * ```
-         * Repack.ASSET_EXTENSIONS.filter((ext) => ext !== 'svg')
-         * ```
-         */
         {
-          test: Repack.getAssetExtensionsRegExp(Repack.ASSET_EXTENSIONS),
-          use: {
-            loader: '@callstack/repack/assets-loader',
-            options: { platform },
-          },
+          test: Repack.getAssetExtensionsRegExp(),
+          use: '@callstack/repack/assets-loader',
         },
       ],
     },

--- a/templates_v5/webpack.config.mjs
+++ b/templates_v5/webpack.config.mjs
@@ -124,22 +124,9 @@ export default (env) => {
           exclude: /node_modules/,
           use: 'babel-loader',
         },
-        /**
-         * This loader handles all static assets (images, video, audio and others), so that you can
-         * use (reference) them inside your application.
-         *
-         * If you want to handle specific asset type manually, filter out the extension
-         * from `ASSET_EXTENSIONS`, for example:
-         * ```
-         * Repack.ASSET_EXTENSIONS.filter((ext) => ext !== 'svg')
-         * ```
-         */
         {
-          test: Repack.getAssetExtensionsRegExp(Repack.ASSET_EXTENSIONS),
-          use: {
-            loader: '@callstack/repack/assets-loader',
-            options: { platform },
-          },
+          test: Repack.getAssetExtensionsRegExp(),
+          use: '@callstack/repack/assets-loader',
         },
       ],
     },


### PR DESCRIPTION
### Summary

- [x] - made `platform` optional for `assetsLoader` - it is now inferred automatically from configuration
- [x] - simplified configs & templates 

### Test plan

- [x] - tests pass
- [x] - testers work 
