### PR TITLE
feat: update `getResolveOptions`

### DIFF
--- a/.changeset/eighty-yaks-kick.md
+++ b/.changeset/eighty-yaks-kick.md
@@ -1,0 +1,5 @@
+---
+"@callstack/repack": minor
+---
+
+Enable support for package imports by default when resolving modules

--- a/.changeset/smooth-impalas-protect.md
+++ b/.changeset/smooth-impalas-protect.md
@@ -1,0 +1,5 @@
+---
+"@callstack/repack": minor
+---
+
+Resolve platform (`.ios`, `.android`) & native (`.native`) extensions when using package exports

--- a/.changeset/spicy-poems-itch.md
+++ b/.changeset/spicy-poems-itch.md
@@ -1,0 +1,5 @@
+---
+"@callstack/repack": minor
+---
+
+Use `import` / `require` condition name depending on the source type (`esm` or `cjs`)

--- a/apps/tester-app/rspack.config.mjs
+++ b/apps/tester-app/rspack.config.mjs
@@ -23,7 +23,7 @@ export default (env) => {
     context,
     entry: './index.js',
     resolve: {
-      ...Repack.getResolveOptions(),
+      ...Repack.getResolveOptions({ enablePackageExports: true }),
     },
     output: {
       uniqueName: 'tester-app',

--- a/apps/tester-app/webpack.config.mjs
+++ b/apps/tester-app/webpack.config.mjs
@@ -29,7 +29,7 @@ export default (env) => {
       : undefined,
     entry,
     resolve: {
-      ...Repack.getResolveOptions(),
+      ...Repack.getResolveOptions({ enablePackageExports: true }),
     },
     output: {
       uniqueName: 'tester-app',

--- a/apps/tester-federation-v2/configs/rspack.host-app.mjs
+++ b/apps/tester-federation-v2/configs/rspack.host-app.mjs
@@ -11,7 +11,7 @@ export default (env) => {
     context,
     entry: './src/host/index.js',
     resolve: {
-      ...Repack.getResolveOptions(),
+      ...Repack.getResolveOptions({ enablePackageExports: true }),
     },
     output: {
       path: '[context]/build/host-app/[platform]',

--- a/apps/tester-federation-v2/configs/rspack.mini-app.mjs
+++ b/apps/tester-federation-v2/configs/rspack.mini-app.mjs
@@ -11,7 +11,7 @@ export default (env) => {
     context,
     entry: './src/mini/index.js',
     resolve: {
-      ...Repack.getResolveOptions(),
+      ...Repack.getResolveOptions({ enablePackageExports: true }),
     },
     output: {
       path: '[context]/build/mini-app/[platform]',

--- a/apps/tester-federation-v2/configs/webpack.host-app.mjs
+++ b/apps/tester-federation-v2/configs/webpack.host-app.mjs
@@ -11,7 +11,7 @@ export default (env) => {
     context,
     entry: './src/host/index.js',
     resolve: {
-      ...Repack.getResolveOptions(),
+      ...Repack.getResolveOptions({ enablePackageExports: true }),
     },
     output: {
       path: '[context]/build/host-app/[platform]',

--- a/apps/tester-federation-v2/configs/webpack.mini-app.mjs
+++ b/apps/tester-federation-v2/configs/webpack.mini-app.mjs
@@ -11,7 +11,7 @@ export default (env) => {
     context,
     entry: './src/mini/index.js',
     resolve: {
-      ...Repack.getResolveOptions(),
+      ...Repack.getResolveOptions({ enablePackageExports: true }),
     },
     output: {
       path: '[context]/build/mini-app/[platform]',

--- a/apps/tester-federation/configs/rspack.host-app.mjs
+++ b/apps/tester-federation/configs/rspack.host-app.mjs
@@ -13,7 +13,7 @@ export default (env) => {
     context,
     entry: './src/host/index.js',
     resolve: {
-      ...Repack.getResolveOptions(),
+      ...Repack.getResolveOptions({ enablePackageExports: true }),
     },
     output: {
       path: '[context]/build/host-app/[platform]',

--- a/apps/tester-federation/configs/rspack.mini-app.mjs
+++ b/apps/tester-federation/configs/rspack.mini-app.mjs
@@ -13,7 +13,7 @@ export default (env) => {
     context,
     entry: './src/mini/index.js',
     resolve: {
-      ...Repack.getResolveOptions(),
+      ...Repack.getResolveOptions({ enablePackageExports: true }),
     },
     output: {
       path: '[context]/build/mini-app/[platform]',

--- a/apps/tester-federation/configs/webpack.host-app.mjs
+++ b/apps/tester-federation/configs/webpack.host-app.mjs
@@ -11,7 +11,7 @@ export default (env) => {
     context,
     entry: './src/host/index.js',
     resolve: {
-      ...Repack.getResolveOptions(),
+      ...Repack.getResolveOptions({ enablePackageExports: true }),
     },
     output: {
       path: '[context]/build/host-app/[platform]',

--- a/apps/tester-federation/configs/webpack.mini-app.mjs
+++ b/apps/tester-federation/configs/webpack.mini-app.mjs
@@ -11,7 +11,7 @@ export default (env) => {
     context,
     entry: './src/mini/index.js',
     resolve: {
-      ...Repack.getResolveOptions(),
+      ...Repack.getResolveOptions({ enablePackageExports: true }),
     },
     output: {
       path: '[context]/build/mini-app/[platform]',

--- a/packages/repack/src/utils/__tests__/getResolveOptions.test.ts
+++ b/packages/repack/src/utils/__tests__/getResolveOptions.test.ts
@@ -5,8 +5,8 @@ const resolveOptionsObject = {
   aliasFields: expect.any(Array),
   conditionNames: expect.any(Array),
   exportsFields: expect.any(Array),
-  importsFields: expect.any(Array),
   extensionAlias: expect.any(Object),
+  byDependency: expect.any(Object),
 };
 
 describe('getResolveOptions', () => {

--- a/packages/repack/src/utils/getResolveOptions.ts
+++ b/packages/repack/src/utils/getResolveOptions.ts
@@ -7,6 +7,7 @@ interface GetResolveOptionsResult {
   exportsFields: string[];
   extensions: string[];
   extensionAlias: Record<string, string[]>;
+  byDependency: Record<string, { conditionNames: string[] }>;
 }
 
 /**
@@ -81,8 +82,9 @@ export function getResolveOptions(
 
   let extensions = ['.js', '.jsx', '.ts', '.tsx', '.json'];
 
-  let conditionNames: string[];
   let exportsFields: string[];
+  let conditionNames: string[];
+  let byDependency: Record<string, { conditionNames: string[] }>;
 
   if (enablePackageExports) {
     /**
@@ -90,11 +92,20 @@ export function getResolveOptions(
      * Order of conditionNames doesn't matter.
      * Order inside of target package.json's `exports` field matters.
      */
-    conditionNames = ['require', 'import', 'react-native'];
     exportsFields = ['exports'];
+    conditionNames = ['react-native'];
+    byDependency = {
+      esm: {
+        conditionNames: ['import'],
+      },
+      commonjs: {
+        conditionNames: ['require'],
+      },
+    };
   } else {
     conditionNames = [];
     exportsFields = [];
+    byDependency = {};
     extensions = extensions.flatMap((ext) => {
       const platformExt = `.${_platform}${ext}`;
       const nativeExt = `.native${ext}`;
@@ -153,7 +164,8 @@ export function getResolveOptions(
      */
     extensionAlias: extensionAlias,
     /**
-     * Reference: Webpack's [configuration.resolve.importsFields](https://webpack.js.org/configuration/resolve/#resolveimportsfields)
+     * Reference: Webpack's [configuration.resolve.byDependency](https://webpack.js.org/configuration/resolve/#resolvebydependency)
      */
+    byDependency: byDependency,
   };
 }

--- a/packages/repack/src/utils/getResolveOptions.ts
+++ b/packages/repack/src/utils/getResolveOptions.ts
@@ -7,7 +7,6 @@ interface GetResolveOptionsResult {
   exportsFields: string[];
   extensions: string[];
   extensionAlias: Record<string, string[]>;
-  importsFields: string[];
 }
 
 /**
@@ -108,11 +107,6 @@ export function getResolveOptions(
   }
 
   /**
-   * Disable importsFields completely since it's not supported by metro at all.
-   */
-  const importsFields: string[] = [];
-
-  /**
    * Match what React Native uses from metro-config.
    * Usage of 'extensionAlias' removes the need for
    * AssetResolverPlugin altogether.
@@ -161,6 +155,5 @@ export function getResolveOptions(
     /**
      * Reference: Webpack's [configuration.resolve.importsFields](https://webpack.js.org/configuration/resolve/#resolveimportsfields)
      */
-    importsFields: importsFields,
   };
 }

--- a/packages/repack/src/utils/getResolveOptions.ts
+++ b/packages/repack/src/utils/getResolveOptions.ts
@@ -78,7 +78,7 @@ export function getResolveOptions(
   ) as ResolveOptions | undefined;
 
   const preferNativePlatform = _options?.preferNativePlatform ?? true;
-  const enablePackageExports = _options?.enablePackageExports ?? true;
+  const enablePackageExports = _options?.enablePackageExports ?? false;
 
   let extensions = ['.js', '.jsx', '.ts', '.tsx', '.json'];
 

--- a/packages/repack/src/utils/getResolveOptions.ts
+++ b/packages/repack/src/utils/getResolveOptions.ts
@@ -87,8 +87,7 @@ export function getResolveOptions(
     const platformExt = `.${_platform}${ext}`;
     const nativeExt = `.native${ext}`;
 
-    /* Skip adding native extension if package exports are enabled. */
-    if (!enablePackageExports && preferNativePlatform) {
+    if (preferNativePlatform) {
       return [platformExt, nativeExt, ext];
     }
     return [platformExt, ext];

--- a/packages/repack/src/utils/getResolveOptions.ts
+++ b/packages/repack/src/utils/getResolveOptions.ts
@@ -82,7 +82,7 @@ export function getResolveOptions(
 
   let extensions = ['.js', '.jsx', '.ts', '.tsx', '.json'];
 
-  /* Add platform (.ios, .android, etc.) and native (.native) extensions */
+  /* Add platform (e.g. `.ios`, `.android`) and native (`.native`) extensions */
   extensions = extensions.flatMap((ext) => {
     const platformExt = `.${_platform}${ext}`;
     const nativeExt = `.native${ext}`;

--- a/packages/repack/src/utils/getResolveOptions.ts
+++ b/packages/repack/src/utils/getResolveOptions.ts
@@ -70,7 +70,7 @@ export function getResolveOptions(
   platformOrOptions: unknown,
   options?: ResolveOptions
 ): GetResolveOptionsResult {
-  // if platform is undefined, use '[platform]' as placeholder
+  /* If platform is undefined, use '[platform]' as placeholder */
   const _platform =
     typeof platformOrOptions === 'string' ? platformOrOptions : '[platform]';
   const _options = (
@@ -81,6 +81,18 @@ export function getResolveOptions(
   const enablePackageExports = _options?.enablePackageExports ?? true;
 
   let extensions = ['.js', '.jsx', '.ts', '.tsx', '.json'];
+
+  /* Add platform (.ios, .android, etc.) and native (.native) extensions */
+  extensions = extensions.flatMap((ext) => {
+    const platformExt = `.${_platform}${ext}`;
+    const nativeExt = `.native${ext}`;
+
+    /* Skip adding native extension if package exports are enabled. */
+    if (!enablePackageExports && preferNativePlatform) {
+      return [platformExt, nativeExt, ext];
+    }
+    return [platformExt, ext];
+  });
 
   let exportsFields: string[];
   let conditionNames: string[];
@@ -96,15 +108,6 @@ export function getResolveOptions(
   } else {
     conditionNames = [];
     exportsFields = [];
-    extensions = extensions.flatMap((ext) => {
-      const platformExt = `.${_platform}${ext}`;
-      const nativeExt = `.native${ext}`;
-
-      if (preferNativePlatform) {
-        return [platformExt, nativeExt, ext];
-      }
-      return [platformExt, ext];
-    });
   }
 
   /**

--- a/packages/repack/src/utils/getResolveOptions.ts
+++ b/packages/repack/src/utils/getResolveOptions.ts
@@ -95,12 +95,8 @@ export function getResolveOptions(
     exportsFields = ['exports'];
     conditionNames = ['react-native'];
     byDependency = {
-      esm: {
-        conditionNames: ['import'],
-      },
-      commonjs: {
-        conditionNames: ['require'],
-      },
+      esm: { conditionNames: ['import'] },
+      commonjs: { conditionNames: ['require'] },
     };
   } else {
     conditionNames = [];

--- a/packages/repack/src/utils/getResolveOptions.ts
+++ b/packages/repack/src/utils/getResolveOptions.ts
@@ -78,13 +78,12 @@ export function getResolveOptions(
   ) as ResolveOptions | undefined;
 
   const preferNativePlatform = _options?.preferNativePlatform ?? true;
-  const enablePackageExports = _options?.enablePackageExports ?? false;
+  const enablePackageExports = _options?.enablePackageExports ?? true;
 
   let extensions = ['.js', '.jsx', '.ts', '.tsx', '.json'];
 
   let exportsFields: string[];
   let conditionNames: string[];
-  let byDependency: Record<string, { conditionNames: string[] }>;
 
   if (enablePackageExports) {
     /**
@@ -94,14 +93,9 @@ export function getResolveOptions(
      */
     exportsFields = ['exports'];
     conditionNames = ['react-native'];
-    byDependency = {
-      esm: { conditionNames: ['import'] },
-      commonjs: { conditionNames: ['require'] },
-    };
   } else {
     conditionNames = [];
     exportsFields = [];
-    byDependency = {};
     extensions = extensions.flatMap((ext) => {
       const platformExt = `.${_platform}${ext}`;
       const nativeExt = `.native${ext}`;
@@ -112,6 +106,16 @@ export function getResolveOptions(
       return [platformExt, ext];
     });
   }
+
+  /**
+   * We add `import` and `require` to conditionNames everytime
+   * because package imports are enabled at all times in metro
+   * and they need condition names to be defined.
+   */
+  const byDependency = {
+    esm: { conditionNames: ['import'] },
+    commonjs: { conditionNames: ['require'] },
+  };
 
   /**
    * Match what React Native uses from metro-config.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -677,8 +677,8 @@ importers:
         specifier: ^0.20.1
         version: 0.20.1
       enhanced-resolve:
-        specifier: ^5.16.0
-        version: 5.18.0
+        specifier: ^5.18.1
+        version: 5.18.1
       jest:
         specifier: ^29.7.0
         version: 29.7.0(@types/node@18.19.41)
@@ -4102,6 +4102,10 @@ packages:
 
   enhanced-resolve@5.18.0:
     resolution: {integrity: sha512-0/r0MySGYG8YqlayBZ6MuCfECmHFdJ5qyPh8s8wa5Hnm6SaFLSK1VYCbj+NKp090Nm1caZhD+QTnmxO7esYGyQ==}
+    engines: {node: '>=10.13.0'}
+
+  enhanced-resolve@5.18.1:
+    resolution: {integrity: sha512-ZSW3ma5GkcQBIpwZTSRAI8N71Uuwgs93IezB7mf7R60tC8ZbJideoDNKjHn2O9KIlx6rkGTTEk1xUCK2E1Y2Yg==}
     engines: {node: '>=10.13.0'}
 
   enquirer@2.3.6:
@@ -12130,6 +12134,11 @@ snapshots:
       tapable: 2.2.1
 
   enhanced-resolve@5.18.0:
+    dependencies:
+      graceful-fs: 4.2.11
+      tapable: 2.2.1
+
+  enhanced-resolve@5.18.1:
     dependencies:
       graceful-fs: 4.2.11
       tapable: 2.2.1

--- a/tests/metro-compat/jest.setup.js
+++ b/tests/metro-compat/jest.setup.js
@@ -14,7 +14,6 @@ const testsToSkip = {
     // Assets are handled differently in webpack
     'should resolve assets using "exports" field and calling `resolveAsset`',
     // Resolving fails as expected but error messages are different
-    'should use most specific pattern base',
     'should use most specific pattern base - custom condition',
     'should throw FailedToResolvePathError when no conditions are matched',
   ]),
@@ -68,5 +67,6 @@ jest.doMock('./resolver/__tests__/utils', () => {
         __options: args[1],
       };
     },
+    posixToSystemPath: originalModule.posixToSystemPath,
   };
 });

--- a/tests/metro-compat/jest.setup.js
+++ b/tests/metro-compat/jest.setup.js
@@ -22,7 +22,7 @@ const testsToSkip = {
 const testsToSkipOnce = {
   describe: new Set(),
   test: new Set([
-    // sourceExts are expanded, platform-specific extensions are not
+    // first occurence of these tests is marked as [nonstrict]
     'without expanding `sourceExts`',
     'without expanding platform-specific extensions',
   ]),

--- a/tests/metro-compat/jest.setup.js
+++ b/tests/metro-compat/jest.setup.js
@@ -11,6 +11,8 @@ const testsToSkip = {
     '[nonstrict] should fall back to "main" field resolution when "exports" is an invalid subpath',
     '[nonstrict] should fall back to "browser" spec resolution and log inaccessible import warning',
     '[nonstrict] should fall back and log warning for an invalid "exports" target value',
+    // Implictly non-strict
+    'patternBase and patternTrailer must match non-overlapping ends of matchKey',
     // Assets are handled differently in webpack
     'should resolve assets using "exports" field and calling `resolveAsset`',
     // Resolving fails as expected but error messages are different

--- a/tests/metro-compat/package.json
+++ b/tests/metro-compat/package.json
@@ -21,7 +21,7 @@
     "babel-jest": "^29.7.0",
     "babel-plugin-module-resolver": "^5.0.0",
     "babel-plugin-syntax-hermes-parser": "^0.20.1",
-    "enhanced-resolve": "^5.16.0",
+    "enhanced-resolve": "^5.18.1",
     "jest": "^29.7.0",
     "memfs": "^4.11.1",
     "type-fest": "^4.12.0"

--- a/tests/metro-compat/resolver/__tests__/package-imports-test.js
+++ b/tests/metro-compat/resolver/__tests__/package-imports-test.js
@@ -1,0 +1,145 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ * @oncall react_native
+ */
+
+import Resolver from '../index';
+import {
+  createPackageAccessors,
+  createResolutionContext,
+  posixToSystemPath as p,
+} from './utils';
+
+// Implementation of PACKAGE_IMPORTS_RESOLVE described in https://nodejs.org/api/esm.html
+describe('subpath imports resolution support', () => {
+  const baseContext = {
+    ...createResolutionContext({
+      [p('/root/src/main.js')]: '',
+      [p('/root/node_modules/test-pkg/package.json')]: '',
+      [p('/root/node_modules/test-pkg/index.js')]: '',
+      [p('/root/node_modules/test-pkg/index-main.js')]: '',
+      // $FlowFixMe[incompatible-type] Flow wants a string for some reason
+      [p('/root/node_modules/test-pkg/symlink.js')]: {
+        realPath: p('/root/node_modules/test-pkg/symlink-target.js'),
+      },
+    }),
+    originModulePath: p('/root/src/main.js'),
+  };
+
+  test('"imports" subpath that maps directly to a file', () => {
+    const context = {
+      ...baseContext,
+      ...createPackageAccessors({
+        [p('/root/node_modules/test-pkg/package.json')]: {
+          main: 'index-main.js',
+          imports: {
+            '#foo': './index.js',
+          },
+        },
+      }),
+      originModulePath: p('/root/node_modules/test-pkg/lib/foo.js'),
+    };
+
+    expect(Resolver.resolve(context, '#foo', null)).toEqual({
+      type: 'sourceFile',
+      filePath: p('/root/node_modules/test-pkg/index.js'),
+    });
+  });
+});
+
+describe('import subpath patterns resolution support', () => {
+  const baseContext = {
+    ...createResolutionContext({
+      [p('/root/src/main.js')]: '',
+      [p('/root/node_modules/test-pkg/package.json')]: JSON.stringify({
+        name: 'test-pkg',
+        main: 'index.js',
+        imports: {
+          '#features/*': './src/features/*.js',
+        },
+      }),
+      [p('/root/node_modules/test-pkg/src/index.js')]: '',
+      [p('/root/node_modules/test-pkg/src/features/foo.js')]: '',
+      [p('/root/node_modules/test-pkg/src/features/foo.js.js')]: '',
+      [p('/root/node_modules/test-pkg/src/features/bar/Bar.js')]: '',
+      [p('/root/node_modules/test-pkg/src/features/baz.native.js')]: '',
+    }),
+    originModulePath: p('/root/node_modules/test-pkg/src/index.js'),
+  };
+
+  test('resolving subpath patterns in "imports" matching import specifier', () => {
+    expect(Resolver.resolve(baseContext, '#features/foo', null)).toEqual({
+      type: 'sourceFile',
+      filePath: p('/root/node_modules/test-pkg/src/features/foo.js'),
+    });
+
+    expect(Resolver.resolve(baseContext, '#features/foo.js', null)).toEqual({
+      type: 'sourceFile',
+      filePath: p('/root/node_modules/test-pkg/src/features/foo.js.js'),
+    });
+  });
+});
+
+describe('import subpath conditional imports resolution', () => {
+  const baseContext = {
+    ...createResolutionContext({
+      [p('/root/src/main.js')]: '',
+      [p('/root/node_modules/test-pkg/package.json')]: JSON.stringify({
+        name: 'test-pkg',
+        main: 'index.js',
+        imports: {
+          '#foo': {
+            development: './lib/foo-dev.js',
+            'react-native': {
+              import: './lib/foo-react-native.mjs',
+              require: './lib/foo-react-native.cjs',
+              default: './lib/foo-react-native.js',
+            },
+            browser: './lib/foo-browser.js',
+            import: './lib/foo-module.mjs',
+            require: './lib/foo-require.cjs',
+            default: './lib/foo.js',
+          },
+        },
+      }),
+      [p('/root/node_modules/test-pkg/index.js')]: '',
+      [p('/root/node_modules/test-pkg/lib/foo.js')]: '',
+      [p('/root/node_modules/test-pkg/lib/foo-require.cjs')]: '',
+      [p('/root/node_modules/test-pkg/lib/foo-module.mjs')]: '',
+      [p('/root/node_modules/test-pkg/lib/foo-dev.js')]: '',
+      [p('/root/node_modules/test-pkg/lib/foo-browser.js')]: '',
+      [p('/root/node_modules/test-pkg/lib/foo-react-native.cjs')]: '',
+      [p('/root/node_modules/test-pkg/lib/foo-react-native.mjs')]: '',
+      [p('/root/node_modules/test-pkg/lib/foo-react-native.js')]: '',
+      [p('/root/node_modules/test-pkg/lib/foo.web.js')]: '',
+    }),
+    originModulePath: p('/root/node_modules/test-pkg/src/index.js'),
+  };
+
+  test('resolving imports subpath with conditions', () => {
+    const context = {
+      ...baseContext,
+      unstable_conditionNames: ['react-native'],
+    };
+
+    expect(
+      Resolver.resolve({...context, isESMImport: false}, '#foo', null),
+    ).toEqual({
+      type: 'sourceFile',
+      filePath: p('/root/node_modules/test-pkg/lib/foo-react-native.cjs'),
+    });
+
+    expect(
+      Resolver.resolve({...context, isESMImport: true}, '#foo', null),
+    ).toEqual({
+      type: 'sourceFile',
+      filePath: p('/root/node_modules/test-pkg/lib/foo-react-native.mjs'),
+    });
+  });
+});

--- a/tests/metro-compat/resolver/__tests__/symlinks-test.js
+++ b/tests/metro-compat/resolver/__tests__/symlinks-test.js
@@ -30,14 +30,14 @@ const CONTEXT: ResolutionContext = {
   originModulePath: '/root/project/foo.js',
 };
 
-it('resolves to a real path when the chosen candidate is a symlink', () => {
+test('resolves to a real path when the chosen candidate is a symlink', () => {
   expect(Resolver.resolve(CONTEXT, './link-to-foo', null)).toEqual({
     type: 'sourceFile',
     filePath: '/root/project/foo.js',
   });
 });
 
-it('does not resolve to a broken symlink', () => {
+test('does not resolve to a broken symlink', () => {
   // ./baz.js is a broken link, baz/index.js is real
   expect(() => Resolver.resolve(CONTEXT, './baz.js', null)).toThrow(
     FailedToResolvePathError,

--- a/tests/metro-compat/resolver/__tests__/utils.js
+++ b/tests/metro-compat/resolver/__tests__/utils.js
@@ -30,6 +30,17 @@ type MockFileMap = $ReadOnly<{
 export function createResolutionContext(
   fileMap: MockFileMap = {},
 ): $Diff<ResolutionContext, {originModulePath: string}> {
+  const directorySet = new Set<string>();
+  for (const filePath of Object.keys(fileMap)) {
+    let currentDir = filePath;
+    let prevDir;
+    do {
+      prevDir = currentDir;
+      currentDir = path.dirname(currentDir);
+      directorySet.add(currentDir);
+    } while (currentDir !== prevDir);
+  }
+
   return {
     dev: true,
     allowHaste: true,
@@ -43,6 +54,29 @@ export function createResolutionContext(
       (typeof fileMap[filePath] === 'string' ||
         typeof fileMap[filePath].realPath === 'string'),
     extraNodeModules: null,
+    fileSystemLookup: inputPath => {
+      // Normalise and remove any trailing slash.
+      const filePath = path.resolve(inputPath);
+      const candidate = fileMap[filePath];
+      if (typeof candidate === 'string') {
+        return {exists: true, type: 'f', realPath: filePath};
+      }
+      if (candidate == null) {
+        if (directorySet.has(filePath)) {
+          return {exists: true, type: 'd', realPath: filePath};
+        }
+        return {exists: false};
+      }
+      if (candidate.realPath == null) {
+        return {exists: false};
+      }
+      return {
+        exists: true,
+        type: 'f',
+        realPath: candidate.realPath,
+      };
+    },
+    isESMImport: false,
     mainFields: ['browser', 'main'],
     nodeModulesPaths: [],
     preferNativePlatform: false,
@@ -56,20 +90,6 @@ export function createResolutionContext(
       web: ['browser'],
     },
     unstable_enablePackageExports: false,
-    unstable_fileSystemLookup: filePath => {
-      const candidate = fileMap[filePath];
-      if (typeof candidate === 'string') {
-        return {exists: true, type: 'f', realPath: filePath};
-      }
-      if (candidate == null || candidate.realPath == null) {
-        return {exists: false};
-      }
-      return {
-        exists: true,
-        type: 'f',
-        realPath: candidate.realPath,
-      };
-    },
     unstable_logWarning: () => {},
     ...createPackageAccessors(fileMap),
   };
@@ -129,3 +149,8 @@ export function createPackageAccessors(
     getPackageForModule,
   };
 }
+
+export const posixToSystemPath: string => string =
+  process.platform === 'win32'
+    ? filePath => filePath.replaceAll('/', '\\').replace(/^\\/, 'C:\\')
+    : filePath => filePath;

--- a/tests/metro-compat/resolver/resolve.ts
+++ b/tests/metro-compat/resolver/resolve.ts
@@ -150,11 +150,11 @@ export function resolve(
   // enhanced-resolve does not use "byDependency" configuration
   if (metroContext.isESMImport) {
     resolveOptions.conditionNames?.push(
-      ...(resolutionPreset.byDependency.esm?.conditionNames ?? [])
+      ...resolutionPreset.byDependency.esm.conditionNames
     );
   } else {
     resolveOptions.conditionNames?.push(
-      ...(resolutionPreset.byDependency.commonjs?.conditionNames ?? [])
+      ...resolutionPreset.byDependency.commonjs.conditionNames
     );
   }
 

--- a/tests/metro-compat/resolver/resolve.ts
+++ b/tests/metro-compat/resolver/resolve.ts
@@ -150,11 +150,11 @@ export function resolve(
   // enhanced-resolve does not use "byDependency" configuration
   if (metroContext.isESMImport) {
     resolveOptions.conditionNames?.push(
-      ...resolutionPreset.byDependency.esm.conditionNames
+      ...(resolutionPreset.byDependency.esm?.conditionNames ?? [])
     );
   } else {
     resolveOptions.conditionNames?.push(
-      ...resolutionPreset.byDependency.commonjs.conditionNames
+      ...(resolutionPreset.byDependency.commonjs?.conditionNames ?? [])
     );
   }
 

--- a/tests/metro-compat/resolver/resolve.ts
+++ b/tests/metro-compat/resolver/resolve.ts
@@ -143,6 +143,12 @@ export function resolve(
     ...options,
   };
 
+  if (metroContext.isESMImport) {
+    resolveOptions.conditionNames?.push('import');
+  } else {
+    resolveOptions.conditionNames?.push('require');
+  }
+
   const resolve = enhancedResolve.create.sync(resolveOptions);
   const resolvedPath = resolve(context, request);
 


### PR DESCRIPTION
### Summary

Since Metro enables package exports by default now, it's about time we finish the support for package exports in Re.Pack as well. For now we will keep it disabled by default but we might enable it in the next minor/major version depending on feedback from users.

Alignment with updated tests from Metro allowed to find missing pieces in the package exports configuration which in turn enabled package exports to work in all of the testers 🎉 

- [x] - enable `packageImports` at all times since metro supports it
- [x] - use `import` / `require` condition name at all times when source type is known
- [x] - add platform & native extensions when using package exports
- [x] - update `metro-resolver` tests  

### Test plan

- [x] - tests pass
- [x] - testers work with package exports enabled 
