### PR TITLE
docs: migration from metro

### DIFF
--- a/website/src/latest/docs/getting-started/_meta.json
+++ b/website/src/latest/docs/getting-started/_meta.json
@@ -1,7 +1,1 @@
-[
-  "introduction",
-  "quick-start",
-  "manual-installation",
-  "microfrontends",
-  "bundlers"
-]
+["introduction", "quick-start", "microfrontends", "bundlers"]

--- a/website/src/latest/docs/getting-started/quick-start.mdx
+++ b/website/src/latest/docs/getting-started/quick-start.mdx
@@ -20,7 +20,7 @@ To create a new React Native project with Re.Pack or adapt an existing one:
   bun: "bunx @callstack/repack-init",
 }} />
 
-In case the command above didn't work for any reason, you can follow the manual installation steps [here](/docs/getting-started/manual-installation).
+In case the command above didn't work for any reason, you can follow the manual migration guide [here](/docs/migration-guides/metro).
 
 :::tip
 The default configuration works for most projects, but if you need custom settings (like additional loaders or plugins), check out our [configuration guide](/docs/guides/configuration).
@@ -49,7 +49,7 @@ To learn about `start` command, check out the [`start`](/api/cli/start.mdx)'s co
 
 When building the release version of your application Re.Pack will bundle your application automatically if you either:
 - Used the automatic installation, or
-- Followed the manual installation steps for [Configure XCode](./manual-installation.mdx#4-configure-xcode) and [Configure Android](./manual-installation.mdx#5-configure-android)
+- Followed the manual migration guide for [configuring XCode](/docs/migration-guides/metro.mdx#4-configure-xcode) and [Configure Android](/docs/migration-guides/metro#5-configure-android)
 
 If you want to create bundle manually (development or production), **the recommended way is to use React Native Community CLI and run**:
 

--- a/website/src/latest/docs/getting-started/quick-start.mdx
+++ b/website/src/latest/docs/getting-started/quick-start.mdx
@@ -22,8 +22,8 @@ To create a new React Native project with Re.Pack or adapt an existing one:
 
 In case the command above didn't work for any reason, you can follow the manual migration guide [here](/docs/migration-guides/metro).
 
-:::tip
-The default configuration works for most projects, but if you need custom settings (like additional loaders or plugins), check out our [configuration guide](/docs/guides/configuration).
+:::tip title="The defaults work well for most projects"
+If you need custom settings (like additional loaders or plugins), check out our [configuration guide](/docs/guides/configuration).
 :::
 
 ## Usage
@@ -43,15 +43,11 @@ To start the development server, you can use React Native Community CLI and run:
   bun: "bun react-native start",
 }} />
 
-To learn about `start` command, check out the [`start`](/api/cli/start.mdx)'s command documentation.
+To learn about `start` command, check out the [start command documentation](/api/cli/start.mdx).
 
 ### Bundling the app
 
