### PR TITLE
docs: remove expo migration guide

### DIFF
--- a/website/src/latest/docs/migration-guides/_meta.json
+++ b/website/src/latest/docs/migration-guides/_meta.json
@@ -1,1 +1,1 @@
-["metro", "expo", "repack-v4"]
+["metro", "repack-v4"]

--- a/website/src/latest/docs/migration-guides/expo.md
+++ b/website/src/latest/docs/migration-guides/expo.md
@@ -1,7 +1,0 @@
-# Migrating from Expo
-
-:::warning title="Notice:"
-The documentation for Re.Pack 5 is currently under development and some of the pages aren't ready yet.
-
-Please use [latest stable version of Re.Pack 4.x documentation](https://re-pack.dev/docs/getting-started) for now.
-:::


### PR DESCRIPTION
### Summary

- [x] - removed expo migration guide for now since its out of scope and we might support Expo in the next minor version

### Test plan

n/a
