### PR TITLE
fix: reanimated plugin transform js files with c and m prefix

### DIFF
--- a/.changeset/silent-peas-think.md
+++ b/.changeset/silent-peas-think.md
@@ -1,0 +1,5 @@
+---
+"@callstack/repack-plugin-reanimated": patch
+---
+
+Fix reanimated plugin rule not picking up mjs and cjs files

--- a/packages/plugin-reanimated/src/rules.ts
+++ b/packages/plugin-reanimated/src/rules.ts
@@ -12,7 +12,7 @@ export const reanimatedModuleRules = {
   ]),
   oneOf: [
     {
-      test: /\.ts$/,
+      test: /\.[cm]?ts$/,
       use: {
         loader: '@callstack/repack-plugin-reanimated/loader',
         options: {
@@ -26,7 +26,7 @@ export const reanimatedModuleRules = {
       },
     },
     {
-      test: /\.tsx$/,
+      test: /\.[cm]?tsx$/,
       use: {
         loader: '@callstack/repack-plugin-reanimated/loader',
         options: {
@@ -40,7 +40,7 @@ export const reanimatedModuleRules = {
       },
     },
     {
-      test: /\.jsx?$/,
+      test: /\.[cm]?jsx?$/,
       use: {
         loader: '@callstack/repack-plugin-reanimated/loader',
         options: {


### PR DESCRIPTION
### Summary

reanimated plugin will now pick up on js files with `c` or `m` prefix like `cjs`, `mjs`, `cts`, `mts` etc.

### Test plan

n/a
