### PR TITLE
fix(init): wrong project root dir when migrating with init

### DIFF
--- a/.changeset/tricky-bugs-film.md
+++ b/.changeset/tricky-bugs-film.md
@@ -1,0 +1,5 @@
+---
+"@callstack/repack-init": patch
+---
+
+Fix init picking up wrong root directory when migrating existing projects

--- a/packages/init/src/index.ts
+++ b/packages/init/src/index.ts
@@ -54,23 +54,23 @@ export default async function run(options: Options) {
       );
     }
 
-    const rootDir = path.join(cwd, projectName!);
+    const projectRootDir = projectExists ? cwd : path.join(cwd, projectName!);
 
-    await modifyDependencies(bundler, rootDir, options.repackVersion);
+    await modifyDependencies(bundler, projectRootDir, options.repackVersion);
 
     await createBundlerConfig(
       bundler,
-      rootDir,
+      projectRootDir,
       options.templateType,
       options.entry
     );
 
-    modifyReactNativeConfig(bundler, rootDir);
+    modifyReactNativeConfig(bundler, projectRootDir);
 
-    modifyIOS(rootDir);
+    modifyIOS(projectRootDir);
 
     if (!projectExists) {
-      await setupGit(rootDir);
+      await setupGit(projectRootDir);
     }
 
     spinner.stop('Setup complete.');


### PR DESCRIPTION
### Summary

- [x] - fixes the issue where migrating existing project would fail because wrong root dir would be picked by `repack-init`

### Test plan

- [x] - migration with init works locally  
