### PR TITLE
fix: hide javascript logs have moved message

### DIFF
--- a/.changeset/light-students-lay.md
+++ b/.changeset/light-students-lay.md
@@ -1,0 +1,6 @@
+---
+"@callstack/repack-dev-server": patch
+"@callstack/repack": patch
+---
+
+Hide "JavaScriptLogs have moved..." message

--- a/packages/dev-server/src/createServer.ts
+++ b/packages/dev-server/src/createServer.ts
@@ -65,10 +65,25 @@ export async function createServer(config: Server.Config) {
     },
   });
 
+  let handledDevMiddlewareNotice = false;
+
   const devMiddleware = createDevMiddleware({
     projectRoot: options.rootDir,
     serverBaseUrl: options.url,
-    logger: instance.log,
+    logger: {
+      ...instance.log,
+      info: (...message) => {
+        if (!handledDevMiddlewareNotice) {
+          if (message.join().includes('JavaScript logs have moved!')) {
+            handledDevMiddlewareNotice = true;
+            return;
+          }
+        } else {
+          instance.log.info(message);
+          return;
+        }
+      },
+    },
     unstable_experiments: {
       // @ts-expect-error removed in 0.76, keep this for backkwards compatibility
       enableNewDebugger: true,

--- a/packages/dev-server/src/createServer.ts
+++ b/packages/dev-server/src/createServer.ts
@@ -71,7 +71,8 @@ export async function createServer(config: Server.Config) {
     projectRoot: options.rootDir,
     serverBaseUrl: options.url,
     logger: {
-      ...instance.log,
+      error: instance.log.error,
+      warn: instance.log.warn,
       info: (...message) => {
         if (!handledDevMiddlewareNotice) {
           if (message.join().includes('JavaScript logs have moved!')) {


### PR DESCRIPTION
### Summary

Since we are not hiding runtime client logs in the dev server output so this message was irrelevant and confusing to the users.

### Test plan

- [x] - message no longer visible in testers