### PR TITLE
fix: normalizeConfig resolve.extension merging

### DIFF
--- a/.changeset/old-cooks-joke.md
+++ b/.changeset/old-cooks-joke.md
@@ -2,4 +2,4 @@
 "@callstack/repack": patch
 ---
 
-Fix normalization of resolve.extensions with [platform] placeholder
+Fix normalization of resolve.extensions with [platform] placeholder & set publicPath to noop explicitly when using deprecated getPublicPath helper function

--- a/.changeset/old-cooks-joke.md
+++ b/.changeset/old-cooks-joke.md
@@ -1,0 +1,5 @@
+---
+"@callstack/repack": patch
+---
+
+Fix normalization of resolve.extensions with [platform] placeholder

--- a/packages/repack/src/commands/common/config/__tests__/normalizeConfig.test.ts
+++ b/packages/repack/src/commands/common/config/__tests__/normalizeConfig.test.ts
@@ -46,32 +46,28 @@ describe('normalizeConfig', () => {
     it('should replace [context] and [platform] placeholders', () => {
       const config = {
         context: '/project',
-        output: {
-          path: '/build/[context]/[platform]',
-        },
+        output: { path: '[context]/build/[platform]' },
       } as ConfigurationObject;
       const normalized = normalizeConfig(config, 'android');
-      expect(normalized.output?.path).toBe('/build/project/android');
+      expect(normalized.output?.path).toBe('/project/build/android');
     });
 
     it('should use process.cwd() when context is not provided', () => {
       const config = {
-        output: {
-          path: '/build/[context]/[platform]',
-        },
+        output: { path: '[context]/build/[platform]' },
       } as ConfigurationObject;
       const normalized = normalizeConfig(config, 'ios');
-      expect(normalized.output?.path).toBe(`/build/${process.cwd()}/ios`);
+      expect(normalized.output?.path).toBe(`${process.cwd()}/build/ios`);
     });
   });
 
   describe('output.publicPath normalization', () => {
-    it('should unset publicPath if it uses deprecated getPublicPath', () => {
+    it('should set publicPath to noop if it uses deprecated getPublicPath', () => {
       const config = {
         output: { publicPath: 'DEPRECATED_GET_PUBLIC_PATH' },
       } as ConfigurationObject;
       const normalized = normalizeConfig(config, 'ios');
-      expect(normalized.output?.publicPath).toBeUndefined();
+      expect(normalized.output?.publicPath).toBe('noop:///');
     });
 
     it('should keep custom publicPath unchanged', () => {

--- a/packages/repack/src/commands/common/config/__tests__/normalizeConfig.test.ts
+++ b/packages/repack/src/commands/common/config/__tests__/normalizeConfig.test.ts
@@ -1,0 +1,124 @@
+import type { ConfigurationObject } from '../../../types.js';
+import { normalizeConfig } from '../normalizeConfig.js';
+
+describe('normalizeConfig', () => {
+  it('should normalize compiler name to platform', () => {
+    const config = {} as ConfigurationObject;
+    const normalized = normalizeConfig(config, 'ios');
+    expect(normalized.name).toBe('ios');
+  });
+
+  describe('devServer.host normalization', () => {
+    it('should normalize local-ip to localhost', () => {
+      const config = {
+        devServer: { host: 'local-ip' },
+      } as ConfigurationObject;
+      const normalized = normalizeConfig(config, 'ios');
+      expect(normalized.devServer?.host).toBe('localhost');
+    });
+
+    it('should normalize local-ipv4 to 127.0.0.1', () => {
+      const config = {
+        devServer: { host: 'local-ipv4' },
+      } as ConfigurationObject;
+      const normalized = normalizeConfig(config, 'ios');
+      expect(normalized.devServer?.host).toBe('127.0.0.1');
+    });
+
+    it('should normalize local-ipv6 to ::1', () => {
+      const config = {
+        devServer: { host: 'local-ipv6' },
+      } as ConfigurationObject;
+      const normalized = normalizeConfig(config, 'ios');
+      expect(normalized.devServer?.host).toBe('::1');
+    });
+
+    it('should keep custom host unchanged', () => {
+      const config = {
+        devServer: { host: '192.168.1.1' },
+      } as ConfigurationObject;
+      const normalized = normalizeConfig(config, 'ios');
+      expect(normalized.devServer?.host).toBe('192.168.1.1');
+    });
+  });
+
+  describe('output.path normalization', () => {
+    it('should replace [context] and [platform] placeholders', () => {
+      const config = {
+        context: '/project',
+        output: {
+          path: '/build/[context]/[platform]',
+        },
+      } as ConfigurationObject;
+      const normalized = normalizeConfig(config, 'android');
+      expect(normalized.output?.path).toBe('/build/project/android');
+    });
+
+    it('should use process.cwd() when context is not provided', () => {
+      const config = {
+        output: {
+          path: '/build/[context]/[platform]',
+        },
+      } as ConfigurationObject;
+      const normalized = normalizeConfig(config, 'ios');
+      expect(normalized.output?.path).toBe(`/build/${process.cwd()}/ios`);
+    });
+  });
+
+  describe('output.publicPath normalization', () => {
+    it('should unset publicPath if it uses deprecated getPublicPath', () => {
+      const config = {
+        output: {
+          publicPath: 'DEPRECATED_GET_PUBLIC_PATH',
+        },
+      } as ConfigurationObject;
+      const normalized = normalizeConfig(config, 'ios');
+      expect(normalized.output?.publicPath).toBeUndefined();
+    });
+
+    it('should keep custom publicPath unchanged', () => {
+      const config = {
+        output: {
+          publicPath: 'http://localhost:8081',
+        },
+      } as ConfigurationObject;
+      const normalized = normalizeConfig(config, 'ios');
+      expect(normalized.output?.publicPath).toBe('http://localhost:8081');
+    });
+  });
+
+  describe('resolve.extensions normalization', () => {
+    it('should replace [platform] in extensions', () => {
+      const config = {
+        resolve: {
+          extensions: ['.js', '.[platform].js', '.native.js'],
+        },
+      } as ConfigurationObject;
+      const normalized = normalizeConfig(config, 'ios');
+      expect(normalized.resolve?.extensions).toEqual([
+        '.js',
+        '.ios.js',
+        '.native.js',
+      ]);
+    });
+
+    it('should override instead of merge extensions arrays', () => {
+      const config = {
+        resolve: {
+          extensions: ['.js', '.[platform].js'],
+        },
+      } as ConfigurationObject;
+      const normalized = normalizeConfig(
+        {
+          ...config,
+          resolve: {
+            ...config.resolve,
+            extensions: ['.ts', '.[platform].ts'],
+          },
+        },
+        'android'
+      );
+      expect(normalized.resolve?.extensions).toEqual(['.ts', '.android.ts']);
+    });
+  });
+});

--- a/packages/repack/src/commands/common/config/__tests__/normalizeConfig.test.ts
+++ b/packages/repack/src/commands/common/config/__tests__/normalizeConfig.test.ts
@@ -68,9 +68,7 @@ describe('normalizeConfig', () => {
   describe('output.publicPath normalization', () => {
     it('should unset publicPath if it uses deprecated getPublicPath', () => {
       const config = {
-        output: {
-          publicPath: 'DEPRECATED_GET_PUBLIC_PATH',
-        },
+        output: { publicPath: 'DEPRECATED_GET_PUBLIC_PATH' },
       } as ConfigurationObject;
       const normalized = normalizeConfig(config, 'ios');
       expect(normalized.output?.publicPath).toBeUndefined();
@@ -78,9 +76,7 @@ describe('normalizeConfig', () => {
 
     it('should keep custom publicPath unchanged', () => {
       const config = {
-        output: {
-          publicPath: 'http://localhost:8081',
-        },
+        output: { publicPath: 'http://localhost:8081' },
       } as ConfigurationObject;
       const normalized = normalizeConfig(config, 'ios');
       expect(normalized.output?.publicPath).toBe('http://localhost:8081');
@@ -90,9 +86,7 @@ describe('normalizeConfig', () => {
   describe('resolve.extensions normalization', () => {
     it('should replace [platform] in extensions', () => {
       const config = {
-        resolve: {
-          extensions: ['.js', '.[platform].js', '.native.js'],
-        },
+        resolve: { extensions: ['.js', '.[platform].js', '.native.js'] },
       } as ConfigurationObject;
       const normalized = normalizeConfig(config, 'ios');
       expect(normalized.resolve?.extensions).toEqual([
@@ -104,9 +98,7 @@ describe('normalizeConfig', () => {
 
     it('should override instead of merge extensions arrays', () => {
       const config = {
-        resolve: {
-          extensions: ['.js', '.[platform].js'],
-        },
+        resolve: { extensions: ['.js', '.[platform].js'] },
       } as ConfigurationObject;
       const normalized = normalizeConfig(
         {

--- a/packages/repack/src/commands/common/config/normalizeConfig.ts
+++ b/packages/repack/src/commands/common/config/normalizeConfig.ts
@@ -1,4 +1,4 @@
-import merge from 'webpack-merge';
+import { mergeWithCustomize } from 'webpack-merge';
 import type { ConfigurationObject } from '../../types.js';
 
 function normalizeDevServerHost(host?: string): string | undefined {
@@ -80,5 +80,14 @@ export function normalizeConfig<C extends ConfigurationObject>(
   }
 
   /* return the normalized config object */
-  return merge(config, normalizedConfig);
+  return mergeWithCustomize({
+    customizeArray(_, array2: unknown[], key: string) {
+      // override resolve.extensions instead of merging
+      if (key === 'resolve.extensions') {
+        return array2;
+      }
+      // use default strategy for anything else
+      return undefined;
+    },
+  })(config, normalizedConfig) as C;
 }

--- a/packages/repack/src/commands/common/config/normalizeConfig.ts
+++ b/packages/repack/src/commands/common/config/normalizeConfig.ts
@@ -1,4 +1,4 @@
-import { mergeWithCustomize } from 'webpack-merge';
+import { customizeArray, mergeWithCustomize } from 'webpack-merge';
 import type { ConfigurationObject } from '../../types.js';
 
 function normalizeDevServerHost(host?: string): string | undefined {
@@ -60,11 +60,11 @@ export function normalizeConfig<C extends ConfigurationObject>(
     };
   }
 
-  /* unset public path if it's using the deprecated `getPublicPath` function */
+  /* set public path to noop if it's using the deprecated `getPublicPath` function */
   if (config.output?.publicPath === 'DEPRECATED_GET_PUBLIC_PATH') {
     normalizedConfig.output = {
       ...normalizedConfig.output,
-      publicPath: undefined,
+      publicPath: 'noop:///',
     };
   }
 
@@ -81,13 +81,8 @@ export function normalizeConfig<C extends ConfigurationObject>(
 
   /* return the normalized config object */
   return mergeWithCustomize({
-    customizeArray(_, array2: unknown[], key: string) {
-      // override resolve.extensions instead of merging
-      if (key === 'resolve.extensions') {
-        return array2;
-      }
-      // use default strategy for anything else
-      return undefined;
-    },
+    customizeArray: customizeArray({
+      'resolve.extensions': 'replace',
+    }),
   })(config, normalizedConfig) as C;
 }


### PR DESCRIPTION
### Summary

- [x] - fixed how `resolve.extensions` is normalized - before the arrays would get merged and would result in extensions like `[platform].js` being present in final config where they should be replaced with `android.js` or `ios.js`.
- [x] - fixed `output.publicPath` unsetting behaviour - we can't really unset that way with `webpack-merge` so instead we set it explicitly to `noop:///` if it's equal to `DEPRECATED_GET_PUBLIC_PATH`
- [x] - added tests for the `normalizeConfig`

### Test plan

- [x] - tests pass
- [x] - testers work
