### PR TITLE
fix: try loading config through esm import first

### DIFF
--- a/.changeset/long-cooks-attend.md
+++ b/.changeset/long-cooks-attend.md
@@ -1,0 +1,5 @@
+---
+"@callstack/repack": patch
+---
+
+Fix failure to load project configuration in Node versions with require(esm)

--- a/packages/repack/src/commands/common/config/loadProjectConfig.ts
+++ b/packages/repack/src/commands/common/config/loadProjectConfig.ts
@@ -1,3 +1,4 @@
+import url from 'node:url';
 import type { Configuration, ConfigurationObject } from '../../types.js';
 
 export async function loadProjectConfig<C extends ConfigurationObject>(
@@ -6,9 +7,10 @@ export async function loadProjectConfig<C extends ConfigurationObject>(
   let config: Configuration<C>;
 
   try {
-    config = require(configFilePath);
+    const { href: fileUrl } = url.pathToFileURL(configFilePath);
+    config = await import(fileUrl);
   } catch {
-    config = await import(configFilePath);
+    config = require(configFilePath);
   }
 
   if ('default' in config) {


### PR DESCRIPTION
### Summary

Since `require(esm)` is a thing, our current method of loading projects with require first and then dynamic import fails - this PR changes this to support newer node versions by trying dynamic import first

### Test plan

- [x] - testers work
