### PR TITLE
fix: mf2 remote resolution with manifest

### DIFF
--- a/packages/repack/src/modules/FederationRuntimePlugins/ResolverPlugin.ts
+++ b/packages/repack/src/modules/FederationRuntimePlugins/ResolverPlugin.ts
@@ -20,18 +20,18 @@ const createScriptLocator = async (
 };
 
 const getPublicPath = (url: string) => {
-  return url.split('/').slice(0, -1).join('/');
+  const [protocol, rest] = url.split('://');
+  return protocol + '://' + rest.split('/')[0];
 };
 
-const getAssetPath = (url: string, path = '') => {
-  const separator = path ? path : getPublicPath(url);
-  const assetPath = path + url.split(separator)[1];
+const getAssetPath = (url: string) => {
+  const assetPath = url.split(getPublicPath(url))[1];
   // normalize by removing leading slash
   return assetPath.startsWith('/') ? assetPath.slice(1) : assetPath;
 };
 
-const rebaseRemoteUrl = (from: string, to: string, path?: string) => {
-  const assetPath = getAssetPath(from, path);
+const rebaseRemoteUrl = (from: string, to: string) => {
+  const assetPath = getAssetPath(from);
   const publicPath = getPublicPath(to);
   return [publicPath, assetPath].join('/');
 };
@@ -57,7 +57,7 @@ const RepackResolverPlugin: (
             throw new Error('[RepackResolverPlugin] Reference URL is missing');
           }
 
-          const url = rebaseRemoteUrl(referenceUrl, entryUrl, scriptId);
+          const url = rebaseRemoteUrl(referenceUrl, entryUrl);
           const locator = await createScriptLocator(url, config);
           return locator;
         }

--- a/packages/repack/src/modules/FederationRuntimePlugins/ResolverPlugin.ts
+++ b/packages/repack/src/modules/FederationRuntimePlugins/ResolverPlugin.ts
@@ -19,33 +19,50 @@ const createScriptLocator = async (
   return { url: entryUrl };
 };
 
+const getPublicPath = (url: string) => {
+  return url.split('/').slice(0, -1).join('/');
+};
+
+const getAssetPath = (url: string, path = '') => {
+  const separator = path ? path : getPublicPath(url);
+  const assetPath = path + url.split(separator)[1];
+  // normalize by removing leading slash
+  return assetPath.startsWith('/') ? assetPath.slice(1) : assetPath;
+};
+
+const rebaseRemoteUrl = (from: string, to: string, path?: string) => {
+  const assetPath = getAssetPath(from, path);
+  const publicPath = getPublicPath(to);
+  return [publicPath, assetPath].join('/');
+};
+
 const RepackResolverPlugin: (
   config?: RepackResolverPluginConfiguration
 ) => FederationRuntimePlugin = (config) => ({
   name: 'repack-resolver-plugin',
   afterResolve(args) {
+    const { remoteInfo } = args;
     const { ScriptManager } =
       require('../ScriptManager/index.js') as typeof RepackClient;
-    const { remoteInfo } = args;
+
+    // when manifest is used, the valid entry URL comes from the version field
+    // otherwise, the entry URL comes from the entry field which has the correct publicPath for the remote set
+    const entryUrl = remoteInfo.version ?? remoteInfo.entry;
 
     ScriptManager.shared.addResolver(
       async (scriptId, caller, referenceUrl) => {
-        // entry container
-        if (scriptId === remoteInfo.entryGlobalName) {
-          const locator = await createScriptLocator(remoteInfo.entry, config);
-          return locator;
-        }
-        // entry chunks
-        if (referenceUrl && caller === remoteInfo.entryGlobalName) {
-          const publicPath = remoteInfo.entry.split('/').slice(0, -1).join('/');
-          const bundlePath = scriptId + referenceUrl.split(scriptId)[1];
-          const url = publicPath + '/' + bundlePath;
+        if (scriptId === remoteInfo.name || caller === remoteInfo.name) {
+          // referenceUrl should always be present and this should never happen
+          if (!referenceUrl) {
+            throw new Error('[RepackResolverPlugin] Reference URL is missing');
+          }
 
+          const url = rebaseRemoteUrl(referenceUrl, entryUrl, scriptId);
           const locator = await createScriptLocator(url, config);
           return locator;
         }
       },
-      { key: remoteInfo.entryGlobalName }
+      { key: remoteInfo.name }
     );
 
     return args;

--- a/packages/repack/src/modules/FederationRuntimePlugins/__tests__/ResolverPlugin.test.ts
+++ b/packages/repack/src/modules/FederationRuntimePlugins/__tests__/ResolverPlugin.test.ts
@@ -1,0 +1,226 @@
+import {
+  type ScriptLocator,
+  ScriptManager,
+} from '../../ScriptManager/index.js';
+import RepackResolverPlugin from '../ResolverPlugin.js';
+
+jest.mock('../../ScriptManager/NativeScriptManager.js', () => ({
+  loadScript: jest.fn(),
+  prefetchScript: jest.fn(),
+  invalidateScripts: jest.fn(),
+  NormalizedScriptLocatorHTTPMethod: {
+    GET: 'GET',
+    POST: 'POST',
+  },
+  NormalizedScriptLocatorSignatureVerificationMode: {
+    STRICT: 'strict',
+    LAX: 'lax',
+    OFF: 'off',
+  },
+}));
+
+// Mock the global webpack context for testing
+(global as any).__webpack_require__ = {
+  repack: {
+    shared: {},
+    u: (id: string) => `${id}.chunk.bundle`,
+    p: 'http://localhost:8081/',
+  },
+};
+
+describe('RepackResolverPlugin', () => {
+  beforeEach(() => {
+    // Reset ScriptManager before each test
+    ScriptManager.init();
+
+    // Clear all resolvers
+    ScriptManager.shared.removeAllResolvers();
+  });
+
+  it('should accept object configuration', () => {
+    // Use a valid ScriptLocator property
+    const config = { headers: { Authorization: 'Bearer token' } };
+    const plugin = RepackResolverPlugin(config);
+    expect(plugin.name).toBe('repack-resolver-plugin');
+    expect(typeof plugin.afterResolve).toBe('function');
+  });
+
+  it('should accept function configuration', () => {
+    const config = async (url: string): Promise<ScriptLocator> => ({
+      url,
+      headers: { Authorization: 'Bearer token' },
+    });
+    const plugin = RepackResolverPlugin(config);
+    expect(plugin.name).toBe('repack-resolver-plugin');
+    expect(typeof plugin.afterResolve).toBe('function');
+  });
+
+  describe('integration tests', () => {
+    const mockRemoteInfo = {
+      name: 'remote1',
+      entry: 'https://example.com/remote1/entry.container.js.bundle',
+      version: 'https://example.com/remote1/mf-manifest.json',
+    };
+
+    it('should resolve a script using version URL when available', async () => {
+      // Create and apply the plugin
+      const plugin = RepackResolverPlugin();
+      // Trigger the plugin to register the resolver
+      plugin.afterResolve!({ remoteInfo: mockRemoteInfo } as any);
+
+      // Now use ScriptManager to resolve a script from the remote
+      const script = await ScriptManager.shared.resolveScript(
+        'remote1',
+        'remote1',
+        (global as any).__webpack_require__,
+        'https://example.com/remote1/asset.js'
+      );
+
+      // Verify the script was resolved with the correct URL
+      expect(script.locator.url).toBe('https://example.com/remote1/asset.js');
+      expect(script.locator.fetch).toBe(true);
+    });
+
+    it('should resolve a script using entry URL when version is not available', async () => {
+      const plugin = RepackResolverPlugin();
+
+      plugin.afterResolve!({
+        remoteInfo: { ...mockRemoteInfo, version: undefined },
+      } as any);
+
+      // Now use ScriptManager to resolve a script from the remote
+      const script = await ScriptManager.shared.resolveScript(
+        'remote1',
+        'remote1',
+        (global as any).__webpack_require__,
+        'https://example.com/remote1/asset.js'
+      );
+
+      // Verify the script was resolved with the correct URL
+      expect(script.locator.url).toBe('https://example.com/remote1/asset.js');
+      expect(script.locator.fetch).toBe(true);
+    });
+
+    it('should apply object configuration to script locator', async () => {
+      const config = { headers: { Authorization: 'Bearer token' } };
+      const plugin = RepackResolverPlugin(config);
+      // Trigger the plugin to register the resolver
+      plugin.afterResolve!({ remoteInfo: mockRemoteInfo } as any);
+
+      // Now use ScriptManager to resolve a script from the remote
+      const script = await ScriptManager.shared.resolveScript(
+        'remote1',
+        'remote1',
+        (global as any).__webpack_require__,
+        'https://example.com/remote1/asset.js'
+      );
+
+      // Verify the script was resolved with the correct headers
+      expect(script.locator.headers).toEqual({ authorization: 'Bearer token' });
+    });
+
+    it('should apply function configuration to script locator', async () => {
+      const config = async (url: string): Promise<ScriptLocator> => ({
+        url,
+        headers: { Authorization: 'Bearer token' },
+      });
+      const plugin = RepackResolverPlugin(config);
+      // Trigger the plugin to register the resolver
+      plugin.afterResolve!({ remoteInfo: mockRemoteInfo } as any);
+
+      // Now use ScriptManager to resolve a script from the remote
+      const script = await ScriptManager.shared.resolveScript(
+        'remote1',
+        'remote1',
+        (global as any).__webpack_require__,
+        'https://example.com/remote1/asset.js'
+      );
+
+      // Verify the script was resolved with the correct headers
+      expect(script.locator.headers).toEqual({ authorization: 'Bearer token' });
+    });
+
+    it('should throw error when reference URL is missing', async () => {
+      const plugin = RepackResolverPlugin();
+      // Trigger the plugin to register the resolver
+      plugin.afterResolve!({ remoteInfo: mockRemoteInfo } as any);
+
+      // Now try to resolve a script without a reference URL
+      await expect(
+        ScriptManager.shared.resolveScript(
+          'remote1',
+          'remote1',
+          (global as any).__webpack_require__
+        )
+      ).rejects.toThrow();
+    });
+
+    it('should properly rebase URLs with custom configuration', async () => {
+      // Create and apply the plugin with custom configuration
+      const config = { headers: { Authorization: 'Bearer token' } };
+      const plugin = RepackResolverPlugin(config);
+      // Trigger the plugin to register the resolver
+      plugin.afterResolve!({ remoteInfo: mockRemoteInfo } as any);
+
+      // Now use ScriptManager to resolve a script from the remote with a nested path
+      const script = await ScriptManager.shared.resolveScript(
+        'remote1',
+        'remote1',
+        (global as any).__webpack_require__,
+        'https://example.com/remote1/assets/nested/chunk1.js'
+      );
+
+      // Verify the script was resolved with the correct URL and headers
+      expect(script.locator.url).toBe(
+        'https://example.com/remote1/assets/nested/chunk1.js'
+      );
+      expect(script.locator.headers).toEqual({ authorization: 'Bearer token' });
+      expect(script.locator.fetch).toBe(true);
+    });
+
+    it('should not resolve scripts for other remotes', async () => {
+      // Add a default resolver to handle other remotes
+      const defaultResolverMock = jest.fn().mockResolvedValue({
+        url: 'http://default.com/script.js',
+      });
+
+      ScriptManager.shared.addResolver(defaultResolverMock);
+
+      // Create and apply the plugin
+      const plugin = RepackResolverPlugin();
+      // Trigger the plugin to register the resolver
+      plugin.afterResolve!({ remoteInfo: mockRemoteInfo } as any);
+
+      // Now try to resolve a script for a different remote
+      await ScriptManager.shared.resolveScript(
+        'other-remote',
+        'other-remote',
+        (global as any).__webpack_require__,
+        'https://example.com/other-remote/asset.js'
+      );
+
+      // Verify the default resolver was called
+      expect(defaultResolverMock).toHaveBeenCalled();
+    });
+
+    it('should rebase the URL correctly', async () => {
+      // Create and apply the plugin
+      const plugin = RepackResolverPlugin();
+      // Trigger the plugin to register the resolver
+      plugin.afterResolve!({ remoteInfo: mockRemoteInfo } as any);
+
+      // Now use ScriptManager to resolve a script with a different path
+      const script = await ScriptManager.shared.resolveScript(
+        'remote1',
+        'remote1',
+        (global as any).__webpack_require__,
+        'https://example.com/remote1/subdir/asset.js'
+      );
+
+      // Verify the URL was rebased correctly
+      expect(script.locator.url).toBe(
+        'https://example.com/remote1/subdir/asset.js'
+      );
+    });
+  });
+});

--- a/packages/repack/src/modules/FederationRuntimePlugins/__tests__/ResolverPlugin.test.ts
+++ b/packages/repack/src/modules/FederationRuntimePlugins/__tests__/ResolverPlugin.test.ts
@@ -44,9 +44,15 @@ describe('RepackResolverPlugin', () => {
 
     // Clear all resolvers
     ScriptManager.shared.removeAllResolvers();
+
+    // mock the error handler to disable polluting the console
+    // @ts-expect-error private method
+    ScriptManager.shared.handleError = () => {
+      throw new Error('mocked error');
+    };
   });
 
-  it('should resolve a script using version URL when available', async () => {
+  it('should resolve a script through a manifest', async () => {
     const plugin = RepackResolverPlugin();
     // trigger the plugin to register the resolver
     plugin.afterResolve!({ remoteInfo: mockRemoteInfo } as any);
@@ -64,7 +70,7 @@ describe('RepackResolverPlugin', () => {
     );
   });
 
-  it('should resolve a script using entry URL when version is not available', async () => {
+  it('should resolve a script through remote entry', async () => {
     const plugin = RepackResolverPlugin();
     // trigger the plugin to register the resolver
     plugin.afterResolve!({
@@ -82,7 +88,7 @@ describe('RepackResolverPlugin', () => {
     expect(script.locator.url).toBe('https://example-entry.com/remoteEntry.js');
   });
 
-  it('should apply object configuration to script locator', async () => {
+  it('should allow custom configuration when used in runtime with a config object', async () => {
     const config = { headers: { Authorization: 'Bearer token' } };
     const plugin = RepackResolverPlugin(config);
     // trigger the plugin to register the resolver
@@ -99,7 +105,7 @@ describe('RepackResolverPlugin', () => {
     expect(script.locator.headers).toEqual({ authorization: 'Bearer token' });
   });
 
-  it('should apply function configuration to script locator', async () => {
+  it('should allow custom configuration when used in runtime with a config function', async () => {
     const config = async (url: string): Promise<ScriptLocator> => ({
       url,
       headers: { Authorization: 'Bearer token' },
@@ -134,7 +140,7 @@ describe('RepackResolverPlugin', () => {
     ).rejects.toThrow();
   });
 
-  it('should properly rebase URLs with custom configuration', async () => {
+  it('should rebase URLs with custom configuration', async () => {
     const config = { headers: { Authorization: 'Bearer token' } };
     const plugin = RepackResolverPlugin(config);
     // trigger the plugin to register the resolver
@@ -174,7 +180,7 @@ describe('RepackResolverPlugin', () => {
     expect(script.locator.url).toBe('http://default.com/script.js');
   });
 
-  it('should rebase the URL correctly', async () => {
+  it('should rebase the URL from reference URL to entry URL', async () => {
     const plugin = RepackResolverPlugin();
     // trigger the plugin to register the resolver
     plugin.afterResolve!({ remoteInfo: mockRemoteInfo } as any);

--- a/packages/repack/src/modules/FederationRuntimePlugins/__tests__/ResolverPlugin.test.ts
+++ b/packages/repack/src/modules/FederationRuntimePlugins/__tests__/ResolverPlugin.test.ts
@@ -19,13 +19,22 @@ jest.mock('../../ScriptManager/NativeScriptManager.js', () => ({
   },
 }));
 
-// Mock the global webpack context for testing
-(global as any).__webpack_require__ = {
-  repack: {
-    shared: {},
-    u: (id: string) => `${id}.chunk.bundle`,
-    p: 'http://localhost:8081/',
-  },
+const webpackRequireMock = () => [];
+
+webpackRequireMock.i = [] as any[];
+webpackRequireMock.l = () => {};
+webpackRequireMock.u = (id: string) => `${id}.chunk.bundle`;
+webpackRequireMock.p = () => '';
+webpackRequireMock.repack = {
+  shared: { scriptManager: undefined },
+};
+
+globalThis.__webpack_require__ = webpackRequireMock;
+
+const mockRemoteInfo = {
+  name: 'remote1',
+  entry: 'https://example-entry.com/remote1/entry.container.js.bundle',
+  version: 'https://example-manifest.com/remote1/mf-manifest.json',
 };
 
 describe('RepackResolverPlugin', () => {
@@ -37,190 +46,149 @@ describe('RepackResolverPlugin', () => {
     ScriptManager.shared.removeAllResolvers();
   });
 
-  it('should accept object configuration', () => {
-    // Use a valid ScriptLocator property
-    const config = { headers: { Authorization: 'Bearer token' } };
-    const plugin = RepackResolverPlugin(config);
-    expect(plugin.name).toBe('repack-resolver-plugin');
-    expect(typeof plugin.afterResolve).toBe('function');
+  it('should resolve a script using version URL when available', async () => {
+    const plugin = RepackResolverPlugin();
+    // trigger the plugin to register the resolver
+    plugin.afterResolve!({ remoteInfo: mockRemoteInfo } as any);
+
+    // manually resolve the script to verify the result
+    const script = await ScriptManager.shared.resolveScript(
+      'remote1',
+      undefined,
+      webpackRequireMock,
+      'https://example-entry.com/remoteEntry.js'
+    );
+
+    expect(script.locator.url).toBe(
+      'https://example-manifest.com/remoteEntry.js'
+    );
   });
 
-  it('should accept function configuration', () => {
+  it('should resolve a script using entry URL when version is not available', async () => {
+    const plugin = RepackResolverPlugin();
+    // trigger the plugin to register the resolver
+    plugin.afterResolve!({
+      remoteInfo: { ...mockRemoteInfo, version: undefined },
+    } as any);
+
+    // manually resolve the script to verify the result
+    const script = await ScriptManager.shared.resolveScript(
+      'remote1',
+      undefined,
+      webpackRequireMock,
+      'https://example-entry.com/remoteEntry.js'
+    );
+
+    expect(script.locator.url).toBe('https://example-entry.com/remoteEntry.js');
+  });
+
+  it('should apply object configuration to script locator', async () => {
+    const config = { headers: { Authorization: 'Bearer token' } };
+    const plugin = RepackResolverPlugin(config);
+    // trigger the plugin to register the resolver
+    plugin.afterResolve!({ remoteInfo: mockRemoteInfo } as any);
+
+    // manually resolve the script to verify the result
+    const script = await ScriptManager.shared.resolveScript(
+      'asset',
+      'remote1',
+      webpackRequireMock,
+      'https://example-entry.com/remote1/asset.js'
+    );
+
+    expect(script.locator.headers).toEqual({ authorization: 'Bearer token' });
+  });
+
+  it('should apply function configuration to script locator', async () => {
     const config = async (url: string): Promise<ScriptLocator> => ({
       url,
       headers: { Authorization: 'Bearer token' },
     });
     const plugin = RepackResolverPlugin(config);
-    expect(plugin.name).toBe('repack-resolver-plugin');
-    expect(typeof plugin.afterResolve).toBe('function');
+    // trigger the plugin to register the resolver
+    plugin.afterResolve!({ remoteInfo: mockRemoteInfo } as any);
+
+    // manually resolve the script to verify the result
+    const script = await ScriptManager.shared.resolveScript(
+      'asset',
+      'remote1',
+      webpackRequireMock,
+      'https://example-entry.com/remote1/asset.js'
+    );
+
+    expect(script.locator.headers).toEqual({ authorization: 'Bearer token' });
   });
 
-  describe('integration tests', () => {
-    const mockRemoteInfo = {
-      name: 'remote1',
-      entry: 'https://example.com/remote1/entry.container.js.bundle',
-      version: 'https://example.com/remote1/mf-manifest.json',
-    };
+  it('should throw error when reference URL is missing', async () => {
+    const plugin = RepackResolverPlugin();
+    // trigger the plugin to register the resolver
+    plugin.afterResolve!({ remoteInfo: mockRemoteInfo } as any);
 
-    it('should resolve a script using version URL when available', async () => {
-      // Create and apply the plugin
-      const plugin = RepackResolverPlugin();
-      // Trigger the plugin to register the resolver
-      plugin.afterResolve!({ remoteInfo: mockRemoteInfo } as any);
-
-      // Now use ScriptManager to resolve a script from the remote
-      const script = await ScriptManager.shared.resolveScript(
+    // manually resolve the script to verify the result (should throw)
+    await expect(
+      ScriptManager.shared.resolveScript(
         'remote1',
-        'remote1',
-        (global as any).__webpack_require__,
-        'https://example.com/remote1/asset.js'
-      );
+        undefined,
+        webpackRequireMock
+      )
+    ).rejects.toThrow();
+  });
 
-      // Verify the script was resolved with the correct URL
-      expect(script.locator.url).toBe('https://example.com/remote1/asset.js');
-      expect(script.locator.fetch).toBe(true);
+  it('should properly rebase URLs with custom configuration', async () => {
+    const config = { headers: { Authorization: 'Bearer token' } };
+    const plugin = RepackResolverPlugin(config);
+    // trigger the plugin to register the resolver
+    plugin.afterResolve!({ remoteInfo: mockRemoteInfo } as any);
+
+    // manually resolve the script to verify the result
+    const script = await ScriptManager.shared.resolveScript(
+      'chunk1',
+      'remote1',
+      webpackRequireMock,
+      'https://example-entry.com/remote1/assets/nested/chunk1.js'
+    );
+
+    expect(script.locator.url).toBe(
+      'https://example-manifest.com/remote1/assets/nested/chunk1.js'
+    );
+    expect(script.locator.headers).toEqual({ authorization: 'Bearer token' });
+    expect(script.locator.fetch).toBe(true);
+  });
+
+  it('should not resolve scripts for other remotes', async () => {
+    // Add a default resolver to handle other remotes
+    const defaultResolverMock = jest.fn().mockResolvedValue({
+      url: 'http://default.com/script.js',
     });
 
-    it('should resolve a script using entry URL when version is not available', async () => {
-      const plugin = RepackResolverPlugin();
+    ScriptManager.shared.addResolver(defaultResolverMock);
 
-      plugin.afterResolve!({
-        remoteInfo: { ...mockRemoteInfo, version: undefined },
-      } as any);
+    const plugin = RepackResolverPlugin();
+    // trigger the plugin to register the resolver
+    plugin.afterResolve!({ remoteInfo: mockRemoteInfo } as any);
 
-      // Now use ScriptManager to resolve a script from the remote
-      const script = await ScriptManager.shared.resolveScript(
-        'remote1',
-        'remote1',
-        (global as any).__webpack_require__,
-        'https://example.com/remote1/asset.js'
-      );
+    // manually resolve the script to verify the result
+    const script = await ScriptManager.shared.resolveScript('other-remote');
 
-      // Verify the script was resolved with the correct URL
-      expect(script.locator.url).toBe('https://example.com/remote1/asset.js');
-      expect(script.locator.fetch).toBe(true);
-    });
+    expect(defaultResolverMock).toHaveBeenCalled();
+    expect(script.locator.url).toBe('http://default.com/script.js');
+  });
 
-    it('should apply object configuration to script locator', async () => {
-      const config = { headers: { Authorization: 'Bearer token' } };
-      const plugin = RepackResolverPlugin(config);
-      // Trigger the plugin to register the resolver
-      plugin.afterResolve!({ remoteInfo: mockRemoteInfo } as any);
+  it('should rebase the URL correctly', async () => {
+    const plugin = RepackResolverPlugin();
+    // trigger the plugin to register the resolver
+    plugin.afterResolve!({ remoteInfo: mockRemoteInfo } as any);
 
-      // Now use ScriptManager to resolve a script from the remote
-      const script = await ScriptManager.shared.resolveScript(
-        'remote1',
-        'remote1',
-        (global as any).__webpack_require__,
-        'https://example.com/remote1/asset.js'
-      );
+    // manually resolve the script to verify the result
+    const script = await ScriptManager.shared.resolveScript(
+      'asset',
+      'remote1',
+      webpackRequireMock,
+      'https://example-entry.com/remote1/subdir/asset.js'
+    );
 
-      // Verify the script was resolved with the correct headers
-      expect(script.locator.headers).toEqual({ authorization: 'Bearer token' });
-    });
-
-    it('should apply function configuration to script locator', async () => {
-      const config = async (url: string): Promise<ScriptLocator> => ({
-        url,
-        headers: { Authorization: 'Bearer token' },
-      });
-      const plugin = RepackResolverPlugin(config);
-      // Trigger the plugin to register the resolver
-      plugin.afterResolve!({ remoteInfo: mockRemoteInfo } as any);
-
-      // Now use ScriptManager to resolve a script from the remote
-      const script = await ScriptManager.shared.resolveScript(
-        'remote1',
-        'remote1',
-        (global as any).__webpack_require__,
-        'https://example.com/remote1/asset.js'
-      );
-
-      // Verify the script was resolved with the correct headers
-      expect(script.locator.headers).toEqual({ authorization: 'Bearer token' });
-    });
-
-    it('should throw error when reference URL is missing', async () => {
-      const plugin = RepackResolverPlugin();
-      // Trigger the plugin to register the resolver
-      plugin.afterResolve!({ remoteInfo: mockRemoteInfo } as any);
-
-      // Now try to resolve a script without a reference URL
-      await expect(
-        ScriptManager.shared.resolveScript(
-          'remote1',
-          'remote1',
-          (global as any).__webpack_require__
-        )
-      ).rejects.toThrow();
-    });
-
-    it('should properly rebase URLs with custom configuration', async () => {
-      // Create and apply the plugin with custom configuration
-      const config = { headers: { Authorization: 'Bearer token' } };
-      const plugin = RepackResolverPlugin(config);
-      // Trigger the plugin to register the resolver
-      plugin.afterResolve!({ remoteInfo: mockRemoteInfo } as any);
-
-      // Now use ScriptManager to resolve a script from the remote with a nested path
-      const script = await ScriptManager.shared.resolveScript(
-        'remote1',
-        'remote1',
-        (global as any).__webpack_require__,
-        'https://example.com/remote1/assets/nested/chunk1.js'
-      );
-
-      // Verify the script was resolved with the correct URL and headers
-      expect(script.locator.url).toBe(
-        'https://example.com/remote1/assets/nested/chunk1.js'
-      );
-      expect(script.locator.headers).toEqual({ authorization: 'Bearer token' });
-      expect(script.locator.fetch).toBe(true);
-    });
-
-    it('should not resolve scripts for other remotes', async () => {
-      // Add a default resolver to handle other remotes
-      const defaultResolverMock = jest.fn().mockResolvedValue({
-        url: 'http://default.com/script.js',
-      });
-
-      ScriptManager.shared.addResolver(defaultResolverMock);
-
-      // Create and apply the plugin
-      const plugin = RepackResolverPlugin();
-      // Trigger the plugin to register the resolver
-      plugin.afterResolve!({ remoteInfo: mockRemoteInfo } as any);
-
-      // Now try to resolve a script for a different remote
-      await ScriptManager.shared.resolveScript(
-        'other-remote',
-        'other-remote',
-        (global as any).__webpack_require__,
-        'https://example.com/other-remote/asset.js'
-      );
-
-      // Verify the default resolver was called
-      expect(defaultResolverMock).toHaveBeenCalled();
-    });
-
-    it('should rebase the URL correctly', async () => {
-      // Create and apply the plugin
-      const plugin = RepackResolverPlugin();
-      // Trigger the plugin to register the resolver
-      plugin.afterResolve!({ remoteInfo: mockRemoteInfo } as any);
-
-      // Now use ScriptManager to resolve a script with a different path
-      const script = await ScriptManager.shared.resolveScript(
-        'remote1',
-        'remote1',
-        (global as any).__webpack_require__,
-        'https://example.com/remote1/subdir/asset.js'
-      );
-
-      // Verify the URL was rebased correctly
-      expect(script.locator.url).toBe(
-        'https://example.com/remote1/subdir/asset.js'
-      );
-    });
+    expect(script.locator.url).toBe(
+      'https://example-manifest.com/remote1/subdir/asset.js'
+    );
   });
 });

--- a/packages/repack/src/modules/ScriptManager/__tests__/ScriptManager.test.ts
+++ b/packages/repack/src/modules/ScriptManager/__tests__/ScriptManager.test.ts
@@ -4,7 +4,7 @@ import NativeScriptManager, {
 import { Script } from '../Script.js';
 import { ScriptManager } from '../ScriptManager.js';
 
-jest.mock('../NativeScriptManager', () => ({
+jest.mock('../NativeScriptManager.js', () => ({
   loadScript: jest.fn(),
   prefetchScript: jest.fn(),
   invalidateScripts: jest.fn(),

--- a/packages/repack/src/modules/ScriptManager/__tests__/ScriptManager.test.ts
+++ b/packages/repack/src/modules/ScriptManager/__tests__/ScriptManager.test.ts
@@ -58,6 +58,13 @@ class ScriptLoaderError extends Error {
 
 beforeEach(() => {
   ScriptManager.init();
+
+  // mock the error handler to disable polluting the console
+  // @ts-expect-error private method
+  ScriptManager.shared.handleError = (error, message, ...args) => {
+    ScriptManager.shared.emit('error', { message, args, originalError: error });
+    throw error;
+  };
 });
 
 afterEach(() => {
@@ -73,14 +80,17 @@ describe('ScriptManagerAPI', () => {
   });
 
   it('throw error if there are no resolvers', async () => {
-    const spy = jest.spyOn(console, 'error').mockImplementationOnce(() => {});
+    const spy = jest.spyOn(
+      ScriptManager.shared,
+      'handleError' as keyof ScriptManager
+    );
 
     await expect(
       ScriptManager.shared.resolveScript('src_App_js', 'main')
-    ).rejects.toThrow(/Error: No script resolvers were added/);
+    ).rejects.toThrow();
 
     expect(spy).toHaveBeenCalled();
-    expect(spy.mock.calls[0][0]).toEqual(
+    expect(spy.mock.calls[0][1]).toEqual(
       expect.stringMatching(
         /^\[ScriptManager\] Failed while resolving script locator/
       )
@@ -88,17 +98,20 @@ describe('ScriptManagerAPI', () => {
   });
 
   it('throw error if no resolvers handled request', async () => {
-    const spy = jest.spyOn(console, 'error').mockImplementationOnce(() => {});
+    const spy = jest.spyOn(
+      ScriptManager.shared,
+      'handleError' as keyof ScriptManager
+    );
 
     ScriptManager.shared.addResolver(async () => undefined);
     ScriptManager.shared.addResolver(async () => undefined);
 
     await expect(
       ScriptManager.shared.resolveScript('src_App_js', 'main')
-    ).rejects.toThrow(/No resolver was able to resolve script src_App_js/);
+    ).rejects.toThrow();
 
     expect(spy).toHaveBeenCalled();
-    expect(spy.mock.calls[0][0]).toEqual(
+    expect(spy.mock.calls[0][1]).toEqual(
       expect.stringMatching(
         /^\[ScriptManager\] Failed while resolving script locator/
       )
@@ -106,7 +119,10 @@ describe('ScriptManagerAPI', () => {
   });
 
   it('remove all resolvers', async () => {
-    const spy = jest.spyOn(console, 'error').mockImplementationOnce(() => {});
+    const spy = jest.spyOn(
+      ScriptManager.shared,
+      'handleError' as keyof ScriptManager
+    );
 
     ScriptManager.shared.addResolver(async () => undefined);
     ScriptManager.shared.addResolver(async () => undefined);
@@ -114,10 +130,10 @@ describe('ScriptManagerAPI', () => {
 
     await expect(
       ScriptManager.shared.resolveScript('src_App_js', 'main')
-    ).rejects.toThrow(/Error: No script resolvers were added/);
+    ).rejects.toThrow();
 
     expect(spy).toHaveBeenCalled();
-    expect(spy.mock.calls[0][0]).toEqual(
+    expect(spy.mock.calls[0][1]).toEqual(
       expect.stringMatching(
         /^\[ScriptManager\] Failed while resolving script locator/
       )


### PR DESCRIPTION
### Summary

fixes broken script resolution when using MF2 manifests

- [x] - fixed the resolver plugin
- [x] - added tests for resolver plugin
- [x] - cleaned up output from ScriptManager tests 

### Test plan

- [x] - tests pass
- [x] - federation tester v2 works with both remote entry url and manifest url