-When building the release version of your application Re.Pack will bundle your application automatically if you either:
-- Used the automatic installation, or
-- Followed the manual migration guide for [configuring XCode](/docs/migration-guides/metro.mdx#4-configure-xcode) and [Configure Android](/docs/migration-guides/metro#5-configure-android)
-
-If you want to create bundle manually (development or production), **the recommended way is to use React Native Community CLI and run**:
+When you are building the release version of your application, Re.Pack will be picked up automatically as the bundler. In case you want to create bundle manually, **the recommended way is to use React Native Community CLI** and run:
 
 <PackageManagerTabs command={{
   npm: "npm run react-native bundle",
@@ -60,11 +56,13 @@ If you want to create bundle manually (development or production), **the recomme
   bun: "bun react-native bundle",
 }} />
 
-To learn about `bundle` command, check out the [`bundle`](/api/cli/bundle.mdx)'s command documentation.
-<br />
-<b>🎉 Congratulations! You've successfully set up Re.Pack in your project. You can now:</b>
+To learn about `bundle` command, check out the [bundle command documentation](/api/cli/bundle.mdx).
 
-- Learn more about [Micro Frontends](/docs/getting-started/microfrontends)
-- Explore [Module Federation](/docs/features/module-federation)
-- Check out [Configuration Guide](/docs/guides/configuration)
-- Browse [API Reference](/api)
+:::tip title="🎉 Congratulations!"
+
+You've successfully set up Re.Pack in your project. We highly recommend to check out the following:
+
+- [Configuration Guide](/docs/guides/configuration) to learn how to configure Re.Pack to your project needs.
+- [API Reference](/api) to learn more about Re.Pack's API.
+
+:::

--- a/website/src/latest/docs/migration-guides/metro.md
+++ b/website/src/latest/docs/migration-guides/metro.md
@@ -1,7 +1,0 @@
-# Migrating from Metro
-
-:::warning title="Notice:"
-The documentation for Re.Pack 5 is currently under development and some of the pages aren't ready yet.
-
-Please use [latest stable version of Re.Pack 4.x documentation](https://re-pack.dev/docs/getting-started) for now.
-:::

--- a/website/src/latest/docs/migration-guides/metro.mdx
+++ b/website/src/latest/docs/migration-guides/metro.mdx
@@ -1,4 +1,9 @@
 import { PackageManagerTabs, Steps, Tabs, Tab } from 'rspress/theme';
+import { CodeBlock } from '@theme';
+import RspackCJSTemplate from '../../../../../templates_v5/rspack.config.cjs?raw';
+import RspackESMTemplate from '../../../../../templates_v5/rspack.config.mjs?raw';
+import WebpackCJSTemplate from '../../../../../templates_v5/webpack.config.cjs?raw';
+import WebpackESMTemplate from '../../../../../templates_v5/webpack.config.mjs?raw';
 
 # Migrating from Metro
 
@@ -47,18 +52,36 @@ This will allow you to use Re.Pack when running `react-native start` and `react-
 
 ### 3. Configuration
 
-<Tabs groupId="bundler">
-  <Tab label="Rspack" value="rspack">
-    Create file `rspack.config.mjs` in the root directory of your project and paste the content from our [Rspack config template](https://github.com/callstack/repack/blob/main/templates_v5/rspack.config.mjs).
+Pick one of the templates below and create configuration file in the root directory of your project. The name of the file should be identical to the one on top of the template e.g. `rspack.config.mjs`.
+
+<Tabs>
+  <Tab label="Rspack ESM">
+    <CodeBlock language="js" title="rspack.config.mjs">
+      {RspackESMTemplate}
+    </CodeBlock>
   </Tab>
-  <Tab label="Webpack" value="webpack">
-    Create file `webpack.config.mjs` in the root directory of your project and paste the content from our [Webpack config template](https://github.com/callstack/repack/blob/main/templates_v5/webpack.config.mjs).
+  <Tab label="Rspack CJS">
+    <CodeBlock language="js" title="rspack.config.cjs">
+      {RspackCJSTemplate}
+    </CodeBlock>
+  </Tab>
+  <Tab label="Webpack ESM">
+    <CodeBlock language="js" title="webpack.config.mjs">
+      {WebpackESMTemplate}
+    </CodeBlock>
+  </Tab>
+  <Tab label="Webpack CJS">
+    <CodeBlock language="js" title="webpack.config.cjs">
+      {WebpackCJSTemplate}
+    </CodeBlock>
   </Tab>
 </Tabs>
 
+
+
 :::info
 
-We recommend to use ESM version of Webpack config with the `.mjs` extension. However, Re.Pack also supports ESM under `.js` and CJS variant under `.js` and `.cjs` extensions. Check our [templates](https://github.com/callstack/repack/blob/main/templates_v5/) for CJS and ESM variants as well as the documentation on [Configuration](/docs/guides/configuration) to see the list of all available Webpack config location and extensions.
+We recommend to use ESM version of Rspack/webpack config with the `.mjs` extension. However, Re.Pack also supports ESM under `.js` and CJS variant under `.js` and `.cjs` extensions. Check our [templates](https://github.com/callstack/repack/blob/main/templates_v5/) for CJS and ESM variants as well as the documentation on [Configuration](/docs/guides/configuration) to see the list of all available Rspack/webpack config location and extensions.
 
 :::
 

--- a/website/src/latest/docs/migration-guides/metro.mdx
+++ b/website/src/latest/docs/migration-guides/metro.mdx
@@ -79,7 +79,7 @@ Pick one of the templates below and create configuration file in the root direct
 
 
 
-:::info
+:::info title="Go with ESM config by default"
 
 We recommend to use ESM version of Rspack/webpack config with the `.mjs` extension. However, Re.Pack also supports ESM under `.js` and CJS variant under `.js` and `.cjs` extensions. Check our [templates](https://github.com/callstack/repack/blob/main/templates_v5/) for CJS and ESM variants as well as the documentation on [Configuration](/docs/guides/configuration) to see the list of all available Rspack/webpack config location and extensions.
 

--- a/website/src/latest/docs/migration-guides/metro.mdx
+++ b/website/src/latest/docs/migration-guides/metro.mdx
@@ -1,8 +1,9 @@
 import { PackageManagerTabs, Steps, Tabs, Tab } from 'rspress/theme';
 
-# Manual installation
+# Migrating from Metro
 
-If the [automatic installation](/docs/getting-started/quick-start) didn't work for any reason, or if you have custom project structure, you can follow these manual installation steps:
+If the automatic migration using `@callstack/repack-init` didn't work for any reason, 
+or if you have custom project structure, you can follow these manual migration steps:
 
 ### 1. Dependencies
 
@@ -113,9 +114,11 @@ npx pod-install
 
 This will install all the necessary iOS dependencies for your project, including the Re.Pack native module.
 
-<b>🎉 Congratulations! You've successfully set up Re.Pack in your project. You can now:</b>
+:::tip title="🎉 Congratulations!"
 
-- Learn more about [Micro Frontends](/docs/getting-started/microfrontends)
-- Explore [Module Federation](/docs/features/module-federation)
-- Check out [Configuration Guide](/docs/guides/configuration)
-- Browse [API Reference](/api)
+You've successfully set up Re.Pack in your project. We highly recommend to check out the following:
+
+- [Configuration Guide](/docs/guides/configuration) to learn how to configure Re.Pack to your project needs.
+- [API Reference](/api) to learn more about Re.Pack's API.
+
+:::


### PR DESCRIPTION
### Summary

Closes https://github.com/callstack/repack/issues/929

moved manual installation and named it `migration from metro` and reworked it slightly

### Test plan

n/a
