### PR TITLE
feat: getAssetTransformRules

### DIFF
--- a/.changeset/eighty-phones-deny.md
+++ b/.changeset/eighty-phones-deny.md
@@ -1,0 +1,5 @@
+---
+"@callstack/repack": minor
+---
+
+Added `getAssetTransformRules` utility function to simplify setting up asset transformation rules in both Webpack and Rspack projects.

--- a/apps/tester-federation-v2/configs/rspack.host-app.mjs
+++ b/apps/tester-federation-v2/configs/rspack.host-app.mjs
@@ -31,10 +31,7 @@ export default (env) => {
     module: {
       rules: [
         ...Repack.getJsTransformRules(),
-        {
-          test: Repack.getAssetExtensionsRegExp(),
-          use: '@callstack/repack/assets-loader',
-        },
+        ...Repack.getAssetTransformRules(),
       ],
     },
     plugins: [

--- a/apps/tester-federation-v2/configs/rspack.mini-app.mjs
+++ b/apps/tester-federation-v2/configs/rspack.mini-app.mjs
@@ -31,13 +31,7 @@ export default (env) => {
     module: {
       rules: [
         ...Repack.getJsTransformRules(),
-        {
-          test: Repack.getAssetExtensionsRegExp(),
-          use: {
-            loader: '@callstack/repack/assets-loader',
-            options: { inline: true },
-          },
-        },
+        ...Repack.getAssetTransformRules({ inline: true }),
       ],
     },
     plugins: [

--- a/apps/tester-federation-v2/configs/webpack.host-app.mjs
+++ b/apps/tester-federation-v2/configs/webpack.host-app.mjs
@@ -37,10 +37,7 @@ export default (env) => {
           use: 'babel-loader',
           type: 'javascript/auto',
         },
-        {
-          test: Repack.getAssetExtensionsRegExp(),
-          use: '@callstack/repack/assets-loader',
-        },
+        ...Repack.getAssetTransformRules(),
       ],
     },
     plugins: [

--- a/apps/tester-federation-v2/configs/webpack.mini-app.mjs
+++ b/apps/tester-federation-v2/configs/webpack.mini-app.mjs
@@ -37,13 +37,7 @@ export default (env) => {
           use: 'babel-loader',
           type: 'javascript/auto',
         },
-        {
-          test: Repack.getAssetExtensionsRegExp(),
-          use: {
-            loader: '@callstack/repack/assets-loader',
-            options: { inline: true },
-          },
-        },
+        ...Repack.getAssetTransformRules({ inline: true }),
       ],
     },
     plugins: [

--- a/apps/tester-federation/configs/rspack.host-app.mjs
+++ b/apps/tester-federation/configs/rspack.host-app.mjs
@@ -33,10 +33,7 @@ export default (env) => {
     module: {
       rules: [
         ...Repack.getJsTransformRules(),
-        {
-          test: Repack.getAssetExtensionsRegExp(),
-          use: '@callstack/repack/assets-loader',
-        },
+        ...Repack.getAssetTransformRules(),
       ],
     },
     plugins: [

--- a/apps/tester-federation/configs/rspack.mini-app.mjs
+++ b/apps/tester-federation/configs/rspack.mini-app.mjs
@@ -33,13 +33,7 @@ export default (env) => {
     module: {
       rules: [
         ...Repack.getJsTransformRules(),
-        {
-          test: Repack.getAssetExtensionsRegExp(),
-          use: {
-            loader: '@callstack/repack/assets-loader',
-            options: { inline: true },
-          },
-        },
+        ...Repack.getAssetTransformRules({ inline: true }),
       ],
     },
     plugins: [

--- a/apps/tester-federation/configs/webpack.host-app.mjs
+++ b/apps/tester-federation/configs/webpack.host-app.mjs
@@ -37,10 +37,7 @@ export default (env) => {
           use: 'babel-loader',
           type: 'javascript/auto',
         },
-        {
-          test: Repack.getAssetExtensionsRegExp(),
-          use: '@callstack/repack/assets-loader',
-        },
+        ...Repack.getAssetTransformRules(),
       ],
     },
     plugins: [

--- a/apps/tester-federation/configs/webpack.mini-app.mjs
+++ b/apps/tester-federation/configs/webpack.mini-app.mjs
@@ -37,13 +37,7 @@ export default (env) => {
           use: 'babel-loader',
           type: 'javascript/auto',
         },
-        {
-          test: Repack.getAssetExtensionsRegExp(),
-          use: {
-            loader: '@callstack/repack/assets-loader',
-            options: { inline: true },
-          },
-        },
+        ...Repack.getAssetTransformRules({ inline: true }),
       ],
     },
     plugins: [

--- a/packages/repack/src/loaders/assetsLoader/options.ts
+++ b/packages/repack/src/loaders/assetsLoader/options.ts
@@ -1,6 +1,17 @@
 import type { LoaderContext } from '@rspack/core';
 import { validate } from 'schema-utils';
 
+export interface AssetLoaderRemoteOptions {
+  enabled: boolean;
+  assetPath?: (args: {
+    resourcePath: string;
+    resourceFilename: string;
+    resourceDirname: string;
+    resourceExtensionType: string;
+  }) => string;
+  publicPath: string;
+}
+
 // Note: publicPath could be obtained from webpack config in the future
 export interface AssetLoaderOptions {
   platform?: string;
@@ -8,16 +19,7 @@ export interface AssetLoaderOptions {
   scalableAssetResolutions?: string[];
   inline?: boolean;
   publicPath?: string;
-  remote?: {
-    enabled: boolean;
-    assetPath?: (args: {
-      resourcePath: string;
-      resourceFilename: string;
-      resourceDirname: string;
-      resourceExtensionType: string;
-    }) => string;
-    publicPath: string;
-  };
+  remote?: AssetLoaderRemoteOptions;
 }
 
 export interface AssetLoaderContext extends LoaderContext<AssetLoaderOptions> {}

--- a/packages/repack/src/utils/__tests__/__snapshots__/getAssetTransformRules.test.ts.snap
+++ b/packages/repack/src/utils/__tests__/__snapshots__/getAssetTransformRules.test.ts.snap
@@ -1,0 +1,111 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`getAssetTransformRules should add SVGR rule when svg="svgr" 1`] = `
+[
+  {
+    "test": /\\\\\\.\\(bmp\\|gif\\|jpg\\|jpeg\\|png\\|psd\\|webp\\|tiff\\|m4v\\|mov\\|mp4\\|mpeg\\|mpg\\|webm\\|aac\\|aiff\\|caf\\|m4a\\|mp3\\|wav\\|html\\|pdf\\|yaml\\|yml\\|otf\\|ttf\\|zip\\|obj\\)\\$/,
+    "use": {
+      "loader": "@callstack/repack/assets-loader",
+      "options": {
+        "inline": undefined,
+        "remote": undefined,
+      },
+    },
+  },
+  {
+    "test": /\\\\\\.svg\\$/,
+    "use": {
+      "loader": "@svgr/webpack",
+      "options": {
+        "native": true,
+      },
+    },
+  },
+]
+`;
+
+exports[`getAssetTransformRules should add URI rule when svg="uri" 1`] = `
+[
+  {
+    "test": /\\\\\\.\\(bmp\\|gif\\|jpg\\|jpeg\\|png\\|psd\\|webp\\|tiff\\|m4v\\|mov\\|mp4\\|mpeg\\|mpg\\|webm\\|aac\\|aiff\\|caf\\|m4a\\|mp3\\|wav\\|html\\|pdf\\|yaml\\|yml\\|otf\\|ttf\\|zip\\|obj\\)\\$/,
+    "use": {
+      "loader": "@callstack/repack/assets-loader",
+      "options": {
+        "inline": undefined,
+        "remote": undefined,
+      },
+    },
+  },
+  {
+    "test": /\\\\\\.svg\\$/,
+    "type": "asset/inline",
+  },
+]
+`;
+
+exports[`getAssetTransformRules should add XML rule when svg="xml" 1`] = `
+[
+  {
+    "test": /\\\\\\.\\(bmp\\|gif\\|jpg\\|jpeg\\|png\\|psd\\|webp\\|tiff\\|m4v\\|mov\\|mp4\\|mpeg\\|mpg\\|webm\\|aac\\|aiff\\|caf\\|m4a\\|mp3\\|wav\\|html\\|pdf\\|yaml\\|yml\\|otf\\|ttf\\|zip\\|obj\\)\\$/,
+    "use": {
+      "loader": "@callstack/repack/assets-loader",
+      "options": {
+        "inline": undefined,
+        "remote": undefined,
+      },
+    },
+  },
+  {
+    "test": /\\\\\\.svg\\$/,
+    "type": "asset/source",
+  },
+]
+`;
+
+exports[`getAssetTransformRules should return default asset transform rules when no options provided 1`] = `
+[
+  {
+    "test": /\\\\\\.\\(bmp\\|gif\\|jpg\\|jpeg\\|png\\|psd\\|svg\\|webp\\|tiff\\|m4v\\|mov\\|mp4\\|mpeg\\|mpg\\|webm\\|aac\\|aiff\\|caf\\|m4a\\|mp3\\|wav\\|html\\|pdf\\|yaml\\|yml\\|otf\\|ttf\\|zip\\|obj\\)\\$/,
+    "use": {
+      "loader": "@callstack/repack/assets-loader",
+      "options": {
+        "inline": undefined,
+        "remote": undefined,
+      },
+    },
+  },
+]
+`;
+
+exports[`getAssetTransformRules should return rules with inline option when provided 1`] = `
+[
+  {
+    "test": /\\\\\\.\\(bmp\\|gif\\|jpg\\|jpeg\\|png\\|psd\\|svg\\|webp\\|tiff\\|m4v\\|mov\\|mp4\\|mpeg\\|mpg\\|webm\\|aac\\|aiff\\|caf\\|m4a\\|mp3\\|wav\\|html\\|pdf\\|yaml\\|yml\\|otf\\|ttf\\|zip\\|obj\\)\\$/,
+    "use": {
+      "loader": "@callstack/repack/assets-loader",
+      "options": {
+        "inline": true,
+        "remote": undefined,
+      },
+    },
+  },
+]
+`;
+
+exports[`getAssetTransformRules should return rules with remote options when provided 1`] = `
+[
+  {
+    "test": /\\\\\\.\\(bmp\\|gif\\|jpg\\|jpeg\\|png\\|psd\\|svg\\|webp\\|tiff\\|m4v\\|mov\\|mp4\\|mpeg\\|mpg\\|webm\\|aac\\|aiff\\|caf\\|m4a\\|mp3\\|wav\\|html\\|pdf\\|yaml\\|yml\\|otf\\|ttf\\|zip\\|obj\\)\\$/,
+    "use": {
+      "loader": "@callstack/repack/assets-loader",
+      "options": {
+        "inline": undefined,
+        "remote": {
+          "enabled": true,
+          "publicPath": "https://example.com/assets",
+        },
+      },
+    },
+  },
+]
+`;

--- a/packages/repack/src/utils/__tests__/getAssetTransformRules.test.ts
+++ b/packages/repack/src/utils/__tests__/getAssetTransformRules.test.ts
@@ -1,0 +1,57 @@
+import { getAssetTransformRules } from '../getAssetTransformRules.js';
+
+describe('getAssetTransformRules', () => {
+  it('should return default asset transform rules when no options provided', () => {
+    const rules = getAssetTransformRules();
+    expect(rules).toMatchSnapshot();
+  });
+
+  it('should return rules with inline option when provided', () => {
+    const rules = getAssetTransformRules({ inline: true });
+
+    // @ts-ignore
+    expect(rules[0]?.use?.options?.inline).toEqual(true);
+    expect(rules).toMatchSnapshot();
+  });
+
+  it('should return rules with remote options when provided', () => {
+    const remoteOptions = { publicPath: 'https://example.com/assets' };
+    const rules = getAssetTransformRules({ remote: remoteOptions });
+
+    // @ts-ignore
+    expect(rules[0]?.use?.options?.remote).toHaveProperty('enabled', true);
+    expect(rules).toMatchSnapshot();
+  });
+
+  it('should add SVGR rule when svg="svgr"', () => {
+    const rules = getAssetTransformRules({ svg: 'svgr' });
+
+    expect(rules).toHaveLength(2);
+    expect(rules[1]?.use?.loader).toEqual('@svgr/webpack');
+    expect(rules).toMatchSnapshot();
+  });
+
+  it('should add XML rule when svg="xml"', () => {
+    const rules = getAssetTransformRules({ svg: 'xml' });
+
+    expect(rules).toHaveLength(2);
+    // @ts-ignore
+    expect(rules[1]?.type).toEqual('asset/source');
+    expect(rules).toMatchSnapshot();
+  });
+
+  it('should add URI rule when svg="uri"', () => {
+    const rules = getAssetTransformRules({ svg: 'uri' });
+
+    expect(rules).toHaveLength(2);
+    // @ts-ignore
+    expect(rules[1]?.type).toEqual('asset/inline');
+    expect(rules).toMatchSnapshot();
+  });
+
+  it('should exclude .svg from main asset extensions when svg option is provided', () => {
+    const rules = getAssetTransformRules({ svg: 'uri' });
+    const ruleTest = rules[0]?.test;
+    expect(ruleTest.test('test.svg')).toEqual(false);
+  });
+});

--- a/packages/repack/src/utils/getAssetTransformRules.ts
+++ b/packages/repack/src/utils/getAssetTransformRules.ts
@@ -1,15 +1,14 @@
-import type { RuleSetRule } from '@rspack/core';
 import type { AssetLoaderRemoteOptions } from '../loaders/assetsLoader/options.js';
 import {
   ASSET_EXTENSIONS,
   getAssetExtensionsRegExp,
 } from './assetExtensions.js';
 
-function getSvgRule(type: 'svgr' | 'xml' | 'uri'): RuleSetRule {
+function getSvgRule(type: 'svgr' | 'xml' | 'uri') {
   if (type === 'svgr') {
     return {
       test: /\.svg$/,
-      use: [{ loader: '@svgr/webpack', options: { native: true } }],
+      use: { loader: '@svgr/webpack', options: { native: true } },
     };
   }
 
@@ -41,15 +40,15 @@ export function getAssetTransformRules({
       }
     : undefined;
 
-  const rules: RuleSetRule[] = [
-    {
-      test: getAssetExtensionsRegExp(extensions),
-      use: {
-        loader: '@callstack/repack/assets-loader',
-        options: { inline, remote: remoteOptions },
-      },
+  const rules = [];
+
+  rules.push({
+    test: getAssetExtensionsRegExp(extensions),
+    use: {
+      loader: '@callstack/repack/assets-loader',
+      options: { inline, remote: remoteOptions },
     },
-  ];
+  });
 
   if (svg) {
     rules.push(getSvgRule(svg));

--- a/packages/repack/src/utils/getAssetTransformRules.ts
+++ b/packages/repack/src/utils/getAssetTransformRules.ts
@@ -1,0 +1,10 @@
+import { getAssetExtensionsRegExp } from './assetExtensions.js';
+
+export function getAssetTransformRules() {
+  return [
+    {
+      test: getAssetExtensionsRegExp(),
+      use: '@callstack/repack/assets-loader',
+    },
+  ];
+}

--- a/packages/repack/src/utils/getAssetTransformRules.ts
+++ b/packages/repack/src/utils/getAssetTransformRules.ts
@@ -30,6 +30,10 @@ export function getAssetTransformRules({
   remote,
   svg,
 }: GetAssetTransformRulesOptions = {}) {
+  const extensions = svg
+    ? ASSET_EXTENSIONS.filter((ext) => ext !== '.svg')
+    : ASSET_EXTENSIONS;
+
   const remoteOptions = remote
     ? {
         enabled: true,
@@ -37,19 +41,12 @@ export function getAssetTransformRules({
       }
     : undefined;
 
-  const extensions = svg
-    ? ASSET_EXTENSIONS.filter((ext) => ext !== '.svg')
-    : ASSET_EXTENSIONS;
-
   const rules: RuleSetRule[] = [
     {
       test: getAssetExtensionsRegExp(extensions),
       use: {
         loader: '@callstack/repack/assets-loader',
-        options: {
-          inline,
-          remote: remoteOptions,
-        },
+        options: { inline, remote: remoteOptions },
       },
     },
   ];

--- a/packages/repack/src/utils/getAssetTransformRules.ts
+++ b/packages/repack/src/utils/getAssetTransformRules.ts
@@ -1,10 +1,62 @@
-import { getAssetExtensionsRegExp } from './assetExtensions.js';
+import type { RuleSetRule } from '@rspack/core';
+import type { AssetLoaderRemoteOptions } from '../loaders/assetsLoader/options.js';
+import {
+  ASSET_EXTENSIONS,
+  getAssetExtensionsRegExp,
+} from './assetExtensions.js';
 
-export function getAssetTransformRules() {
-  return [
+function getSvgRule(type: 'svgr' | 'xml' | 'uri'): RuleSetRule {
+  if (type === 'svgr') {
+    return {
+      test: /\.svg$/,
+      use: [{ loader: '@svgr/webpack', options: { native: true } }],
+    };
+  }
+
+  return {
+    test: /\.svg$/,
+    type: type === 'xml' ? 'asset/source' : 'asset/inline',
+  };
+}
+
+interface GetAssetTransformRulesOptions {
+  inline?: boolean;
+  remote?: Omit<AssetLoaderRemoteOptions, 'enabled'>;
+  svg?: 'svgr' | 'xml' | 'uri';
+}
+
+export function getAssetTransformRules({
+  inline,
+  remote,
+  svg,
+}: GetAssetTransformRulesOptions = {}) {
+  const remoteOptions = remote
+    ? {
+        enabled: true,
+        ...remote,
+      }
+    : undefined;
+
+  const extensions = svg
+    ? ASSET_EXTENSIONS.filter((ext) => ext !== '.svg')
+    : ASSET_EXTENSIONS;
+
+  const rules: RuleSetRule[] = [
     {
-      test: getAssetExtensionsRegExp(),
-      use: '@callstack/repack/assets-loader',
+      test: getAssetExtensionsRegExp(extensions),
+      use: {
+        loader: '@callstack/repack/assets-loader',
+        options: {
+          inline,
+          remote: remoteOptions,
+        },
+      },
     },
   ];
+
+  if (svg) {
+    rules.push(getSvgRule(svg));
+  }
+
+  return rules;
 }

--- a/packages/repack/src/utils/getAssetTransformRules.ts
+++ b/packages/repack/src/utils/getAssetTransformRules.ts
@@ -30,7 +30,7 @@ export function getAssetTransformRules({
   svg,
 }: GetAssetTransformRulesOptions = {}) {
   const extensions = svg
-    ? ASSET_EXTENSIONS.filter((ext) => ext !== '.svg')
+    ? ASSET_EXTENSIONS.filter((ext) => ext !== 'svg')
     : ASSET_EXTENSIONS;
 
   const remoteOptions = remote

--- a/packages/repack/src/utils/getAssetTransformRules.ts
+++ b/packages/repack/src/utils/getAssetTransformRules.ts
@@ -18,12 +18,39 @@ function getSvgRule(type: 'svgr' | 'xml' | 'uri') {
   };
 }
 
+/**
+ * Interface for {@link getAssetTransformRules} options.
+ */
 interface GetAssetTransformRulesOptions {
+  /**
+   * Whether to inline assets as base64 URIs.
+   */
   inline?: boolean;
+
+  /**
+   * Configuration for remote asset loading.
+   */
   remote?: Omit<AssetLoaderRemoteOptions, 'enabled'>;
+
+  /**
+   * Determines how SVG files should be processed:
+   * - 'svgr': Uses `@svgr/webpack` to transform SVGs into React Native components
+   * - 'xml': Loads SVGs as raw XML source to be used with SvgXml from react-native-svg
+   * - 'uri': Loads SVGs as inline URIs to be used with SvgUri from react-native-svg
+   */
   svg?: 'svgr' | 'xml' | 'uri';
 }
 
+/**
+ * Creates `module.rules` configuration for handling assets in React Native applications.
+ *
+ * @param options Configuration options
+ * @param options.inline Whether to inline assets as base64 URIs (defaults to false)
+ * @param options.remote Configuration for remote asset loading with publicPath and optional assetPath function
+ * @param options.svg Determines how SVG files should be processed ('svgr', 'xml', or 'uri')
+ *
+ * @returns Array of webpack/rspack rules for transforming assets
+ */
 export function getAssetTransformRules({
   inline,
   remote,

--- a/packages/repack/src/utils/index.ts
+++ b/packages/repack/src/utils/index.ts
@@ -8,3 +8,4 @@ export * from './getJsTransformRules.js';
 export * from './getSwcLoaderOptions.js';
 export * from './getFlowTransformRules.js';
 export * from './getCodegenTransformRules.js';
+export * from './getAssetTransformRules.js';

--- a/templates_v5/rspack.config.cjs
+++ b/templates_v5/rspack.config.cjs
@@ -16,10 +16,7 @@ module.exports = {
   module: {
     rules: [
       ...Repack.getJsTransformRules(),
-      {
-        test: Repack.getAssetExtensionsRegExp(),
-        use: '@callstack/repack/assets-loader',
-      },
+      ...Repack.getAssetTransformRules(),
     ],
   },
   plugins: [new Repack.RepackPlugin()],

--- a/templates_v5/rspack.config.mjs
+++ b/templates_v5/rspack.config.mjs
@@ -21,10 +21,7 @@ export default {
   module: {
     rules: [
       ...Repack.getJsTransformRules(),
-      {
-        test: Repack.getAssetExtensionsRegExp(),
-        use: '@callstack/repack/assets-loader',
-      },
+      ...Repack.getAssetTransformRules(),
     ],
   },
   plugins: [new Repack.RepackPlugin()],

--- a/templates_v5/webpack.config.cjs
+++ b/templates_v5/webpack.config.cjs
@@ -21,10 +21,7 @@ module.exports = {
         use: 'babel-loader',
         type: 'javascript/auto',
       },
-      {
-        test: Repack.getAssetExtensionsRegExp(),
-        use: '@callstack/repack/assets-loader',
-      },
+      ...Repack.getAssetTransformRules(),
     ],
   },
   optimization: {

--- a/templates_v5/webpack.config.mjs
+++ b/templates_v5/webpack.config.mjs
@@ -26,10 +26,7 @@ export default {
         use: 'babel-loader',
         type: 'javascript/auto',
       },
-      {
-        test: Repack.getAssetExtensionsRegExp(),
-        use: '@callstack/repack/assets-loader',
-      },
+      ...Repack.getAssetTransformRules(),
     ],
   },
   optimization: {

--- a/website/src/5.x/api/utils/_meta.json
+++ b/website/src/5.x/api/utils/_meta.json
@@ -1,6 +1,7 @@
 [
   "constants",
   "get-asset-extension-regexp",
+  "get-asset-transform-rules",
   "get-codegen-transform-rules",
   "get-dirname",
   "get-flow-transform-rules",

--- a/website/src/5.x/api/utils/get-asset-transform-rules.md
+++ b/website/src/5.x/api/utils/get-asset-transform-rules.md
@@ -26,14 +26,11 @@ interface GetAssetTransformRulesOptions {
 
 ### options
 
-- Required: `false`
-
 Configuration options for asset transformations.
 
 ### options.inline
 
 - Type: `boolean`
-- Default: `false`
 
 Whether to inline assets as base64 URIs.
 
@@ -44,7 +41,6 @@ Learn more about the inlining assets in the [Inlining Assets guide](/docs/guides
 ### options.remote
 
 - Type: `object`
-- Required: `false`
 
 Configuration for remote asset loading.
 
@@ -64,7 +60,6 @@ See [`assetsLoader` documentation](/api/loaders/assets-loader#remotepublicpath) 
 ### options.remote.assetPath
 
 - Type: `(args: { resourcePath: string; resourceFilename: string; resourceDirname: string; resourceExtensionType: string; }) => string`
-- Required: `false`
 
 A function to customize how the asset path is generated for remote assets.
 
@@ -73,7 +68,6 @@ See [`assetsLoader` documentation](/api/loaders/assets-loader#remoteassetpath) f
 ### options.svg
 
 - Type: `'svgr' | 'xml' | 'uri'`
-- Required: `false`
 
 Determines how SVG files should be processed:
 

--- a/website/src/5.x/api/utils/get-asset-transform-rules.md
+++ b/website/src/5.x/api/utils/get-asset-transform-rules.md
@@ -1,0 +1,102 @@
+# getAssetTransformRules
+
+A helper function that generates `module.rules` configuration for handling assets in React Native applications.
+
+:::tip
+This helper function allows you to create a single configuration for all assets in your project. If you need more granular control over asset processing, refer to the [`assetsLoader`](/api/loaders/assets-loader) documentation.
+:::
+
+## Parameters
+
+```ts
+interface GetAssetTransformRulesOptions {
+  inline?: boolean;
+  remote?: {
+    publicPath: string;
+    assetPath?: (args: {
+      resourcePath: string;
+      resourceFilename: string;
+      resourceDirname: string;
+      resourceExtensionType: string;
+    }) => string;
+  };
+  svg?: "svgr" | "xml" | "uri";
+}
+```
+
+### options
+
+- Required: `false`
+
+Configuration options for asset transformations.
+
+### options.inline
+
+- Type: `boolean`
+- Default: `false`
+
+Whether to inline assets as base64 URIs.
+
+:::tip
+Learn more about the inlining assets in the [Inlining Assets guide](/docs/guides/inlining-assets).
+:::
+
+### options.remote
+
+- Type: `object`
+- Required: `false`
+
+Configuration for remote asset loading.
+
+:::tip
+Learn more about using remote assets in the [Remote Assets guide](/docs/guides/remote-assets).
+:::
+
+### options.remote.publicPath
+
+- Type: `string`
+- Required: `true`
+
+Public path for loading remote assets.
+
+See [`assetsLoader` documentation](/api/loaders/assets-loader#remotepublicpath) for reference.
+
+### options.remote.assetPath
+
+- Type: `(args: { resourcePath: string; resourceFilename: string; resourceDirname: string; resourceExtensionType: string; }) => string`
+- Required: `false`
+
+A function to customize how the asset path is generated for remote assets.
+
+See [`assetsLoader` documentation](/api/loaders/assets-loader#remoteassetpath) for reference.
+
+### options.svg
+
+- Type: `'svgr' | 'xml' | 'uri'`
+- Required: `false`
+
+Determines how SVG files should be processed:
+
+- `'svgr'`: Uses `@svgr/webpack` to transform SVGs into React Native components
+- `'xml'`: Loads SVGs as raw XML source to be used with `SvgXml` from `react-native-svg`
+- `'uri'`: Loads SVGs as inline URIs to be used with `SvgUri` from `react-native-svg`
+
+:::tip
+Learn more about using SVG in the [SVG guide](/docs/guides/svg).
+:::
+
+## Example
+
+```js title=rspack.config.cjs
+const Repack = require("@callstack/repack");
+
+module.exports = {
+  module: {
+    rules: [
+      ...Repack.getAssetTransformRules({
+        svg: "svgr",
+      }),
+    ],
+  },
+};
+```


### PR DESCRIPTION
### Summary

- [x] - added `getAssetTransformRules` which creates a default configuration for asset handling in both `rspack` and `webpack` configurations
- [x] - added tests for `getAssetTransformRules`
- [x] - added docs for `getAssetTransformRules`
- [x] - updated templates
- [x] - updated configs in testers  

### Test plan

- [x] - tests pass
- [x] - testers work 
