### PR TITLE
refactor: use highest minor version for repack

### DIFF
--- a/.changeset/light-pumpkins-compete.md
+++ b/.changeset/light-pumpkins-compete.md
@@ -1,0 +1,6 @@
+---
+"@callstack/repack-init": patch
+"@callstack/repack": patch
+---
+
+Use newest minor version of Re.Pack when creating a project with `repack-init`

--- a/packages/init/src/tasks/modifyDependencies.ts
+++ b/packages/init/src/tasks/modifyDependencies.ts
@@ -6,7 +6,7 @@ import { RepackInitError } from '../utils/error.js';
 import logger from '../utils/logger.js';
 
 function getOwnCurrentVersion() {
-  return '~' + packageJson.version;
+  return '^' + packageJson.version;
 }
 
 function getBundlerSpecificDependencies(bundler: 'rspack' | 'webpack') {

--- a/packages/init/versions.json
+++ b/packages/init/versions.json
@@ -1,10 +1,10 @@
 {
   "rspack": {
-    "@rspack/core": "~1.2.0",
-    "@swc/helpers": "~0.5.15"
+    "@rspack/core": "^1.2.8",
+    "@swc/helpers": "^0.5.15"
   },
   "webpack": {
-    "terser-webpack-plugin": "^5.3.11",
-    "webpack": "^5.97.1"
+    "terser-webpack-plugin": "^5.3.14",
+    "webpack": "^5.98.0"
   }
 }


### PR DESCRIPTION
### Summary

- [x] - change from `~` to `^` when adding Re.Pack as a dependency
- [x] - bump package version in `versions.json`

### Test plan

n/a
