### PR TITLE
fix: `EXPO_OS` not being set in expo-modules plugin

### DIFF
--- a/.changeset/green-rats-brush.md
+++ b/.changeset/green-rats-brush.md
@@ -1,0 +1,5 @@
+---
+"@callstack/repack-plugin-expo-modules": patch
+---
+
+Fix EXPO_OS not being properly set in expo-modules plugin

--- a/packages/plugin-expo-modules/src/plugin.ts
+++ b/packages/plugin-expo-modules/src/plugin.ts
@@ -4,7 +4,7 @@ interface ExpoModulesPluginOptions {
   /**
    * Target application platform (e.g. `ios`, `android`).
    *
-   * By default, the platform is inferred from `compiler.name` which is set by Re.Pack.
+   * By default, the platform is inferred from `compiler.options.name` which is set by Re.Pack.
    */
   platform?: string;
 }
@@ -13,11 +13,11 @@ export class ExpoModulesPlugin implements RspackPluginInstance {
   constructor(private options: ExpoModulesPluginOptions = {}) {}
 
   apply(compiler: Compiler) {
-    const platform = this.options.platform ?? compiler.name;
+    const platform = this.options.platform ?? (compiler.options.name as string);
 
     // expo modules expect this to be defined in runtime
     new compiler.webpack.DefinePlugin({
       'process.env.EXPO_OS': JSON.stringify(platform),
-    });
+    }).apply(compiler);
   }
 }


### PR DESCRIPTION
### Summary

- [x] - use `compiler.options.name` instead of `compiler.name`
- [x] - call `apply` on `DefinePlugin`

### Test plan

- [x] - testers work
