### PR TITLE
fix: OutputPlugin not using bundleOutput & sourcemapOutput args

### DIFF
--- a/.changeset/tasty-pianos-march.md
+++ b/.changeset/tasty-pianos-march.md
@@ -1,0 +1,5 @@
+---
+"@callstack/repack": patch
+---
+
+Fix OutputPlugin not picking up bundleOutput & sourcemapOutput args

--- a/packages/repack/src/commands/common/setupEnvironment.ts
+++ b/packages/repack/src/commands/common/setupEnvironment.ts
@@ -13,14 +13,14 @@ function setEnvVar(key: string, value: string | undefined): void {
 
 interface EnvironmentArgs {
   assetsDest?: string;
-  bundleFilename?: string;
-  sourcemapFilename?: string;
+  bundleOutput?: string;
+  sourcemapOutput?: string;
   verbose?: boolean;
 }
 
 export function setupEnvironment(args: EnvironmentArgs): void {
   setEnvVar(VERBOSE_ENV_KEY, args.verbose ? 'true' : undefined);
-  setEnvVar(BUNDLE_FILENAME_ENV_KEY, args.bundleFilename);
-  setEnvVar(SOURCEMAP_FILENAME_ENV_KEY, args.sourcemapFilename);
+  setEnvVar(BUNDLE_FILENAME_ENV_KEY, args.bundleOutput);
+  setEnvVar(SOURCEMAP_FILENAME_ENV_KEY, args.sourcemapOutput);
   setEnvVar(ASSETS_DEST_ENV_KEY, args.assetsDest);
 }


### PR DESCRIPTION
### Summary

- [x] - fixed a type that prevent setting up the env variables for OutputPlugin correctly

### Test plan

- [x] - testers work
