### PR TITLE
fix: look for webpack configs in webpack start command

### DIFF
--- a/.changeset/shiny-starfishes-grow.md
+++ b/.changeset/shiny-starfishes-grow.md
@@ -1,0 +1,5 @@
+---
+"@callstack/repack": patch
+---
+
+Fix webpack start command looking for rspack configs

--- a/packages/repack/src/commands/webpack/start.ts
+++ b/packages/repack/src/commands/webpack/start.ts
@@ -49,7 +49,7 @@ export async function start(
 
   const configs = await makeCompilerConfig<Configuration>({
     args: args,
-    bundler: 'rspack',
+    bundler: 'webpack',
     command: 'start',
     rootDir: cliConfig.root,
     platforms: args.platform ? [args.platform] : detectedPlatforms,


### PR DESCRIPTION
### Summary

fixed a bug where webpack command was looking for rspack config - this was not causing issue in projects where there are both rspack and webpack configs existing together.

### Test plan

- [x] - testers work
