### PR TITLE
feat(init): use gradient in welcome message

### DIFF
--- a/.changeset/tiny-doors-hug.md
+++ b/.changeset/tiny-doors-hug.md
@@ -1,0 +1,5 @@
+---
+"@callstack/repack-init": patch
+---
+
+Use gradient in welcome message

--- a/packages/init/src/tasks/welcomeMessage.ts
+++ b/packages/init/src/tasks/welcomeMessage.ts
@@ -1,14 +1,18 @@
-import { intro } from '@clack/prompts';
-import chalk from 'chalk';
+import { log } from '@clack/prompts';
+import dedent from 'dedent';
 import gradient from 'gradient-string';
 
+const logo = dedent`
+  ▄▀▀▀ ▀▀▀▀   █▀▀█ █▀▀█ ▄▀▀▀ █  █
+  █    ▀▀▀▀   █▀▀▀ █▀▀█ █    █▀▀▄
+  ▀    ▀▀▀▀ ▀ ▀    ▀  ▀  ▀▀▀ ▀  ▀
+`;
+
 export default function welcomeMessage() {
-  intro(
-    chalk.bold(
-      gradient([
-        { color: '#9b6dff', pos: 0.45 },
-        { color: '#3ce4cb', pos: 0.9 },
-      ])('RE.PACK INIT')
-    )
+  log.message(
+    gradient([
+      { color: '#9b6dff', pos: 0.45 },
+      { color: '#3ce4cb', pos: 0.9 },
+    ]).multiline(logo)
   );
 }


### PR DESCRIPTION
### Summary

replaced `REPACK INIT` with the same logo that we use in dev server

<img width="421" alt="image" src="https://github.com/user-attachments/assets/6828a3d6-212f-41cb-922a-cfd48bdbc89c" />


### Test plan

n/a
