### PR TITLE
docs: remove repeated deployment from quick start

### DIFF
--- a/website/src/latest/docs/getting-started/quick-start.mdx
+++ b/website/src/latest/docs/getting-started/quick-start.mdx
@@ -64,19 +64,6 @@ You've successfully set up Re.Pack in your project. We highly recommend to check
 
 - [Configuration Guide](/docs/guides/configuration) to learn how to configure Re.Pack to your project needs.
 - [API Reference](/api/) to learn more about Re.Pack's API.
+- [Deployment of MiniApps](/docs/guides/deploy) to learn how to deploy your federated MiniApps with Zephyr Cloud.
 
-:::
-
-
-### Deploy the app 
-
-To [deploy the application with MiniApps](/docs/guides/deploy), you can wrap the build configuration with Zephyr Cloud's `zephyr-repack-plugin` plugin. 
-
-:::tip title="Learn more about Zephyr Cloud"
-
-- [Website](https://zephyr-cloud.io)
-- [Documentation](https://docs.zephyr-cloud.io)
-- [Discord](https://zephyr-cloud.io/discord)
-- [Twitter](https://zephyr-cloud.io/twitter)
-- [YouTube](https://zephyr-cloud.io/youtube)
 :::


### PR DESCRIPTION
### Summary

removed deployment from quick start to keep it simpler while still mentioning the Deployment page in the the bottom tip block

### Test plan

n/a
