### PR TITLE
refactor: make platform optional in `DevelopmentPlugin`

### DIFF
--- a/.changeset/many-ants-rescue.md
+++ b/.changeset/many-ants-rescue.md
@@ -1,0 +1,5 @@
+---
+"@callstack/repack": patch
+---
+
+Make `platform` option of DevelopmentPlugin optional

--- a/packages/repack/src/plugins/DevelopmentPlugin.ts
+++ b/packages/repack/src/plugins/DevelopmentPlugin.ts
@@ -19,7 +19,10 @@ type PackageJSON = { version: string };
  * {@link DevelopmentPlugin} configuration options.
  */
 export interface DevelopmentPluginConfig {
-  platform: string;
+  /**
+   * Target application platform.
+   */
+  platform?: string;
 }
 
 /**
@@ -103,7 +106,7 @@ export class DevelopmentPlugin implements RspackPluginInstance {
     const host = compiler.options.devServer.host;
     const port = compiler.options.devServer.port;
     const protocol = this.getProtocolType(compiler.options.devServer);
-    const platform = this.config.platform;
+    const platform = this.config.platform ?? (compiler.options.name as string);
 
     new compiler.webpack.DefinePlugin({
       __PLATFORM__: JSON.stringify(platform),


### PR DESCRIPTION
### Summary

- [x] - platform param is now optional in `DevelopmentPlugin` configuration - it's inferred from `compiler.options.name` by default

### Test plan

n/a
