### PR TITLE
fix: remove enforcement of output filenames in dev

### DIFF
--- a/.changeset/good-apes-grab.md
+++ b/.changeset/good-apes-grab.md
@@ -1,0 +1,5 @@
+---
+"@callstack/repack": patch
+---
+
+Remove enforcement of output filenames in dev mode

--- a/packages/repack/src/plugins/DevelopmentPlugin.ts
+++ b/packages/repack/src/plugins/DevelopmentPlugin.ts
@@ -121,11 +121,6 @@ export class DevelopmentPlugin implements RspackPluginInstance {
     // set public path for development with dev server
     compiler.options.output.publicPath = `${protocol}://${host}:${port}/${platform}/`;
 
-    // enforce output filenames in development mode
-    compiler.options.output.filename = (pathData) =>
-      pathData.chunk?.name === 'main' ? 'index.bundle' : '[name].bundle';
-    compiler.options.output.chunkFilename = '[name].chunk.bundle';
-
     if (compiler.options.devServer.hot) {
       // setup HMR
       new compiler.webpack.HotModuleReplacementPlugin().apply(compiler);


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

After removing and testing in debug everything works the same way as before in TesterApp.

### Test plan

1. Open TesterApp, everything should work in the same way as before 👍
