### PR TITLE
fix: don't convert `.mjs` config path to url twice on Windows

### DIFF
--- a/.changeset/four-walls-beg.md
+++ b/.changeset/four-walls-beg.md
@@ -1,0 +1,5 @@
+---
+"@callstack/repack": patch
+---
+
+Fix failure to read `.mjs` config on Windows

--- a/packages/repack/src/commands/common/config/getConfigFilePath.ts
+++ b/packages/repack/src/commands/common/config/getConfigFilePath.ts
@@ -1,7 +1,5 @@
 import fs from 'node:fs';
-import os from 'node:os';
 import path from 'node:path';
-import url from 'node:url';
 import {
   DEFAULT_RSPACK_CONFIG_LOCATIONS,
   DEFAULT_WEBPACK_CONFIG_LOCATIONS,
@@ -15,9 +13,6 @@ function discoverConfigFilePath(root: string, candidates: string[]) {
       : path.join(root, candidate);
 
     if (fs.existsSync(filename)) {
-      if (path.extname(filename) === '.mjs' && os.platform() === 'win32') {
-        return url.pathToFileURL(filename).href;
-      }
       return filename;
     }
   }


### PR DESCRIPTION
### Summary

Closes #1107

### Test plan

- [x] - tester-app on Windows with `.mjs` config works
