### PR TITLE
fix: `publicPath` in dev doesnt use overriden port

### DIFF
--- a/.changeset/weak-hairs-serve.md
+++ b/.changeset/weak-hairs-serve.md
@@ -1,0 +1,5 @@
+---
+"@callstack/repack": patch
+---
+
+Fix publicPath not using port overriden through CLI in development

--- a/packages/repack/src/commands/common/config/__tests__/normalizeConfig.test.ts
+++ b/packages/repack/src/commands/common/config/__tests__/normalizeConfig.test.ts
@@ -70,12 +70,33 @@ describe('normalizeConfig', () => {
       expect(normalized.output?.publicPath).toBe('noop:///');
     });
 
+    it('should set publicPath to devServer public path if it uses DEV_SERVER_PUBLIC_PATH', () => {
+      const config = {
+        devServer: { host: 'example.com', port: 3000 },
+        output: { publicPath: 'DEV_SERVER_PUBLIC_PATH' },
+      } as ConfigurationObject;
+      const normalized = normalizeConfig(config, 'ios');
+      expect(normalized.output?.publicPath).toBe(
+        'http://example.com:3000/ios/'
+      );
+    });
+
     it('should keep custom publicPath unchanged', () => {
       const config = {
         output: { publicPath: 'http://localhost:8081' },
       } as ConfigurationObject;
       const normalized = normalizeConfig(config, 'ios');
       expect(normalized.output?.publicPath).toBe('http://localhost:8081');
+    });
+
+    it('should replace [platform] placeholders', () => {
+      const config = {
+        output: { publicPath: 'http://example.com:3000/[platform]/' },
+      } as ConfigurationObject;
+      const normalized = normalizeConfig(config, 'ios');
+      expect(normalized.output?.publicPath).toBe(
+        'http://example.com:3000/ios/'
+      );
     });
   });
 

--- a/packages/repack/src/commands/common/config/getCommandConfig.ts
+++ b/packages/repack/src/commands/common/config/getCommandConfig.ts
@@ -10,7 +10,7 @@ function getStartCommandDefaults() {
       server: 'http',
     },
     output: {
-      publicPath: `http://${DEFAULT_HOSTNAME}:${DEFAULT_PORT}/[platform]/`,
+      publicPath: 'DEV_SERVER_PUBLIC_PATH',
     },
   };
 }

--- a/packages/repack/src/commands/common/config/normalizeConfig.ts
+++ b/packages/repack/src/commands/common/config/normalizeConfig.ts
@@ -24,10 +24,19 @@ function normalizeOutputPath(
     .replaceAll('[platform]', platform);
 }
 
-function normalizePublicPath(publicPath: string, platform: string): string {
+function normalizePublicPath(
+  publicPath: string,
+  platform: string,
+  host?: string,
+  port?: number
+): string {
   /* set public path to noop if it's using the deprecated `getPublicPath` function */
   if (publicPath === 'DEPRECATED_GET_PUBLIC_PATH') {
     return 'noop:///';
+  }
+
+  if (publicPath === 'DEV_SERVER_PUBLIC_PATH') {
+    return `http://${host}:${port}/${platform}/`;
   }
 
   return publicPath.replaceAll('[platform]', platform);
@@ -73,7 +82,12 @@ export function normalizeConfig<C extends ConfigurationObject>(
   if (config.output?.publicPath) {
     normalizedConfig.output = {
       ...normalizedConfig.output,
-      publicPath: normalizePublicPath(config.output.publicPath, platform),
+      publicPath: normalizePublicPath(
+        config.output.publicPath,
+        platform,
+        normalizedConfig.devServer?.host ?? config.devServer?.host,
+        normalizedConfig.devServer?.port ?? config.devServer?.port
+      ),
     };
   }
 


### PR DESCRIPTION
### Summary

Fixed an issue where overriding the devServer port would not be reflected in `output.publicPath`.

### Test plan

- [x] - tests pass
