### PR TITLE
fix: normalize carefully with `webpack-merge`

### DIFF
--- a/.changeset/cool-bats-peel.md
+++ b/.changeset/cool-bats-peel.md
@@ -1,0 +1,5 @@
+---
+"@callstack/repack": patch
+---
+
+Fix an issue where normalizing config would override a field on object from other config


### PR DESCRIPTION
### Summary

we only do a shallow copy of config object in `makeCompilerConfig` and editing nested props like `config.output.path` would result in overwriting the `path` field on the same object (because of a shallow copy) - we can't make deep copy because configs might contain non-serializable fields like functions so in this PR, I've fixed the normalisation logic by collecting properties to normalise first and making a config object out of them and then using `webpack-merge` to merge the config with the one with normalised values.

### Test plan

- [x] - tests pass
- [x] - testers work
