### PR TITLE
fix: include path in MF2 remote public path

### DIFF
--- a/.changeset/pretty-dragons-destroy.md
+++ b/.changeset/pretty-dragons-destroy.md
@@ -1,0 +1,5 @@
+---
+"@callstack/repack": patch
+---
+
+Fix handling of MF2 remote assets paths in ResolverPlugin

--- a/packages/repack/src/modules/FederationRuntimePlugins/ResolverPlugin.ts
+++ b/packages/repack/src/modules/FederationRuntimePlugins/ResolverPlugin.ts
@@ -20,8 +20,7 @@ const createScriptLocator = async (
 };
 
 const getPublicPath = (url: string) => {
-  const [protocol, rest] = url.split('://');
-  return protocol + '://' + rest.split('/')[0];
+  return url.split('/').slice(0, -1).join('/');
 };
 
 const getAssetPath = (url: string) => {


### PR DESCRIPTION
### Summary

This PR fixes the incorrect URL rebasing when resolving MF2 remotes. Previously we were only replacing the base URL (without path) and this caused a regression when `publicPath` of a remote is set to a URL with a path (e.g. `http://localhost:8081/ios`). 

Since all MF2 assets are always generated with a flat directory structure (meaning they will all exist next to each other, in the same directory), we can take the last part of the URL (after last '/') and rebase it onto the publicPath of an entrypoint of a remote.

Examples:
| URL Type | Example 1 | Example 2 |
|----------|-----------|-----------|
| Initial URL | `noop:///asset.js` | `http://localhost:8081/ios/chunk.js` |
| Entry URL | `https://example.com/ios/mf-manfiest.js` | `https://example.com/ios/entry.js` |
| Target URL | `https://example.com/ios/asset.js` | `https://example.com/ios/chunk.js` |

### Test plan

- [x] - tests pass
- [x] - testers work with both manifests and containers as entrypoints 
