### PR TITLE
fix: prevent emitting unused container bundles in development

### DIFF
--- a/.changeset/breezy-garlics-shop.md
+++ b/.changeset/breezy-garlics-shop.md
@@ -1,0 +1,5 @@
+---
+"@callstack/repack": patch
+---
+
+Fix emitting to the same file when developing a host-type app with module-federation

--- a/packages/repack/src/plugins/DevelopmentPlugin.ts
+++ b/packages/repack/src/plugins/DevelopmentPlugin.ts
@@ -62,16 +62,16 @@ export class DevelopmentPlugin implements RspackPluginInstance {
       }
 
       // repack MF plugins expose config property
-      if ('config' in plugin) {
+      if ('config' in plugin && !!plugin.config.exposes) {
         return plugin.config.name;
       }
 
       // official MF plugins expose _options property
-      if ('_options' in plugin) {
+      if ('_options' in plugin && !!plugin.config.exposes) {
         return plugin._options.name;
       }
 
-      return null;
+      return;
     });
 
     return entrypoints.filter(Boolean);


### PR DESCRIPTION
### Summary

prevent an issue in development like below:

![image](https://github.com/user-attachments/assets/3800f677-2697-4038-b9f5-614d38a5571e)

this was caused because even though there was no container bundle being emitted, we were adjusting it entries, which caused it to be actually emitted which should not happen in the first place

### Test plan

- [x] - federation testers work
