### PR TITLE
fix: handle RN 0.79 deep import changes

### DIFF
--- a/.changeset/calm-pandas-nail.md
+++ b/.changeset/calm-pandas-nail.md
@@ -1,0 +1,5 @@
+---
+"@callstack/repack": patch
+---
+
+Check for default import when using deep imports from `react-native` in WebpackHMRClient, DevServerClient and when using remote or inline assets

--- a/packages/repack/src/loaders/assetsLoader/__tests__/__snapshots__/assetsLoader.test.ts.snap
+++ b/packages/repack/src/loaders/assetsLoader/__tests__/__snapshots__/assetsLoader.test.ts.snap
@@ -5,7 +5,7 @@ exports[`assetLoader on android should load and extract asset with scales 1`] = 
   "__packager_asset": true,
   "hash": "86abef08a42e972a96c958d6fa9d43da,02ad731a8881911e488b51c48a4cc6c1,d9f7c31eebb3a41cc180431867b04f38",
   "height": 272,
-  "httpServerLocation": "assets/node_modules/rspack-virtual-module-1a1ffb6a/__fixtures__",
+  "httpServerLocation": "assets/node_modules/rspack-virtual-module-2f60a7fc/__fixtures__",
   "name": "star",
   "scales": [
     1,
@@ -21,11 +21,11 @@ exports[`assetLoader on android should load and extract asset with scales 2`] = 
 "/
 └─ out/
    ├─ drawable-mdpi/
-   │  └─ node_modules_rspackvirtualmodule1a1ffb6a___fixtures___star.png
+   │  └─ node_modules_rspackvirtualmodule2f60a7fc___fixtures___star.png
    ├─ drawable-xhdpi/
-   │  └─ node_modules_rspackvirtualmodule1a1ffb6a___fixtures___star.png
+   │  └─ node_modules_rspackvirtualmodule2f60a7fc___fixtures___star.png
    ├─ drawable-xxhdpi/
-   │  └─ node_modules_rspackvirtualmodule1a1ffb6a___fixtures___star.png
+   │  └─ node_modules_rspackvirtualmodule2f60a7fc___fixtures___star.png
    └─ main.js"
 `;
 
@@ -34,7 +34,7 @@ exports[`assetLoader on android should load and extract asset without scales 1`]
   "__packager_asset": true,
   "hash": "30be0ddcd5932e77845666e7b6f6a863",
   "height": 51,
-  "httpServerLocation": "assets/node_modules/rspack-virtual-module-72a8c2da/__fixtures__",
+  "httpServerLocation": "assets/node_modules/rspack-virtual-module-dede2d21/__fixtures__",
   "name": "logo",
   "scales": [
     1,
@@ -48,7 +48,7 @@ exports[`assetLoader on android should load and extract asset without scales 2`]
 "/
 └─ out/
    ├─ drawable-mdpi/
-   │  └─ node_modules_rspackvirtualmodule72a8c2da___fixtures___logo.png
+   │  └─ node_modules_rspackvirtualmoduledede2d21___fixtures___logo.png
    └─ main.js"
 `;
 
@@ -57,7 +57,7 @@ exports[`assetLoader on android should prefer platform specific asset 1`] = `
   "__packager_asset": true,
   "hash": "373411381c08b2c5034c814c24c26b19",
   "height": 51,
-  "httpServerLocation": "assets/node_modules/rspack-virtual-module-ee716c7b/__fixtures__",
+  "httpServerLocation": "assets/node_modules/rspack-virtual-module-acc39058/__fixtures__",
   "name": "logo",
   "scales": [
     1,
@@ -71,7 +71,7 @@ exports[`assetLoader on android should prefer platform specific asset 2`] = `
 "/
 └─ out/
    ├─ drawable-mdpi/
-   │  └─ node_modules_rspackvirtualmoduleee716c7b___fixtures___logo.png
+   │  └─ node_modules_rspackvirtualmoduleacc39058___fixtures___logo.png
    └─ main.js"
 `;
 
@@ -80,7 +80,7 @@ exports[`assetLoader on ios should load and extract asset with scales 1`] = `
   "__packager_asset": true,
   "hash": "86abef08a42e972a96c958d6fa9d43da,02ad731a8881911e488b51c48a4cc6c1,d9f7c31eebb3a41cc180431867b04f38",
   "height": 272,
-  "httpServerLocation": "assets/node_modules/rspack-virtual-module-1a1ffb6a/__fixtures__",
+  "httpServerLocation": "assets/node_modules/rspack-virtual-module-2f60a7fc/__fixtures__",
   "name": "star",
   "scales": [
     1,
@@ -97,7 +97,7 @@ exports[`assetLoader on ios should load and extract asset with scales 2`] = `
 └─ out/
    ├─ assets/
    │  └─ node_modules/
-   │     └─ rspack-virtual-module-1a1ffb6a/
+   │     └─ rspack-virtual-module-2f60a7fc/
    │        └─ __fixtures__/
    │           ├─ star.png
    │           ├─ star@2x.png
@@ -110,7 +110,7 @@ exports[`assetLoader on ios should load and extract asset without scales 1`] = `
   "__packager_asset": true,
   "hash": "30be0ddcd5932e77845666e7b6f6a863",
   "height": 51,
-  "httpServerLocation": "assets/node_modules/rspack-virtual-module-72a8c2da/__fixtures__",
+  "httpServerLocation": "assets/node_modules/rspack-virtual-module-dede2d21/__fixtures__",
   "name": "logo",
   "scales": [
     1,
@@ -125,7 +125,7 @@ exports[`assetLoader on ios should load and extract asset without scales 2`] = `
 └─ out/
    ├─ assets/
    │  └─ node_modules/
-   │     └─ rspack-virtual-module-72a8c2da/
+   │     └─ rspack-virtual-module-dede2d21/
    │        └─ __fixtures__/
    │           └─ logo.png
    └─ main.js"
@@ -136,7 +136,7 @@ exports[`assetLoader on ios should prefer platform specific asset 1`] = `
   "__packager_asset": true,
   "hash": "6839dbc2a8dafd50c1d82b7db5fe274a",
   "height": 51,
-  "httpServerLocation": "assets/node_modules/rspack-virtual-module-87e5ccb0/__fixtures__",
+  "httpServerLocation": "assets/node_modules/rspack-virtual-module-1d9593d4/__fixtures__",
   "name": "logo",
   "scales": [
     1,
@@ -151,7 +151,7 @@ exports[`assetLoader on ios should prefer platform specific asset 2`] = `
 └─ out/
    ├─ assets/
    │  └─ node_modules/
-   │     └─ rspack-virtual-module-87e5ccb0/
+   │     └─ rspack-virtual-module-1d9593d4/
    │        └─ __fixtures__/
    │           └─ logo.png
    └─ main.js"
@@ -162,7 +162,7 @@ exports[`assetLoader should convert to remote-asset with URL containing a path a
   "__packager_asset": true,
   "height": 51,
   "scale": 1,
-  "uri": "http://localhost:9999/remote-assets/assets/node_modules/rspack-virtual-module-72a8c2da/__fixtures__/logo.png",
+  "uri": "http://localhost:9999/remote-assets/assets/node_modules/rspack-virtual-module-dede2d21/__fixtures__/logo.png",
   "width": 297,
 }
 `;
@@ -174,7 +174,7 @@ exports[`assetLoader should convert to remote-asset with URL containing a path a
    └─ remote-assets/
       └─ assets/
          └─ node_modules/
-            └─ rspack-virtual-module-72a8c2da/
+            └─ rspack-virtual-module-dede2d21/
                └─ __fixtures__/
                   └─ logo.png"
 `;
@@ -184,7 +184,7 @@ exports[`assetLoader should convert to remote-asset with scales 1 1`] = `
   "__packager_asset": true,
   "height": 272,
   "scale": 1,
-  "uri": "http://localhost:9999/assets/node_modules/rspack-virtual-module-1a1ffb6a/__fixtures__/star.png",
+  "uri": "http://localhost:9999/assets/node_modules/rspack-virtual-module-2f60a7fc/__fixtures__/star.png",
   "width": 286,
 }
 `;
@@ -196,7 +196,7 @@ exports[`assetLoader should convert to remote-asset with scales 1 2`] = `
    └─ remote-assets/
       └─ assets/
          └─ node_modules/
-            └─ rspack-virtual-module-1a1ffb6a/
+            └─ rspack-virtual-module-2f60a7fc/
                └─ __fixtures__/
                   ├─ star.png
                   ├─ star@2x.png
@@ -208,7 +208,7 @@ exports[`assetLoader should convert to remote-asset with scales 2 1`] = `
   "__packager_asset": true,
   "height": 272,
   "scale": 2,
-  "uri": "http://localhost:9999/assets/node_modules/rspack-virtual-module-066e1faa/__fixtures__/star@x2.png",
+  "uri": "http://localhost:9999/assets/node_modules/rspack-virtual-module-4e63ce4e/__fixtures__/star@x2.png",
   "width": 286,
 }
 `;
@@ -220,7 +220,7 @@ exports[`assetLoader should convert to remote-asset with scales 2 2`] = `
    └─ remote-assets/
       └─ assets/
          └─ node_modules/
-            └─ rspack-virtual-module-066e1faa/
+            └─ rspack-virtual-module-4e63ce4e/
                └─ __fixtures__/
                   ├─ star.png
                   ├─ star@2x.png
@@ -232,7 +232,7 @@ exports[`assetLoader should convert to remote-asset with scales 3 1`] = `
   "__packager_asset": true,
   "height": 272,
   "scale": 3,
-  "uri": "http://localhost:9999/assets/node_modules/rspack-virtual-module-aba2f916/__fixtures__/star@x3.png",
+  "uri": "http://localhost:9999/assets/node_modules/rspack-virtual-module-1f80d675/__fixtures__/star@x3.png",
   "width": 286,
 }
 `;
@@ -244,7 +244,7 @@ exports[`assetLoader should convert to remote-asset with scales 3 2`] = `
    └─ remote-assets/
       └─ assets/
          └─ node_modules/
-            └─ rspack-virtual-module-aba2f916/
+            └─ rspack-virtual-module-1f80d675/
                └─ __fixtures__/
                   ├─ star.png
                   ├─ star@2x.png
@@ -256,7 +256,7 @@ exports[`assetLoader should convert to remote-asset with specified assetPath wit
   "__packager_asset": true,
   "height": 272,
   "scale": 1,
-  "uri": "http://localhost:9999/assets/node_modules/rspack-virtual-module-1a1ffb6a/__fixtures__/nested-folder/star-fake-hash.png",
+  "uri": "http://localhost:9999/assets/node_modules/rspack-virtual-module-2f60a7fc/__fixtures__/nested-folder/star-fake-hash.png",
   "width": 286,
 }
 `;
@@ -268,7 +268,7 @@ exports[`assetLoader should convert to remote-asset with specified assetPath wit
    └─ remote-assets/
       └─ assets/
          └─ node_modules/
-            └─ rspack-virtual-module-1a1ffb6a/
+            └─ rspack-virtual-module-2f60a7fc/
                └─ __fixtures__/
                   └─ nested-folder/
                      ├─ star-fake-hash.png
@@ -281,7 +281,7 @@ exports[`assetLoader should convert to remote-asset with specified assetPath wit
   "__packager_asset": true,
   "height": 272,
   "scale": 2,
-  "uri": "http://localhost:9999/assets/node_modules/rspack-virtual-module-066e1faa/__fixtures__/nested-folder/star-fake-hash@x2.png",
+  "uri": "http://localhost:9999/assets/node_modules/rspack-virtual-module-4e63ce4e/__fixtures__/nested-folder/star-fake-hash@x2.png",
   "width": 286,
 }
 `;
@@ -293,7 +293,7 @@ exports[`assetLoader should convert to remote-asset with specified assetPath wit
    └─ remote-assets/
       └─ assets/
          └─ node_modules/
-            └─ rspack-virtual-module-066e1faa/
+            └─ rspack-virtual-module-4e63ce4e/
                └─ __fixtures__/
                   └─ nested-folder/
                      ├─ star-fake-hash.png
@@ -306,7 +306,7 @@ exports[`assetLoader should convert to remote-asset with specified assetPath wit
   "__packager_asset": true,
   "height": 272,
   "scale": 3,
-  "uri": "http://localhost:9999/assets/node_modules/rspack-virtual-module-aba2f916/__fixtures__/nested-folder/star-fake-hash@x3.png",
+  "uri": "http://localhost:9999/assets/node_modules/rspack-virtual-module-1f80d675/__fixtures__/nested-folder/star-fake-hash@x3.png",
   "width": 286,
 }
 `;
@@ -318,7 +318,7 @@ exports[`assetLoader should convert to remote-asset with specified assetPath wit
    └─ remote-assets/
       └─ assets/
          └─ node_modules/
-            └─ rspack-virtual-module-aba2f916/
+            └─ rspack-virtual-module-1f80d675/
                └─ __fixtures__/
                   └─ nested-folder/
                      ├─ star-fake-hash.png
@@ -331,7 +331,7 @@ exports[`assetLoader should convert to remote-asset with specified assetPath wit
   "__packager_asset": true,
   "height": 51,
   "scale": 1,
-  "uri": "http://localhost:9999/remote-assets/assets/node_modules/rspack-virtual-module-72a8c2da/__fixtures__/nested-folder/logo-fake-hash.png",
+  "uri": "http://localhost:9999/remote-assets/assets/node_modules/rspack-virtual-module-dede2d21/__fixtures__/nested-folder/logo-fake-hash.png",
   "width": 297,
 }
 `;
@@ -343,7 +343,7 @@ exports[`assetLoader should convert to remote-asset with specified assetPath wit
    └─ remote-assets/
       └─ assets/
          └─ node_modules/
-            └─ rspack-virtual-module-72a8c2da/
+            └─ rspack-virtual-module-dede2d21/
                └─ __fixtures__/
                   └─ nested-folder/
                      └─ logo-fake-hash.png"
@@ -354,7 +354,7 @@ exports[`assetLoader should convert to remote-asset without scales 1`] = `
   "__packager_asset": true,
   "height": 51,
   "scale": 1,
-  "uri": "http://localhost:9999/assets/node_modules/rspack-virtual-module-72a8c2da/__fixtures__/logo.png",
+  "uri": "http://localhost:9999/assets/node_modules/rspack-virtual-module-dede2d21/__fixtures__/logo.png",
   "width": 297,
 }
 `;
@@ -366,12 +366,12 @@ exports[`assetLoader should convert to remote-asset without scales 2`] = `
    └─ remote-assets/
       └─ assets/
          └─ node_modules/
-            └─ rspack-virtual-module-72a8c2da/
+            └─ rspack-virtual-module-dede2d21/
                └─ __fixtures__/
                   └─ logo.png"
 `;
 
-exports[`assetLoader should inline asset with scales (1) - React Native <0.72 1`] = `
+exports[`assetLoader should inline asset with scales (1) 1`] = `
 {
   "height": 272,
   "scale": 1,
@@ -380,28 +380,13 @@ exports[`assetLoader should inline asset with scales (1) - React Native <0.72 1`
 }
 `;
 
-exports[`assetLoader should inline asset with scales (1) - React Native <0.72 2`] = `
+exports[`assetLoader should inline asset with scales (1) 2`] = `
 "/
 └─ out/
    └─ main.js"
 `;
 
-exports[`assetLoader should inline asset with scales (1) - React Native >=0.72 1`] = `
-{
-  "height": 272,
-  "scale": 1,
-  "uri": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAR4AAAEQCAYAAABmwxumAAAACXBIWXMAAAsTAAALEwEAmpwYAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAA2WSURBVHgB7d2xliNHFcbxD0xAuH6DckZoZ2RbKZGXJ9gmJFsyiJDfwM7IdhwSecnIet7AJiPrJiObJSMbVPTorFarkbpaVd11q/6/c+459swcn/GodFVf6XZLApZxTwVE+7mAZV7tqxOwwC8ELPN6X+8FACtx+3p8KicgElELS7w6+udOALCCXh92PL0AIDOnD03nUC8ERCBqIZY/87VOAJDRccwibgHIzunTpkPcQjSiFmL4C9/rBAAZnItZxC0A2Tg933SIW4hC1MJcfsbPdAKAhC7FLOIWgORChHqcUQ8ibmEGohbmeDXz515E/CwAXPRO83Y8xC0AScyNWcQtzEbUwjWx0Ym4hatoPLjGK95LAcANQnR6FHELwEpCZHpcWF7AM4hauOSWs5rXAoAFlsSs47gFAFG8ljcd4hYuImrhOZ1ux9vqAKIMun3HQ9wCMJvX7U2HuIVnEbVwTqd0iFsAZkkRs4hbAGbzStd0iFs4i6iFU53SI24BuChlzCJuAbjKK33TIW7hE0QtHMsZibwA4IwcMetQgwDgxJfK13SIW/gIUQsHnfLzAoAjPyr/jmcQADxxyt90DuWE5hG1EKw54NcJALROzDpULwDNc1qv6RC38H9ELWxxHRXXbgGNC9Fn7R0PcQtomNP6TedQfOBfw4habfPaTicATQqRZ6sdD3ELaJDTdk2HuNU4ola7vLbXCUBTQtTZesfTC0AznLZvOsSthhG12uRVjk4AmhAiTik7nl4AqheiTSlNJ9SDiFvNIWq1p7TrpELT4dqtxtB42lPik/y1AFSrtJhF3GoUO562eJWJuNUYGk9bSn5yvxSAKoVIU2LUIm41hh1PO8Jup+QndvjdvhSaQONph4UzlNdCE34mtMJClHm/r8+F6rHjaYOXjfOT8Dt6oXo0njZ0soO31YFKDCr33axz724BMM7LTtM5lBeqRtSqXyd7iFuAcYNs7XaIW4BxXrYaDnGrEUStunWyi7gFGDXI1i6HuAUYF657stRoiFsNIWrVq5N9XgBMGWRrd3OuBgEwo4aYRdyqGFGrTp3q4YXq0Hjq9FL1+FoAiudkK0rNKSdUhR1PfWocvOuEqtB46vNa9XkpAMVyshWhiFuNYsdTl5qvb+LarYrQeOpS8ztAvLtVET5loh5O9U/6hk+geC+Yx46nHl7164Qq0Hjq8Vr1I25VgqhVB6d2LqgkblWAHU8dvNrRCebReOrQQsw6IG5VgKhln1N7960hbhnHjsc+r/Z0gmk0HvtanOglbhlH1LLthdr8NIYQs74Qccssdjy2tXr9Umi4XLtlGI3HtpaffC29k1cdopZdrcasA+KWYex47PJqW2i8XjCJxmMXZxy8u2UWUcuuELNeqG3ELaPY8dgUdjutN50g/A2+FMz5haYHjgfPFiLGB38W92O25v4QtXaaHkAAyOkP+/r2+Iwn7Hp+EK8eANIb9/W7fd2Hf/ns6Bv/3tffNF35S/QCkMq7ff1mX/88fOGzkx94//RD/9nXr/f1SwHAMqGf/ElTvPrv8TcuvZ3u9tWL6AUg3j80vfs6nvvmpbfTR00zEt8JAOYLPcPrmaYTfKbr/r6vf2k692F2BMBzQrQKZzl/0Um0OhUzuez29VZcHwPgU/ea3rUa5/zwnB3PQehm32tqVl4AMAmHx79XxKUrS6/VcuLgGWjdqKPZnBgxO55jobMx8wO0K6Sf3+poNifG0sYTMPMDtOcwm/NHXTlAviTVbTGciF5A7S7O5sRIdVuMUdPMzzcCUKOrszkxbola59yLmR+gJrNnc2LkugOhEzM/gHX3ipjNiZF6x3PAzA9gW/RsTow17rnsxMEzYMWo6W3yn5TRGvdcHvf1laYdEIByhedoeK5mbTpBrqh1KhxKMfMDlCnJbE6MLT7exonoBZQi2WxOjC0+3mYUMz9ACcJsThh9GbWytaLWOfeaum2IXsz8AOs5ns3ZxJaNJwgXmIWLTUPXdQKQ272mppP9APmSrRtPwMwPsI6sszkxtjhcvsSJg2cgtVErzObEKO2z00cx8wOktNpsTowSotYpZn6A260+mxOjtKh1yonoBcTaZDYnRmlR69QoZn6AGJvN5sQoMWqdcy9mfoBLRk0HyJvN5sSw0niCw8yP29evBODgXoW9a3WNpcYThAOzv4qZH+CgmNmcGKUfLl/ixMEz2jXK2C7nWOmHy5eMYuYHbQoHyMXN5rSo29fDvh4pquIKa/yNKmA5ap1yInqhXsXP5sSwHLVOjWLmB3UyMZuD6ZVhkK1tNEWd1iDevTXH7esH2VpoFHWoXhUfG1ib44nBzA+sMjmbE6Omw+VLnDh4RvlGGZ7NiVHT4fIlo6a5h+8ElInZnMp1YuaHKqfCWuzUmFai1iknohe2V9VsToxWotapUcz8YFvM5jTOi5kfar0axLuseOLEzA+Vv3pxIzucsZOthUzZqSou7kyl1cPlS5w4eEY6oxqZzcHtwnb4W9l6RaXKq7CGiFaI1omDZyq+mpzNQVpONB9qfvUipiOhnWw9Aaj1K0QrIDkvdj/UpzWI2Rxk5vZ1J1tPDCpf9eIAGSvaydYThEpb1dx4HfY4Eb1arEHTdVbAZpj5aauYzUFROrH7qbmYzUGxnGg+NVYvZnNgwE62nljU88VsDkzxYvdjuQYxmwOjnKZtuoUnGvWhenGAnFWrtz5dyyhYVe1nWpWA+/Hk5TRt2WHP56L5ZMOOJy8vWNUJ2dB48notWPW1kA1RKx8nYpZ1xK1M2PHk4wXrXglZ0HjyYdHaR1TOhKiVR5gBeRCsCzHrCxG3kmPHkwe7nTqEFxAeywxoPHmwWOtB3MqAqJVHiFmM3NeBuJUBO570wm6HplOP8Fhyt8HEaDzpEbPqQ9xKjKiVHjGrPsStxNjxpEXMqhNxKzEaT1rErHrx2CZE1EorXJvlhBqFmPW5kAQ7nnS8aDo1C3HLC0nQeNLphNoRtxIhaqVDzKofcSsRdjxpeNF0WkDcSoTGk0YntIK4lQBRKw1iVjuIWwmw47mdF02nJcStBGg8t+uE1hC3bkTUuh0xqz2jpmu3sBA7ntuE63ec0Bon4tZNaDy36YRWeWExotZtiFntGkXcWowdz3LErLY5setZjMaznBda54VFaDzLcTtMvBQW4YxnGSc+Fx2TcM4zClHY8SzDABkOOiEajWcZYhYOiFsLELXiORGz8LFw0SifQBGBHU88L+BjnRCFxhOPmIVTXwtRiFpxnIhZOI+4FYEdTxwvHHz/VJh0AjLp9/XYeIWPaH5z9Dd58/Q1S/8POaoXkIGTrSdCjvpJ569PC18bCvtdtyg+vnomotZ8Xm37TtPfYDzzvfC1MMH7jdrWCUisl61X31QVYpTXfJ3a3f30AhIKW2griz/1E8kpnlO7jZq4hWQ62Vr8KeqNbrdT3t+xxOoEJPJOthb/LTVouslZKk5tRa9eQAItxaw75YkKL57+25b+FkvrQcQtJNDJ1sJf+mRJEa2uaWXmpxNwo9pj1nOzObk41R+93gm4Uc2v0N9qOzvZ+3vNLeIWbhLuNGhpwcc8Mby2F/6+g2z97eaWF7DQnWwt9jnVq6yP5XGqc+bnrYCFaotZaxwgL7WTrb/ltSJuYZGaYtagtLM5uTjVFb28cBYXiT6vlk+SCPfM+UrTu1elGzX9rrXc54dPI0G0QbZeXU9rrdmcXDrZj7oPAiJ42Vrgp7X2bE4uTvZfALyAme5ka3Ef15azObnsZOsxqP3xQCaDbC3ux6ff2ateVmd+iFuYxcvWwg7Vq45odY3b1w+y9diE8gKuuJOtRW35AHmpnWw9RsQtXDXIxmIOv6eF2ZxcnOw8VsQtXORlYyGHV1CmYm3d58cLeEZ4Qpe8eK3P5uTSqfyZH+IWnjWo3IVby2xOLk5lP36DgDPCeUmpi5ZXy/l2Kvdx9AJOlBizBrFYlyh15mcn4ERpC7UXB8i3cCpv5mcQcKS0mMUBcjo7lfXYtjwCgRPhiV7CohzEwszBqZwd7U7Akx+1/YJkNiev8Lct4RyvF6Dp1XDLhRjmTzphLZ22n/lxQvO2jFnM5mzDadvotROat1XMYjZneztt89j3QtOc1l90g5jNKYnXNrsfzvMa1mndxdaLBVcip/VnfhiZaFhoBCw0HOy03nrohSY5rbPABjGbY4nTetGL3W+DOuVfWMzm2LTWzA+74Ab1yregmM2pQ6e8u59eaIpT3sXkhFo45W0+7Igb0inPImI2p1475VkzxK2G9Eq7eAYxm9MCr/S7n15oQtjapl44bJfb4ZT+BvOsnwZ0SrNYuPF623ZK13g6oXrvdPtCGcRsDtIdPPdC1VLELGZzcCzFzM+DWFNV63Tb4ugEnNfptt1PJ1RraczqxWwOrnNa3nzeCtVacuc5ZnMQayfiFp6Ez1qKWQiDmM3Bcl7xux8vVOdO8xdAuDcLrz64lVPcunsrVGdOzGI2BznMva83casyXvOiFbM5yMVpXvTyQjXudP0AmVca5DZn5oc3Myry3CtN2Nq+ErCuTpfXJCrgdf4B7sVsDrbj9PxHK3nBvDuxnUW5dmJ9Vul4S8tsDkrk9fE6JW4Z58VsDmxw+nh37gWz7sRsDmw5zPwQtwzjABkWuX39JJj0QkQroEj/A4mP3oFv7IfsAAAAAElFTkSuQmCC",
-  "width": 286,
-}
-`;
-
-exports[`assetLoader should inline asset with scales (1) - React Native >=0.72 2`] = `
-"/
-└─ out/
-   └─ main.js"
-`;
-
-exports[`assetLoader should inline asset with scales (2) - React Native <0.72 1`] = `
+exports[`assetLoader should inline asset with scales (2) 1`] = `
 {
   "height": 407.5,
   "scale": 2,
@@ -410,28 +395,13 @@ exports[`assetLoader should inline asset with scales (2) - React Native <0.72 1`
 }
 `;
 
-exports[`assetLoader should inline asset with scales (2) - React Native <0.72 2`] = `
+exports[`assetLoader should inline asset with scales (2) 2`] = `
 "/
 └─ out/
    └─ main.js"
 `;
 
-exports[`assetLoader should inline asset with scales (2) - React Native >=0.72 1`] = `
-{
-  "height": 407.5,
-  "scale": 2,
-  "uri": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAA1gAAAMvCAYAAADPuHHRAAAACXBIWXMAACE4AAAhOAFFljFgAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAADQ/SURBVHgB7d0tlyVXdibg1/YAw6p/EMVmWDUzUzSzkdTQSLehWTezkUtsmNXMRirBQS0zs8x/0G1mlmE2TDIb1nOPr1KqysqP+xER95wTz7PWXt1LKi1JpZsRd8d+4+wEANow/FgAUK0/DwC04Yt97QIAFfsfAYA2fLmvHwIAAMBFhn396ccaAgCVEhEEoAVffPD/dwEAAOBsN/l5gnUTAAAAzjLk5+bqvl4FACokIghA7cZH/tguAAAAnOzDeKCYIAAAwJmGfNpciQkCUC0RQQBqNj7z53YBAADgaI/FA8UEAQAATjTk6eZKTBCAKokIAlCr8YhfswsAAAAvei4eKCYIAABwpBL9+9MR9X3EBAGoiIggADX64shf9+qEXwsAALBJ3+W4CZaYIAAAwDOOjQeKCQJQHRFBAGoz5jRiggBUQ4MFQG3OaZY+CwAAAJ8okb8/RUwQAADgImV69aczawwAXJmIIAA1ueRdqi8DAADAT86JB34YEwQAACCHiN+fLqwxAHBFIoIA1GKXyzmuHQAAYO8ul0+wxAQBAIDNG3N5cyUmCMDViQgCUINd5iMmCAAAbNoc8UAxQQAAYPPGzNdciQkCcFUiggBc2y7zExMEAAA2ac54oJggAACwWWPmb67EBAG4GhFBAK5pySjfGAAAgA1ZIh54X3cBAADYiLdZrrkSEwTgKkQEAbiWXZY3BgAAYAP+kOUnWHcBAADo3JDlm6v7GgIAKxERBOAa1lwEvAsAAEDH1ogH3tdNAAAAOjVkveZKTBCAVYkIArC2NeOB1/x7AgAALK5E9taeYIkJAgAA3RmyfnN1X68CAAsTEQRgTWOuZxcAAICOlKjetSZYYoIAAEA3hlyvuRITBGAVIoIArGXM9e0CAADQgRLRu/YE6yYAAACNG3L95kpMEIDFiQgCsIYx9dgFAACgYSWaV8sE6yYAAACNKpG8WpqrUt9HTBCAhYgIArC0L1KX0lzV9s8EQCc0WAAsrcZm5ssAAAA0prZ4oJggAIsywQJgSWPqVJqrMQAwMw0WAEuq+V2nzwMAANCQEsWrMSIoJgjAIkywAFhKmV7V3MCUf7a3AYAZabAAWEoLR6F/GQCY0Z8FAJbRQgTvh329DgDMxAQLgCWMaeP9JqcJAjArDRYAS9ilHS1EGQEAgA27S72nBz52miAAAECVxrTTXN3XGACYgYggAHPbpT1iggAAQJXu0tb0SkwQAACo0pi2GisxQQBmJSIIwJx2aZeYIAAAUJW7tDW1EhMEAACq9DZtNVRiggDMTkQQgLns0r4xAAAAFbhLW9Oqx+ouAAAAV9ZDPFBMEICLiQgCMIdd+jEGAM6kwQJgDp+lH58HAADgSoa0FQE8poYAwBlMsAC4VI8LencBgDNosAC41Jfpz2cBAABY2ZC2on9iggAsygQLgEv0GA+81/O/GwAL0WABcImeT9xzmiAAJ/uzAMB5hn3dpW+v9/VDAOBIJlgAnGtM/3YBgBNosAA415fpn5ggACcREQTgHEP6jwfeExME4GgmWACcY8x27AIAR9JgAXCOLcQD74kJAnA0EUEATjVkO/HAe2KCABzFBAuAU43Znl0A4AgaLABO9UW2R0wQgKOICAJwilf7+j7bU+KBbyImCMALTLAAOMUWp1dFaSy3+u8OwAk0WACcYstNxpZOTgTgTCKCABxrq/HAe2KCALzIBAuAY43ZttJgvg0APEODBcCxvIMkJgjAC0QEAThWiQe+yraJCQLwLBMsAI5Rpldbb64KMUEAnqXBAuAY4oE/ExME4EkiggAc425fQyhKPPB1AOARJlgAvGSM5upDJSY4BgAeocEC4CW78JDIJACPEhEE4CXigZ8SEwTgUSZYADxnjObqMWKCADxKgwXAc3bhKWKCAHxCRBCA54gHPk1MEIBPmGAB8JQxmqvniAkC8AkNFgBP2YWXiAkC8BERQQCeIh74MjFBAD5iggXAY95Gc3UMMUEAPqLBAuAxu3CsMQDwIxFBAB4jHni8aV9vAgAxwQLgU+KBpxliigXAjzRYADy0C6caAwDRYAHwqc/CqfyeAfDfvIMFwIeGHN6/4nTlPawpAGyaCRYAH7I493y7ALB5GiwAPvRlOJeYIAAiggD8ZIh44KXEBAE2zgQLgHtjuJSIJcDGabAAuCceeLnPA8CmiQgCUAwRD5zL6339EAA2yQQLgGIMc9kFgM3SYAFQiAfOR0wQYMNEBAEYIh44NzFBgI0ywQJgDHPbBYBN0mABIB44PzFBgI0SEQTYtiHigUsREwTYIBMsgG0bw1J2AWBzNFgA2/ZFWIqYIMAGiQgCbNerfX0fllLigW8iJgiwKSZYANtlerWs0sD6PQbYGA0WwHb58r88JzQCbIyIIMB2/SksTUwQYGNMsAC2yfRqHSUm+DYAbIYGC2CbNFjrERME2BARQYBtKqcHvgprEBME2BATLIDtKdMrzdV6xAQBNkSDBbA94oHrExME2AgRQYDtudvXENZU4oGvA0D3TLAAtmWM5uoaSkxwDADd02ABbMsuXItoJsAGiAgCbIt44PWICQJsgAkWwHaM0Vxdk5ggwAZosAC2YxeuTUwQoHMiggDbIR54fWKCAJ0zwQLYhjGaqxqICQJ0ToMFsA27UAsxQYCOiQgCbIN4YD2mfb0JAF0ywQLo39tormoyREwQoFsaLID+7UJtxgDQJRFBgP6JB9ZnipggQJdMsAD6Jh5YpyGmWABd0mAB9M2JdfUaA0B3NFgAffs81OqzANAd72AB9GvI4f0r6lXew5oCQDdMsAD6JR5Yv10A6IoGC6BfX4baiQkCdEZEEKBPQ8QDWyEmCNAREyyAPo2hFaKcAB3RYAH0STywHU56BOiIiCBAf4aIB7bm9b5+CADNM8EC6M8YWrMLAF3QYAH0RzywPWKCAJ0QEQToyxDxwFaJCQJ0wAQLoC9jaNUuADRPgwXQF/HAdokJAnRARBCgH0PEA1snJgjQOBMsgH6MoXWWDgM0ToMF0A9fztsn4gnQOBFBgD682tf3oXUlHvgmYoIAzTLBAuiD6VUfSqPsvyVAwzRYAH3wpbwfYoIADRMRBOhDiQe+Cj0QEwRomAkWQPvK9Epz1Y/y3/JtAGiSBgugfeKB/RETBGiUiCBA+8QD+yMmCNAoEyyAtokH9klMEKBRGiyAtokH9st/W4AGiQgCtO1uX0PoUYkHvg4ATTHBAmjXGM1Vz0pMcAwATdFgAbRrF3onJgjQGBFBgHaJB/ZPTBCgMSZYAG0ao7naAjFBgMZosADatAtbISYI0BARQYA2iQduh5ggQENMsADaM0ZztSViggAN0WABtGcXtkZMEKARIoIA7REP3J5pX28CQPVMsADa8jaaqy0aIiYI0AQNFkBbdmGrxgBQPRFBgLaIB27XFDFBgOqZYAG0Qzxw24aYYgFUT4MF0I4xbN0YAKqmwQJox5dh6z4LAFXzDhZAG4Yc3r+C8h7WFACqZIIF0AaLZrm3CwDV0mABtEE8kHtiggAVExEEqN8Q8UA+9npfPwSA6phgAdRvDHxsFwCqpMECqJ94IA99HgCqJCIIULch4oE8TkwQoEImWAB1GwOP2wWA6miwAOomHshTxAQBKiQiCFCvIeKBPE9MEKAyJlgA9RoDz9sFgKposADqJR7IS8QEASojIghQpyHigRxHTBCgIiZYAHUaA8f5IgBUQ4MFUCdfmjmWKClARUQEAerzal/fB45T4oFvIiYIUAUTLID6mF5xitKQ+8wAVEKDBVAfX5Y5lc8MQCVEBAHqU+KBrwLHExMEqIQJFkBdyiRCc8WpymfmbQC4Og0WQF1EvTiX0wQBKiAiCFAX8UDOJSYIUAETLIB6iAdyCTFBgAposADqIR7IpXyGAK5MRBCgHnf7GgLnK/HA1wHgakywAOowRnPF5UpMcAwAV6PBAqjDLjAPMUGAKxIRBKiDeCBzERMEuCITLIDrG6O5Yj5iggBXpMECuL5dYF5iggBXIiIIcH3igcxNTBDgSkywAK5rjOaK+YkJAlyJBgvgukS5WIrPFsAViAgCXJd4IEuZ9vUmAKzKBAvget5Gc8VyhogJAqxOgwVwPbvAssYAsCoRQYDrEQ9kaVPEBAFWZYIFcB3igaxhyOGzBsBKNFgA1zEG1uE0QYAVabAAruPLwDo+CwCr8Q4WwPqGHN6/grWU97CmALA4EyyA9YlssbZdAFiFBgtgfeKBrE1MEGAlIoIA6xoiHsh1vN7XDwFgUSZYAOsaA9exCwCL02ABrEs8kGv5PAAsTkQQYD1DxAO5LjFBgIWZYAGsZwxc1y4ALEqDBbAe8UCuTUwQYGEiggDrGCIeSB3EBAEWZIIFsI4xUIddAFiMBgtgHeKB1EJMEGBBIoIAy3u1r+8D9RATBFiICRbA8r4I1MVnEmAhGiyA5fkyS21EVgEWIiIIsCzxQGpU4oFvIiYIMDsTLIBlmV5Ro9L4+2wCLECDBbAsX2Kplc8mwAJEBAGWVeKBrwL1ERMEWIAJFsByyoRAc0WtymfzbQCYlQYLYDkiWNTOaYIAMxMRBFiOeCC1ExMEmJkJFsAyxmiuqJ+YIMDMNFgAy9gF2iDKCjAjEUGAZdztawjUr8QDXweAWZhgAcxvjOaKdpSY4BgAZqHBApjfLtAWMUGAmYgIAsxPPJDWiAkCzMQEC2BeYzRXtEdMEGAmGiyAee0CbRITBJiBiCDAvMQDaZWYIMAMTLAA5jNGc0W7xAQBZqDBApiPiBWt8xkGuJCIIMB8xANp3bSvNwHgbCZYAPN4G80V7RsiJghwEQ0WwDx2gT6MAeBsIoIA8xAPpBdTxAQBzmaCBXA58UB6MsTnGeBsGiyAy42BvuwCwFk0WACX+zLQl88CwFm8gwVwmSGH96+gN+U9rCkAnMQEC+AyFrPSq10AOJkGC+Aynwf6JCYIcAYRQYDzDREPpG+v9/VDADiaCRbA+cZA33YB4CQaLIDzOT2Q3onAApxIRBDgPEPEA9kGMUGAE5hgAZxnDGzDLgAcTYMFcB7xQLZCTBDgBCKCAKcbIh7ItogJAhzJBAvgdGNgW3YB4CgaLIDTiQeyNWKCAEcSEQQ4zat9fR/YHjFBgCOYYAGc5ovANvnsAxxBgwVwGl8y2SrRWIAjiAgCHE88kC0r8cA3ERMEeJYJFsDxTK/YsvKAwc8AwAs0WADHGwPb9lkAeJaIIMDxSjzwVWC7xAQBXmCCBXCcEo3SXLF15WfgbQB4kgYL4DjePYEDpwkCPENEEOA44oFwICYI8AwTLICXjdFcwT0xQYBnaLAAXrYL8CGRWYAniAgCvOxuX0OAeyUe+DoAfMIEC+B5YzRX8FCJCY4B4BMaLIDn7QI8RkwQ4BEiggDPEw+Ex4kJAjzCBAvgaWM0V/AUMUGAR2iwAJ62C/AcMUGAB0QEAZ4mHgjPExMEeOC+wSpPoP4pvkgAAACc64f7iOB3+/rlvm4DAADAqW739Yu/+OAPlDH/tzlMtcYAAABwjN/u6+/29cNT72AN+7qJyCAAAMBTpn39al9/vP8Df/7ML/xFDhMtAAAAPlZ6pdIz/fHDP/gXz/wF/y+Hd7P+a19/ta+/DAAAwLaVV6v+YV9/n0PP9JFjj2kfIjIIAABs27/ncAL79NQvOHbR8LSvN/v6KgAAANvzu329zTPNVfFcRPAxtzl0bSUy+CoAAAB9m3I4yOKfj/nFpzZYxX/s619ziAv+zwAAAPTpNg9OCXzJOQ1WUV7s+j+xMwsAAOjTT7utTvmLjj3k4jlDHIABAAD0YcqJU6sPHXvIxUv/AHZmAQAArSsHWXyy2+oU50YEH7rfmfWfOUQG7cwCAABacb/b6l0e2W11ijkigg8NERkEAADa8OJuq1PMERF8aIqdWQAAQP2O2m11irkigo+5jZ1ZAABAfaacsNvqFEs2WIWdWQAAQE1uc8EpgS9ZusEq7MwCAABqcNZuq1MsccjFc4Y4AAMAAFjXlAWnVh9a4pCL50w5nCv/uwAAACzv4t1Wp1gjIvhQOVf+32JnFgAAsJwSAyxxwP+dC3dbnWLtiOBDQ0QGAQCAec262+oUa0cEH5piZxYAADCf2XdbneLaE6wPjfv6JqZZAADA6aZ9/TqHY9iv5hrvYD1lip1ZAADA6W739csc9vBeVU0NVmFnFgAAcIr73VarHWTxnJoigg8NcQAGAADwuCkr7bY6xbUPuXjOFDuzAACAT6262+oUtUUEH7IzCwAAuHeV3VanqDki+NAQkUEAANiqq+22OkXNEcGHptiZBQAAW3TV3VanaGmC9aExdmYBAEDvplSw2+oUtb+D9ZQph51Zr3PoZAEAgL7cppLdVqdotcEqygtu38XOLAAA6En5nv8PqWi31SlajQg+NMQBGAAA0LopFe62OkVLh1w8Z4qdWQAA0LJqd1udouWI4EMf7swq72W9CgAAULvqd1udopeI4ENDRAYBAKB2tzmcEjilE71EBB+aYmcWAADUrEQCyymBUzrS6wTrQ2PszAIAgFpMaWy31Sl6egfrKVPszAIAgBrcpsHdVqfYQoNV3O/M+q99/XUAAIA1Nb3b6hRbiAg+NMQBGAAAsJYpje+2OkWvh1w8Z4qdWQAAsIYudludYisRwYfszAIAgOWUSODf7uvrdB4JfGiLEcGHhn39Pg7AAACAOdyms91Wp9jqBOtDpbv+lxyazTEAAMC5SiSwTK5+yEaZYH1sjJ1ZAABwqikd77Y6hQnWx6bYmQUAAKco65D+Jh3vtjqFButTdmYBAMDL7ndb/TYbO8jiOSKCzxtiZxYAADw0ZUO7rU6xxT1Yp5hiZxYAAHxoc7utTiEi+DI7swAAYMO7rU4hIniaIXZmAQCwPbfZ8G6rU5hgncbOLAAAtuarHJqrze62OoUJ1vnKFKtMs4YAAEB/pthtdTITrPP939iZBQBAn+y2OpMG6zJ2ZgEA0BO7rS4kIjifIXZmAQDQrmlfv4yDLC5iD9Z8pn29iZ1ZAAC053631RQuIiI4PzuzAABohd1WMxMRXM4QO7MAAKjXbey2mp0J1nLszAIAoFZ2Wy3EBGsddmYBAFCDKXZbLcoEax12ZgEAcG12W61Ag7WeD3dm/dW+/jIAALA8u61WJCJ4HUPszAIAYHn/vq8v4iCL1diDdR1T7MwCAGBZ5bvmGM3VqkQEr8vOLAAA5ma31RWJCNZh2Nc3cZw7AACXuY3dVldlglWH8pTh29iZBQDA+cohFn8Xu62uygSrPnZmAQBwiil2W1XDBKs+dmYBAHAsu60qo8Gqk51ZAAA8x26rSokI1m+InVkAAPzMbquK2YNVvyl2ZgEAcGC3VeVEBNthZxYAwHbZbdUIEcH2DLEzCwBgS25jt1UzTLDaY2cWAMB22G3VGBOstg1xAAYAQI+m2G3VJBOstpUnGXZmAQD0paSVfhW7rZqkwWqfnVkAAH24323193GQRbNEBPsyRGQQAKBFdlt1wh6svkw57Mz6KgAAtMJuq46ICPbpNnZmAQDUrkQC/2Zf/xyRwG6ICPZtiJ1ZAAA1uo3dVl0yweqbnVkAAPWx26pjJljbMcQBGAAA1zTFbqvuOeRiO6Z9/SKHiRYAAOsq38HKd7Hb0DURwW0pL0/amQUAsB67rTZGRHC7hogMAgAsyW6rDRIR3K4pdmYBACyl7LYqK3OmsCkigtzm8HSlRAbtzAIAuMyHu63YIA0WxX/s619zeMoyBACAc9zm0Fz9MWyWBot7dmYBAJzPbiv+m0MueMwQB2AAABxj2tevYmrFjxxywWOm2JkFAPCS+91Wmit+IiLIU+zMAgB4nN1WPElEkGMMERkEACjstuJZIoIcY4qdWQAAdlvxIhFBTnEbO7MAgO2ZcjjIwm4rXqTB4lT3O7OGff3PAAD07TZOCeQEGizOUV7s/D+xMwsA6JvdVpzMIRdcaogDMACAvkwxteJMDrngUlPszAIA+lEOsrDbirOJCDKH+51Z/5lDZNDOLACgNfe7rd7FbisuICLI3IaIDAIAbbHbitmICDK3KXZmAQDtsNuKWYkIspTb2JkFANRrit1WLECDxZLszAIAanQbpwSyEA0WS7MzCwCoid1WLMohF6xpiAMwAIDrmGJqxQoccsGaphz2SvwuAADrsduK1YgIsrayV+LfYmcWALC8EgMsccD/HbutWImIINc0RGQQAFiG3VZchYgg1zTFziwAYH52W3E1JljUYtzXNzHNAgDON+3r1zkcww5X4R0sajHFziwA4Hy3+/plDns44Wo0WNTEziwA4Bz3u60cZMHViQhSqyEOwAAAnjfFbisq45ALajXFziwA4Gl2W1ElEUFq9uHOrHIS0KsAAFtntxVVExGkFUNEBgFg625zOCVwClRKRJBWTLEzCwC2rEQCyymBU6BiJli0aIydWQCwFVPstqIh3sGiRVMOO7Ne5/BuFgDQp9vYbUVjNFi0qrzg+l3szAKAHpX7/D/EbisaJCJID4Y4AAMAejHFbisa5pALejDFziwA6IHdVjRPRJBe2JkFAO2y24puiAjSoyEigwDQitvYbUVHRATp0RQ7swCgBXZb0R0TLHo3xs4sAKjNFLut6JR3sOjdFDuzAKAmZc3K38RuKzqlwWIL7ndm/de+/joAwDXc77b6bRxkQcdEBNmaIQ7AAIC1TbHbio1wyAVbM8XOLABYk91WbIqIIFtkZxYALK9EAv92X19HJJANERFk64Z9/T4OwACAOd3Gbis2ygSLrStP1/4lh4cNYwCAS5VIYJlc/RDYIBMs+NkYO7MA4FxT7LYCEyz4wBQ7swDgHHZbwY80WPAxO7MA4Hh2W8EDIoLwtCF2ZgHAU6bYbQWfsAcLnjbt603szAKAh+y2gieICMLL7MwCgAO7reAFIoJwvCF2ZgGwXbex2wpeZIIFx7MzC4Ct+iqH5spuK3iBCRacp0yxyjRrCAD0a4rdVnASEyw4z/+NnVkA9M1uKziDBgvOZ2cWAD2y2wouICII8xhiZxYA7Zv29cs4yALOZg8WzGOKnVkAtO1+t9UU4GwigjAvO7MAaI3dVjAjEUFYxhA7swCo323stoJZmWDBMuzMAqB2dlvBAkywYHl2ZgFQkyl2W8FiTLBgeXZmAVALu61gYRosWMeHO7P+al9/GQBYj91WsBIRQVjfEDuzAFjPv+/rizjIAlZhDxasb4qdWQCso9xrxmiuYDUignA9dmYBsBS7reBKRATh+oZ9fRPHuQMwj9vYbQVXY4IF11eeMn4bO7MAuFw5xOLvYrcVXI0JFtTFziwAzjHFbiuoggkW1MXOLABOZbcVVESDBfWxMwuAY9htBRUSEYS6DbEzC4BP2W0FlbIHC+o25bAz66sAwIHdVlAxEUFow23szALYuhIJLO9a/XNEAqFaIoLQliF2ZgFs0W3stoImmGBBW+zMAtgeu62gISZY0K4hDsAA6NkUu62gOSZY0K7yJNPOLIA+lbTCr2K3FTRHgwVtszMLoC/3u63+Pg6ygCaJCEI/hogMArTMbivogD1Y0I8pdmYBtMpuK+iEiCD05zZ2ZgG0wm4r6IyIIPRriJ1ZADW7jd1W0B0TLOiXnVkA9bLbCjplggXbMMQBGAA1mHI4fv2PAbrkkAvYhmlfv8hhogXAdZRrcLkWa66gYyKCsB3l5Wk7swDWZ7cVbIiIIGzTEJFBgDXYbQUbIyII2zTFziyApZXdVmVlxhRgM0QEYdtuc3i6WiKDdmYBzOPD3VbAxmiwgP/Y17/m8JR1CACXuM2huXKQBWyUBgso7MwCuJzdVoBDLoBPDHEABsAppthtBfzIIRfAQ1PszAI4lt1WwEdEBIHH3O/M+s8cIoN2ZgF8zG4r4FEaLOA55Yns/8rhAAwAfvYv+3oXgAe8gwW85C7exwJ4qEywXgfgAe9gAc8Zo7kCeEzZHTgG4AENFvCcXQB4yhcBeEBEEHiOeCDA08QEgU+YYAFPGaO5AniOmCDwCQ0W8JRdAHiJmCDwERFB4CnigQAvm/b1JgA/MsECHlP2Xg0B4CVDxASBD2iwgMfsAsCxxgD8SEQQeIx4IMDxpogJAj8ywQIeEg8EOM0QUyzgRxos4KExAJxqDEA0WMCnvgwAp/osAPEOFvCxIYf3rwA4XXkPawqwaSZYwIcszAQ43y7A5mmwgA+JBwKcT0wQEBEEfjJEPBDgUq/39UOAzTLBAu6NAeBSuwCbpsEC7okHAlzu8wCbJiIIFEPEAwHmIiYIG2aCBRRjAJjLLsBmabCAQjwQYD5igrBhIoLAEPFAgLmJCcJGmWABYwCY2y7AJmmwAPFAgPmJCcJGiQjCtg0RDwRYipggbJAJFmzbGACW8kWAzdFgwba5+QMsRwQbNkhEELbr1b6+DwBLKfHANxEThE0xwYLtMr0CWFZ5kOVaCxujwYLtctMHWJ5rLWyMiCBsV4kHvgoASxIThI0xwYJtKk9UNVcAyyvX2rcBNkODBdsksgKwHqcJwoaICMI2iQcCrEdMEDbEBAu2RzwQYF1igrAhGizYHvFAgPW59sJGiAjC9tztawgAayrxwNcBumeCBdsyRnMFcA0lJjgG6J4GC7ZlFwCuRUwQNkBEELZFPBDgesQEYQNMsGA7xmiuAK5JTBA2QIMF27ELANcmJgidExGE7RAPBLg+MUHonAkWbMMYzRVADcQEoXMaLNgGkRSAergmQ8dEBGEbxAMB6jHt602ALplgQf/eRnMFUJMhYoLQLQ0W9G8XAGozBuiSiCD0TzwQoD5TxAShSyZY0DfxQIA6DTlco4HOaLCgb2MAqJXTBKFDGizo25cBoFafBeiOd7CgX0MO718BUK/yHtYUoBsmWNAv0ROA+u0CdEWDBf0SDwSon5ggdEZEEPo0RDwQoBWv9/VDgC6YYEGfxgDQil2AbmiwoE/igQDt+DxAN0QEoT9DxAMBWiMmCJ0wwYL+jAGgNbsAXdBgQX/EAwHaIyYInRARhL4MEQ8EaJWYIHTABAv6MgaAVu0CNE+DBX0RDwRol5ggdEBEEPrxal/fB4CWiQlC40ywoB9fBIDWuZZD4zRY0A83ZYD2iXpD40QEoQ/igQB9KPHANxEThGaZYEEfTK8A+lAemLmmQ8M0WNAHN2OAfnwWoFkigtCHEg98FQB6ICYIDTPBgvaV6ZXmCqAf5Zr+NkCTNFjQPvFAgP44TRAaJSII7RMPBOiPmCA0ygQL2jZGcwXQIzFBaJQGC9q2CwC9EgGHBokIQtvu9jUEgB6VeODrAE0xwYJ2jdFcAfSsxATHAE3RYEG7dgGgd2KC0BgRQWiXeCBA/8QEoTEmWNCmMZorgC0QE4TGaLCgTbsAsBVigtAQEUFok3ggwHaICUJDTLCgPWM0VwBbIiYIDdFgQXtERQC2x7UfGiEiCO0RDwTYnmlfbwJUzwQL2vI2miuALRoiJghN0GBBW3YBYKvGANUTEYS2iAcCbNcUMUGongkWtEM8EGDbhrgPQPU0WNCOMQBs3S5A1TRY0I4vA8DWfRagat7BgjYMObx/BQDlPawpQJVMsKANFkwCcG8XoFoaLGjD5wGAAzFBqJiIINRviHggAB97va8fAlTHBAvqNwYAPrYLUCUNFtTP6YEAPCQ6DpUSEYS6DREPBOBxYoJQIRMsqNsYAHjcLkB1NFhQN/FAAJ4iJggVEhGEeg0RDwTgeWKCUBkTLKjXGAB43i5AVTRYUC/xQABeIiYIlRERhDq92tf3AYDnlXjgm4gJQjVMsKBOXwQAXlYeyLlnQEU0WFAnN0sAjiVSDhUREYT6iAcCcAoxQaiICRbUx/QKgFOICUJFNFhQnzEAcJrPAlRBRBDqU+KBrwIAxxMThEqYYEFdSsRDcwXAqcq9422Aq9NgQV1k6AE4l9MEoQIiglAX8UAAziUmCBUwwYJ6jNFcAXA+MUGogAYL6rELAFxG1ByuTEQQ6nG3ryEAcL4SD3wd4GpMsKAOYzRX8JxpX7/8saYATykxwTHA1WiwoA67AE+53dcvfvzfUqXJ+jbAU8QE4YpEBKEO4oHwqRJ1+mpfXz/x59/t6x8DPCQmCFekwYLrG/d1E+BD075+ta8/vvDrhhx+foYAHyqT3tsAqxMRhOvbBfjQ73KIBL7UXBXTj7/2dwE+JCYIV2KCBdcnHggHJdb06319l/PscogMDgHEBOFKTLDgusb4MgjFbQ6TqHObq+J9DrGoYyZf0DunCcKVaLDgukQ44BDvm+v49SmHRu2rAGOA1YkIwnWJB7JlUw6RwNssY9zXN/EzxnZN+3oTYFUmWHA9b+OLH9tVooD3u62Wchs7s9i2IaZYsDoNFlzPLrA95cX73+ZwBPsPWd6Uw8/abwPbNAZYlYggXI94IFsz5bjdVksZYmcW2zNFTBBWZYIF1zHElzy25ZTdVkuZYmcW2zPE/QZW9RcBrmG3r78O9K/EAP92X1/v6//l+so/w7/t6z9zeA/yVaB//5Vl33cEPmCCBdfxZaB/t7l8t9VS3sfOLLbjswCr0WDB+oYcnpxDz+bcbbWUKXZmsQ1jxARhNRosWJ/lwvRsyqGx+k3a8S6HRmsK9GsXYBUaLFjf54E+rbHbaiklKmhnFj0TE4SVOKYd1jXkcDw79KQcZFFidl+nD2X69k+B/rzOOvvnYNNMsGBdY6AvUw5Tq16aq6L8u5S9QVOgL7sAi9NgwbqcHkhP7ndbTenPlEOTZWcWPRFRhxWICMJ6hogH0ocSMfp16jx+fQm7ff1jnMJGH8QEYWEmWLCeMdC+29S722op72NnFv3YBViUBgvWIx5I68pBFrXvtlrKFDuz6IOYICxMRBDWMUQ8kHZNOUQCb0NRFoX/PiKDtEtMEBZkggXrGANtanm31VLszKJ1uwCL0WDBOsQDaU15uv3bff0qnnQ/ZsrhS2r5PfL7Q2vEBGFBIoKwvFf7+j7Qjn/f1xexB+pYw75uIjJIO8pDgTfxcAAWYYIFy/si0I6y92mM5uoUU+zMoi3lwZ97EyxEgwXLcxOjBeVJdokD/iaeap+r/N6Vw0CmQP1E12EhIoKwLPFAWnAbjcGchn19E4fbUDcxQViICRYsawzUrRzSsNXdVkuZcvg9tTOLmokJwkI0WLAsNy9qNeXQBHwdlvIuhyPup0CdPgswOxFBWFaJB74K1KXstiqRQNGgdQw5NFveeaE2YoKwABMsWE6ZXmmuqIndVtcxxc4s6lTuUW8DzEqDBcsRD6QmZbdViauJBF5P+b0XGaQ2JqswMw0WLOfzQB3stqrHFDuzqIuHgTAzDRYsY4x4INdnt1W97MyiFuVeNQaYjQYLlrELXNdtDnG070Kt3udwkuNt4LpMsWBGThGEZdzlcHIYXEM5TMG7Vm15t69/DFxHmXC/DjALEyyY3xjNFdcxxW6rVr3L4d2sKbA+MUGYkQYL5rcLrO/bHCKBt6FVUw4N8reB9YkJwkxEBGF+4oGsqUR7voqpVW/KIRglMuiwHNYiJggz0WDBvMZ93QTWUXZblafOU+jRkMP1ZAisw6ErMAMRQZjXLrAOu636N+XwXtZXgXWICcIMTLBgXuKBLO1+t9Vt2JJdDpHBIbAcMUGYgQkWzGeMLz8s6zYOstiq9xHfYnlOE4QZaLBgPqIVLKnstipfsKewVVMOnwGRQZY0BriIiCDMRzyQJUz7+nVMLvjYEAdgsIwph3f/gDOZYME83sYXHeZntxVPmXL4bNiZxdyGmGLBRTRYMI9dYD7lRfMSCdz9+P/hMeWzscvhs+JzwpzGAGcTEYR5/CGHKRZcym4rzjFEZJD5TBEThLOZYMHlhmiumEfZbVU+S1PgNFPszGI+QzTrcDYNFlzO6YFcqsS7yulwvwlc5l0Oe9KmwGV2Ac6iwYLLfRk4320cZMG8voudWVzuswDAFQz7+pNSZ5aJFUt7l7Z+JlRdNQQ4mQkWXEY8kHNMOUytvg4s610O72ZNgdO5x8EZNFhwmc8Dp7nfbfXHwDqm2JnFedzjAFjVkLaiHuq69X1EArm+8hksn8WWfnbUdetVgJOYYMH5xsBxym4rkUBqUD6D5bM4BY6zC3ASDRac78vAy+y2ojZT7MzieGKCcKI/C3COYV93gadN+/p1HJVN3cohBv8Up8XxvNc57OsDjmCCBecZA0+7jT1EtOF+Z9Z3gaftAhxNgwXnEQ/kKb/N4QvrFGjDtK9fRWSQp4kJwglEBOF0Q8QD+dSUw5dUx6/TsmFfNxEZ5FNignAkEyw43Rj4WDnIwm4rejDFziwetwtwFA0WnM5me+6Vp7klEvibeLJLP8pneZfDIS0+19wTE4QjiQjCacrCxe8Dh91WpdmeAv0aIjLIQWm230TTDS8ywYLTmF5R2G3FVkyxM4uD8oDRPRCA2ZWjjP+kNlt38Q4e21W+XJefgRZ+VtUydRMAmFF5etfKTVAt88ViCGzbsK/fp62fXTVflYh8uRcCzxARhOONYavstoKDKXZmbVlprsYAz9JgwfFkz7dnyuHI6q8DfOhdDu9mTWFrnCYIwGxKNKKlKIe6rEpTJQoDzys/I+VnpaWfbXVZiQkCMIsyvWrpBqgu+/KwC3CKXTyE2lKNAZ4kIgjHEQ/chrLbqkQC3wc4xfscfnamsAVfBgAu5Mls/+U9K5jHu7T1s69Or+8DABcY09aNT51WdxF3gbmNsTOr9xoDPEpEEF62C726zSHWdBtgTrc5rDb4LvRKdB6As92lraeK6rj6TYA1vEtb1wZ1XIkJAnCWMW3d8NTLdbevtwHWNMTDqh5rDPAJEUF43i705Hc5RAL/GGBNUw4/e78LPRETBOBkd2nraaJ6vOy2gnrs4mTWnq6tAHC0MW3d6NTjdZNDPAmoxxAPsHqpMcBHRAThabvQuhJHKieZTQFqMu3rzb6+Cq0TEwTgaHdp6ymi+rnu4qkqtGKM623LJSYIwFHKKXMt3eDUz3Wzr1cBWjLs633autaon2sM8BMRQXjcLrTmh339NodI4A8BWjLlcN0VGWzTGOAnfxbgMXdxMEJLpn39Ko5fhx4McThNa6Yc3qkDYoIFjynxwCG0wm4r6MsUO7NaM8QUC36iwYJP7UILSgzw1/v6TUQCoTflZ7r8bJef8Sm0YAwAPOEPaevl4i3WTUwZYSuGOGWwhfpDAOARQ9q6oW2xvg6wRe/S1rVqizUEEBGEByxMrNeUwwmBvwmwRe9icXjtdgGAB8QD66yb2G0FHAyxM6vmazUA/GRIWzeyLdT3MbECHleuDS1dz7ZSQ2DjRAThZ+KBdZlyiAN55wp4TLk2lN1LU6iJeymbp8GCn30eamG3FXCMKXZm1ca9FID/NqStCEavVSKBnn4C59jFce61lHdm2TQTLDgYw7Xd5vAk+rsAnO59DrFik+/r2wWAzbtJW08HeyvvWQFzepe2roG91U0A2LQhbd24eqq7mB4CyxgjMnjNEhNks0QEwRf8aylRwBIJvA3A/G5ziAx+G65hFwA26yZtPRVsvey2AtZmZ9b6dRMANmlIWzes1utuX28DsL4hIoNrl5ggmyQiyNaNYS12WwHXNMXOrLXtAsDmlPeAWnoa2GLZbQXUZhfTrDXqJgBsSokutHKTavnmOgSgPsO+/pC2rqmtVXnAJibI5ogIsmWmKsv6KocTvKYA1GfKITL4VVhKaa7cawE2RDxwmbqLd9uAtpTDd8q1q4VrbGt1EwA2QTxwmfp9xEGANg37ep+2rrktlJggwEaUyEJLN6gWbqB2WwE9sDNr/hoDQPfep62bU811FwdZAH0ZIjI4Z30TALpXJi6t3Jhqrq8j+gH0q1zjWrom11piggCdEw+c52bpZChgC3YxzZqjxgDQrfdp66ZUW91EJBDYliF2Zl1a3wSAbt2lrZtSTeUgC2DL3qWta3ZN9X0A6NKYtm5ItdRdxDsACjuzzq8xsAF/HtiWXThVWcj8i33dBoA/7uuX+/o2nMq7uwAduktbT/uuWXZbATyvXCOdSnvafQWAjoxp60Z0zSpPaIcA8JIhHt6dUmOgcyKCbMkuHON3OdwApwDwkmlfb3K4dvIyMUGAjtylrad8a5fdVgCX2cW95ph7DQAdGNPWDWjtuolIIMAchhyuqS1c+69VYwBo3vu0dfNZsxxkATC/d2nrXrBmfR0AmneXtm4+a9RdPEUEWJKdWY+XmCBA48oNrqUbzxr1+329CgBLGyJF8ViNAaBZJYrQ0k1nybLbCuA67Mz6uN4FgGbdpa2bzlJltxXAdQ1xT7qvuwDQJPHAQ5UpnkggQB3epa17yFI1BoDmbD0eWOIoYwCozS6mWe8CQHP+kLZuNnPWTUQCAWo2ZNs7s24CQFOGtHWjmbMcZAHQjndp6x4zZw0BoBmlyWjpJjNH3UUkEKBFQ7YZGXwXAJqxtXjg+zjIAqBlQ7a3M+smADRhSFs3mEvKbiuAvmxtZ9YQAKq3S1s3l3PLbiuAPg3ZTmTQQ0KABtykrZvLOWW3FUD/3qWte9M5dRMAqjakrRvLqWW3FcC27NL/NMsDQ4CK7dLWTeWUuolIIMAWDek7nSEmCFCxm7R1U3HzAeBY79LWvevYugkAVRrS1g3lmLrb19sAwMGQPiODYoJ04c8DfRnTl2/39YscTgsEgGLK4d7wbfqyCwDVuUlbT+ueKrutADhGTzuzbgJAVYa0dSN5quy2AuAUQ/qJDIoJ0jwRQXoypn2/y+F9qykAcJxpX2/29VXa90UAqMZ3aesp3YdltxUAcygNyl3augd+WDcBoAolUtDKzeOxm8kQAJjHkHbfSS4PHMUEASqwS1s3kPtykAUAS3mXtu6J97ULAFfXWjzwLnZbAbC8Ie1FBm8CwNW1ctMo9T7iDwCsp9xz3qed+6SYIMCVlRd6W7lhiAQCcC27tLMzawwAV/M+9d8o7LYCoAZD2ogMfhMArqb2p3FfBwDq8i513zvFBAGupOZ44F1EHACoV+07s8YAsLr3qfOmcBORQADqN+zr96nzXvpNAFjdXeq7ITjIAoDWvEt999PvA8CqxtR1I7iL3VYAtGtIfQ8uxwCwmvep5wZQDrLwMi4ArattZ5aDogBWdJfrX/jttgKgR7vUcUqvmCDASsZc/6JvtxUAPRtSx8PMMQAs7n2ue7EXWQBgK97FPRege3e5zkW+/H3HAMC2XHNnlpggwMLGXOcCfxMHWQCwXUOutzNrDACLeZ/1L+wOsgCAg3dZ/z4sJgiwoLusd0Evfy+7rQDgY0PWvx8DsIDS7Kx1MbfbCgCeVu6R5V651n15DACzW+NCXl6m3QUAOMYu6+zMehcAZneXZS/edlsBwOmGLH+PvgsAs1o6HugFWgC4zLsse68eA8Bs3mW5J2JjAIA5jFlumvUuAMzmD5n/Qn0TB1kAwNyGLLMz6yYAzGLI/Bdpu60AYFnvMv/9ewgAFyvN0FwX5rvYbQUAaxkyb2TwXQC42FzxQLutAGB9c+7MugkAFxly+cXYbisAuL5d5plmDQHgbLtc/qRrCABQgyGXN1neowa4QGmQLokEAgD1eZfLHp4CcIYh511472K3FQDUbsz50yzvVAOcYZfznmq56AJAG4Z9vY+YIMAqSrN07IW2HGThYgsAbXqX0x+oAnCCIadFAu22AoC2DTktMiixAnCCXY67uNptBQD9OGVnluQKwAnK6P+lSOAuAECPdnl5miUmCHCkIS9fUIcAAD0b8nKTJcUCcIRdno8EAgDb8S5Pfy/YBYAXfZfHD7IYAwBs0ZjHp1liggAvKKP+hxfP30cEAAC2bsinO7PKO9m+IwA8Yxe7rQCAp5XvBmKCAEe6jweWGIDdVgDAY4b8HBkUEwR4Rpla2W0FALzkfmeWmCDAE8Z9fREAgOPtYn0LAAAA9OX/A00/xzQdfMQbAAAAAElFTkSuQmCC",
-  "width": 428,
-}
-`;
-
-exports[`assetLoader should inline asset with scales (2) - React Native >=0.72 2`] = `
-"/
-└─ out/
-   └─ main.js"
-`;
-
-exports[`assetLoader should inline asset with scales (3) - React Native <0.72 1`] = `
+exports[`assetLoader should inline asset with scales (3) 1`] = `
 {
   "height": 362,
   "scale": 3,
@@ -440,28 +410,13 @@ exports[`assetLoader should inline asset with scales (3) - React Native <0.72 1`
 }
 `;
 
-exports[`assetLoader should inline asset with scales (3) - React Native <0.72 2`] = `
+exports[`assetLoader should inline asset with scales (3) 2`] = `
 "/
 └─ out/
    └─ main.js"
 `;
 
-exports[`assetLoader should inline asset with scales (3) - React Native >=0.72 1`] = `
-{
-  "height": 362,
-  "scale": 3,
-  "uri": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAABHYAAAQ+CAYAAAC6OriBAAAACXBIWXMAACxLAAAsSwGlPZapAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAFJNSURBVHgB7N09mxzltQbqZ7NPQDj6BzWZQykjo8hMxBA6ogmJDsqsaKPMmVGGI0zoyFJGRp9fsE2mTKXMGZA583nfXcgIMTPq7qmqro/7vq512dvG3oDno/vp9axKAADWrfl5AABW550AAKzbVZldAABW6P8JAMC6fVLmxwAAAACwKE2Zf/88TQAAVkYVCwBYs6vX/vkuAAAAACzGd/llY+e7AAAAALAITX4JdV7NRQAAVkQVCwBYq/aaf20XAAAAAGbv9RqWOhYAAADAQjT5baijjgUArI4qFgCwRu0t/94uAAAAAMzWdTUsdSwAAACAmWtyc6ijjgUArIoqFgCwNu0Bf8wuAAAAAMzObTUsdSwAAACAmaoVq38fMD9EHQsAWAFVLABgTa4O/OMujvhjAQAAAJjA0xy2saOOBQAAADAjh9aw1LEAgNVQxQIA1qLNcdSxAIDFE+wAAGtxSkjzfgAAAAA4u1qt+nfUsQAAAAAWpW7r/PvEaQMAsFCqWADAGtzlVs4nAQAAAOBsTqlhvV7HAgAAAOAM2pwe6qhjAQCLpooFACzdLnfnsecAAAAAZ/Aid9/YUccCAAAAmFibu4c66lgAwGKpYgEAS7bLcNSxAAAAACY0RA1LHQsAAABgYm2GC3XUsQCARVLFAgCWapfhqWMBAAAATGDIGpY6FgAAAMBE2gwf6qhjAQCLo4oFACzRmJWpNgAAAACMZowa1qt5EQAAAABGcT/jhTrqWADAoqhiAQBLs8v42gAAAAAwuP/N+Bs7LwIAAADAoJqMH+q8miYAADOnigUALMmYT8N60y4AAAAADGaKGtar+S4AAAAADKLJdKGOOhYAsAiqWADAUkxZwzrn/08AAACA1anVqKk3dtSxAAAAAO6oyfShzqu5CADATKliAQBL0OZ8dgEAAADgZLUSda6NHXUsAAAAgBM1OV+oo44FAMyaKhYAMHdtzm8XAAAAAI5Wq1Dn3tj5LgAAAAAcpcn5Qx11LABgtlSxAIA5azMfuwAAAABwsFqBmsvGzncBAAAA4CC1+jSXUKfOD1HHAgBmRhULAJirq8xLDXXm9ucEAGycYAcAmKs5hiifBAAAAIBbza2GpY4FAMySjR0AYI7azFMNddoAAMyEYAcAmKM537L5KAAAAADcqFae5ljFUscCAGbFxg4AMDd1W2fOwUn9c7sfAIAZEOwAAHOzhEeKfxIAgBn4rwAAzMsSqk4/lrkXAIAzs7EDAMxJm2Xcr/F0LABgFgQ7AMCc7LIcS6iMAQAAAEzmReb7NKzrno4FAAAAQPpq01JCnVfTBgDgjFSxAIC52GV51LEAAAAAsqwaljoWAAAAwM/aLCvQUccCAGZBFQsAmINdlksdCwAAANi0F1nWlo46FgAAAEBxP8sKctSxAIDZUMUCAM5tl+VrAwAAALBBL7Ks7Zzr5kUAAAAANmYNNSx1LADgbFSxAIBz2mU92gAATEywAwCc0/tZj48CAAAAsBFNllW1OmSaAABMyMYOAHAuV1mfXQAAJiTYAQDO5ZOsz/sBAAAAWLkmy6pYqWMBALNkYwcAOIc11rBeWfNfGwAwM4IdAOAc1vwEKU/HAgAm818BAJhWU+ZF1u1emR8DADAyGzsAwNTarN8uAAATEOwAAFP7JOunjgUATEIVCwCYUpP117BeUccCAEZnYwcAmFKb7dgFAGBkgh0AYEpbqGG9oo4FAIxOFQsAmEqT7dSwXlHHAgBGZWMHAJhKm+3ZBQBgRIIdAGAqV9kedSwAYFSqWADAFC7K/JDtqTWsy6hjAQAjsbEDAExhi9s6VQ20tvrXDgBMQLADAExhy+HGlp4EBgBMTBULABjbVmtYr6hjAQCjsbEDAIytzbbVYKsNAMAIBDsAwNjcmPF0LABgJKpYAMDYag3rItumjgUAjMLGDgAwprqts/VQp6p/D+4HAGBggh0AYExqWL/wdCwAYHCqWADAmF6UaUJVa1j3AgAwIBs7AMBY2gh1XufpWADA4AQ7AMBYduFNqmkAwKBUsQCAsahh/ZY6FgAwKBs7AMAY2gh1rqOOBQAMSrADAIxhF26ijgUADEYVCwAYgxrWzdSxAIDB2NgBAIbWRqhzG3UsAGAwgh0AYGi78DbqWADAIFSxAIChqWG9nToWADAIGzsAwJDuR6hzCHUsAGAQgh0AYEi7cKg2AAB3pIoFAAxJDetwXZnLAADcgY0dAGAoaljHaWJrBwC4I8EOADCUXThWGwCAOxDsAABDeT8cy98zAOBO3NgBAIbQpL+vw/HqnZ0uAAAnsLEDAAzhKpxqFwCAEwl2AIAhfBJOpY4FAJxMFQsAuKsmalh3pY4FAJzExg4AcFdtuCtVNgDgJIIdAOCu1LDu7qMAAJxAFQsAuIsmalhDuVfmxwAAHMHGDgBwF20Yyi4AAEcS7AAAd6GGNRx1LADgaKpYAMCpmqhhDU0dCwA4io0dAOBUbRjaLgAARxDsAACnUsManjoWAHAUVSwA4BRN1LDGoo4FABzMxg4AcIo2jOUqAAAHEuwAAKcQPoxHxQ0AOJgqFgBwrIsyP4Sx1BrWZdSxAIAD2NgBAI5lW2dcNTjz9xgAOIhgBwA4ltBhfOpYAMBBVLEAgGP9O4xNHQsAOIiNHQDgGLZ1plHrWPcDAPAWgh0A4BiCnemoYwEAb6WKBQAcoz4N6yJMQR0LAHgrGzsAwKHqto5QZzrqWADAWwl2AIBDqWFNTx0LALiVKhYAcKgXZZowpVrDuhcAgBvY2AEADtFGqHMOtY7VBgDgBoIdAOAQu3AuKnAAwI1UsQCAQ6hhnY86FgBwIxs7AMDbtBHqnJM6FgBwI8EOAPA2u3Bu6lgAwLVUsQCAt1HDOj91LADgWjZ2AIDbtBHqzIE6FgBwLcEOAHCbXZgLdSwA4DdUsQCA26hhzUdX5jIAAK+xsQMA3OR+hDpz0kQdCwB4g2AHALjJLsxNGwCA16hiAQA3UcOany7qWADAa2zsAADXUcOapya2dgCA1wh2AIDreALTfLUBAPiZYAcAuM5HYa7eDwDAz9zYAQDe1KS/r8N81Ts7XQCAzbOxAwC8SQ1r/nYBAIhgBwD4rU/C3KljAQD/RxULAHhdEzWspVDHAgBs7AAAv9KGpVCZAwAEOwDAr6hhLYcnlwEAqlgAwH80UcNamntlfgwAsFk2dgCAV9qwNLsAAJsm2AEAXlHDWh51LADYOFUsAKBqooa1VOpYALBhNnYAgKoNS7ULALBZgh0AoFLDWi51LADYMFUsAKCJGtbSqWMBwEbZ2AEA2rB0VwEANkmwAwAIBZZPlQ4ANkoVCwC27aLMD2Hpag3rMupYALA5NnYAYNts66xDDej8bwkAGyTYAYBtEwashzoWAGyQKhYAbFutYV2ENVDHAoANsrEDANtVt3WEOutR/7e8HwBgUwQ7ALBdaljro44FABujigUA26WGtT7qWACwMTZ2AGCb1LDWSR0LADZGsAMA26SGtV7+twWADVHFAoBtelGmCWtUa1j3AgBsgo0dANieNkKdNat1rDYAwCYIdgBge3Zh7dSxAGAjVLEAYHvUsNZPHQsANsLGDgBsSxuhzhaoYwHARgh2AGBbdmEr1LEAYANUsQBgW9SwtkMdCwA2wMYOAGxHG6HOlqhjAcAGCHYAYDt2YWvUsQBg5VSxAGA71LC2pytzGQBgtWzsAMA23I9QZ4uaqGMBwKoJdgBgG3Zhq9oAAKuligUA26CGtV1d1LEAYLVs7ADA+qlhbVsTWzsAsFqCHQBYvzZsXRsAYJUEOwCwfp+ErXs/AMAqubEDAOvWpL+vA/XOThcAYFVs7ADAul0FersAAKsj2AGAdVPD4hV1LABYIVUsAFivJmpY/Nq9Mj8GAFgNGzsAsF5t4Nd2AQBWRbADAOulhsWbPgoAsCqqWACwTk3UsLieOhYArIiNHQBYpzZwvV0AgNUQ7ADAOqlhcRN1LABYEVUsAFifJmpY3E4dCwBWwsYOAKxPG7jdLgDAKgh2AGB91LB4G3UsAFgJVSwAWJcmalgcRh0LAFbAxg4ArEsbOMxVAIDFE+wAwLp4s86hVPYAYAVUsQBgPS7K/BA4TK1hXUYdCwAWzcYOAKyHbR2OUYNAXzMAsHCCHQBYD2/SOZavGQBYOFUsAFiPWsO6CBxOHQsAFs7GDgCsQ928EOpwrPo1cz8AwGIJdgBgHVRqOJWnYwHAgqliAcA6qGFxKnUsAFgwGzsAsHxqWNyFOhYALJhgBwCWTw2Lu/I1BAALpYoFAMv3okwTOF2tYd0LALA4NnYAYNnaCHW4u1rHagMALI5gBwCWbRcYhjoWACyQKhYALJsaFkNRxwKABbKxAwDL1Uaow3DUsQBggQQ7ALBcu8Cw1LEAYGFUsQBgudSwGJo6FgAsjI0dAFimNkIdhqeOBQALI9gBgGVSmWEsvrYAYEFUsQBgmdSwGEtX5jIAwCLY2AGA5bkfoQ7jaaKOBQCLIdgBgOXZBcbVBgBYBFUsAFgeNSzG1kUdCwAWwcYOACyLGhZTaNJ/rQEAMyfYAYBlaQPT8HQsAFgAwQ4ALMsngWm8HwBg9tzYAYDlaNLf14Gp1Ds7XQCA2bKxAwDLoRrD1HYBAGZNsAMAy6GGxdTUsQBg5lSxAGAZmqhhcR73yvwYAGCWbOwAwDK0gfPYBQCYLcEOACyDGhbn8lEAgNlSxQKA+WuihsV5qWMBwEzZ2AGA+WsD57ULADBLgh0AmD81LM5NHQsAZkoVCwDmrYkaFvOgjgUAM2RjBwDmrQ3Mwy4AwOwIdgBg3tSwmAt1LACYIVUsAJivizI/BOZDHQsAZsbGDgDM11VgXnxNAsDMCHYAYL68iWZuVAMBYGZUsQBgntSwmKNaw7qMOhYAzIaNHQCYJ9s6zFENHH1tAsCMCHYAYJ68eWaufG0CwIyoYgHAPNUa1kVgftSxAGBGbOwAwPzUjQihDnNVvzbvBwCYBcEOAMyPqgtz5+lYADATqlgAMD9qWMydOhYAzISNHQCYlzZCHeZPHQsAZkKwAwDzsgssg8ogAMyAKhYAzMuLMk1g/moN614AgLOysQMA89FGqMNy1DpWGwDgrAQ7ADAfu8CyqGMBwJmpYgHAfKhhsTTqWABwZjZ2AGAe2gh1WB51LAA4M8EOAMzDLrBM6lgAcEaqWAAwD2pYLJU6FgCckY0dADi/NkIdlksdCwDOSLADAOenysLS+RoGgDNRxQKA81PDYum6MpcBACZnYwcAzut+hDosXxN1LAA4C8EOAJzXLrAObQCAyaliAcB5qWGxFl3UsQBgcjZ2AOB81LBYkya+ngFgcoIdADifNrAuuwAAkxLsAMD5fBJYl/cDAEzKjR0AOI8m/X0dWJt6Z6cLADAJGzsAcB5XgXXaBQCYjGAHAM7jo8A6qWMBwIRUsQBgek3UsFi3e2V+DAAwOhs7ADC9NrBuuwAAkxDsAMD0PA2LtVM1BICJqGIBwLSaqGGxDepYADABGzsAMK02sA27AACjE+wAwLTUsNgKdSwAmIAqFgBMp4kaFtuijgUAI7OxAwDTaQPbsgsAMCrBDgBMRw2LrVHHAoCRqWIBwDQuyvwQ2B51LAAYkY0dAJjGVWCbfO0DwIgEOwAwDW9u2SoVRAAYkSoWAIxPDYstqzWsy6hjAcAobOwAwPhs67BlNdj0PQAAIxHsAMD4vKll694PADAKVSwAGF+tYV0EtksdCwBGYmMHAMZVt3WEOmxd/R64HwBgcIIdABiXGhb0PB0LAEagigUA41LDgp46FgCMwMYOAIynjVAHXlHHAoARCHYAYDy7AK9TTQSAgaliAcB4XpRpArxSa1j3AgAMxsYOAIyjjVAH3lTrWG0AgMEIdgBgHLsA11HHAoABqWIBwDjUsOB66lgAMCAbOwAwvDZCHbiJOhYADEiwAwDD2wW4jToWAAxEFQsAhqeGBbdTxwKAgdjYAYBhtRHqwNuoYwHAQAQ7ADAsFRM4TBsA4M5UsQBgWGpYcJiuzGUAgDuxsQMAw7kfoQ4cqomtHQC4M8EOAAxnF+AYbQCAO1HFAoDhqGHBcbqoYwHAndjYAYBhNBHqwLGa+L4BgDsR7ADAMDwNC06zCwBwMsEOAAzjkwCneD8AwMnc2AGAu2vS39cBTlPv7HQBAI5mYwcA7k4NC+5mFwDgJIIdALi7jwLchToWAJxIFQsA7qaJGhYM4V6ZHwMAHMXGDgDcTRtgCLsAAEcT7ADA3XgaFgxDpREATqCKBQCna6KGBUNSxwKAI9nYAYDTtQGGtAsAcBTBDgCcTg0LhqWOBQBHUsUCgNM0UcOCMahjAcARbOwAwGnaAGPYBQA4mGAHAE6jhgXjUMcCgCOoYgHA8S7K/BBgDLWGdRl1LAA4iI0dADjeVYCx1ODU9xgAHEiwAwDH86YTxqXqCAAHUsUCgOOoYcH41LEA4EA2dgDgOG2AsaljAcCBBDsAcBxvNmEa7wcAeCtVLAA4Tq1hXQQYmzoWABzAxg4AHK5u6wh1YBr1e+1+AIBbCXYA4HBqWDAtT8cCgLdQxQKAw6lhwbRqDeteAIAb2dgBgMO0EerA1Or3XBsA4EaCHQA4zC7AOahAAsAtVLEA4DAvyjQBpqaOBQC3sLEDAG/XRqgD56KOBQC3EOwAwNvtApyTOhYA3EAVCwDeTg0LzksdCwBuYGMHAG7XRqgD56aOBQA3EOwAwO12AeZAHQsArqGKBQC3U8OCeVDHAoBr2NgBgJu1EerAXKhjAcA1BDsAcDPVD5iXNgDAr6hiAcDN1LBgXroylwEA/sPGDgBc736EOjA3TWztAMCvCHYA4Hq7AHPUBgD4D8EOAFzv/QBz9EkAgP9wYwcAfqtJf18HmKd6Z6cLAGBjBwCu4WlYMG+7AAD/R7ADAL+l6gHzpioJAD9TxQKAX2uihgVLoI4FALGxAwBvUsOCZfC9CgAR7ADAmz4KsAS+VwEgqlgA8LomaliwJPfK/BgA2DAbOwDwizbAkuwCABsn2AGAX3gaFiyLOhYAm6eKBQC9JmpYsETqWABsmo0dAOi1AZZoFwDYMMEOAPTUsGCZ1LEA2DRVLABQw4KlU8cCYLNs7ACAGhYs3S4AsFGCHQBQw4KlU8cCYLNUsQDYuosyPwRYslrDuow6FgAbZGMHgK27CrB0NaD1vQzAJgl2ANg6bwZhHVQqAdgkVSwAtkwNC9ZDHQuATbKxA8CWtQHWoga1bQBgYwQ7AGyZGhasi6djAbA5qlgAbFmtYV0EWAt1LAA2x8YOAFtVt3WEOrAu9Xv6fgBgQwQ7AGyVGhask6djAbApqlgAbJUaFqxTrWHdCwBshI0dALaojVAH1srTsQDYFMEOAFu0C7BmqpYAbIYqFgBb9KJME2Ct1LEA2AwbOwBsTRuhDqydOhYAmyHYAWBrdgG2QB0LgE1QxQJga9SwYBvUsQDYBBs7AGxJG6EObIU6FgCbINgBYEt2AbZEHQuA1VPFAmBL1LBgW9SxAFg9GzsAbMX9CHVga9SxAFg9wQ4AW7ELsEVtAGDFVLEA2Ao1LNimrsxlAGClbOwAsAVqWLBdTWztALBigh0AtmAXYMvaAMBKCXYA2IL3A2zZRwGAlXJjB4C1a9Lf1wG2rd7Z6QIAK2NjB4C1uwqASiYAKyXYAWDtPgmASiYAK6WKBcCaNVHDAn6hjgXA6tjYAWDN1LCA1/mZAMDqCHYAWDNPwgFe52cCAKujigXAWjVRwwJ+616ZHwMAK2FjB4C1agPwW7sAwIoIdgBYK0/DAq6jjgXAqqhiAbBGTdSwgJupYwGwGjZ2AFijNgA32wUAVkKwA8AaqWEBt1HHAmA1VLEAWJsmaljA26ljAbAKNnYAWJs2AG+3CwCsgGAHgLW5CsDbqWMBsAqqWACsyUWZHwLwdrWGdRl1LAAWzsYOAGtiWwc4VA2C/cwAYPH+n5//0S82ANbA07CAY/y/AYCFe72K9XmZPwcAAACAuat14sdv3thpynz38z8CAAAAMD9dmQ/qP75zzb9Rj8g9CQAAAABzUzObB+kznPz3DX/Qt2Velrmf/v4OAAAAAOdTq1d/KPNlmX+9+hff9rjzpszf0wc8AAAAAExvX+bT/Lyl87r/fst/sKZBf0kfALUBAAAAYEqP04c6P173b75tY+d1dWunbu80AQAAAGBMXfpAZ3/bH/S2jZ3X/bPMszL3opoFAAAAMJanZT4s8/xtf+AxwU7148//5T+V+X0AAAAAGErNXR6VeZjXDiTf5pgq1puaMt9FNQsAAADgrroyH+SaA8m3eSen68pcpn9+OgAAAACnqdnKgxwZ6lTHVrGu822Zl+nv7lwEAAAAgEPU6tUfynyZA6tXb7pLFetNTZmv47HoAAAAAG+zT//Uqy53MMTGzis1ZfomfVjUBgAAAIDr1OPIn6XPUu5kyI2d19Va1t/jsDIAAADAK136LZ19BjLkxs7r/lnmWZl76UMeAAAAgC17WubDMs8zoLGCnaquE9U/6Z/KvFfm3QAAAABsS81HHqWvX510IPk2Y1Wx3tSU+S6qWQAAAMB2fF/mKnc8kHybdzKNrsxl+ueyAwAAAKxdzUDajBjqVGNWsa7zbZmX6e/uXAQAAABgXWr16g9lvswI1as3TVXFelNT5ut4LDoAAACwHvv0T73qMpGpN3ZeqenVN+mDpTYAAAAAy1aPI3+WPvOYzLk2dl7XxGFlAAAAYJm69Fs6+5zBuTZ2XleTrGdl7qW/vQMAAACwBLWN9HGZ5zmTOQQ7VQ13npb5qcx7Zd4NAAAAwDzVHONRmT9mggPJt5lDFetNTVSzAAAAgHn6vsxVJjyQfJt3Mj9dmcsyjwMAAAAwH0/SPwSqy0zMpYp1nX2Zl+nv7lwEAAAA4Dxq9erDMl/lzNWrN82xivWmpszX8Vh0AAAAYHr79E+96jJDc97YeaWmYvXKdA2h2gAAAABM42GZz9JnE7O0hI2d1zVxWBkAAAAYV5d+S2efmVvCxs7rakL2rMy99Ld3AAAAAIZUW0Mfl3meBVhasFPVcOdpmZ/KvFfm3QAAAADcTc0bHpX5Y2Z2IPk2S6tivamJahYAAABwN9+XucpMDyTf5p0sW1fmsszjAAAAABzvSfpzL10WaIlVrOvs06drtZp1EQAAAIDb1erVh2W+yoKtJdip6lGjeli5pmxNAAAAAK63Tx/q/CMLt6Zgp6ppW71eXW8HtQEAAAD4tYdlPkufISze0o8n36aJw8oAAABAr0v/GPPFb+m8bunHk2/TlXmQfoMHAAAA2K6aDdSMYFWhTrW2Ktab6nPnn5b5Kf1h5XcDAAAAbEWtWz0q88f0GcHqrLmK9aYmqlkAAACwFfXp2VdZ6GPMD7XmKtabujKXZR4HAAAAWLMn6Z+a3WXl1l7Fus4+fWpXq1kXAQAAANaiVq/qY8y/ykZsMdipnpd5lj69awIAAAAs3T59qLO6A8m32WqwU9UUr17FrneG2gAAAABL9bDMZ+nf62/Klo4n36aJw8oAAACwNF2Zj7OxLZ3Xbel48m269M+z/yYAAADAEtQDyfW9/GZDnWrLVaw31efZPy3zMn01690AAAAAc1PrVo/KfJH+vfymqWJdr4lqFgAAAMxNfcr1VTbwGPNDqWJdrytzWeZxAAAAgDmo1av6dOsu/Icq1u326dPA98pcBAAAAJhal/5A8lfhNwQ7b/e8zLP0tazfBQAAAJjKPht/6tXbCHYOUw8z/S39TaI2AAAAwNgelvks/XtybuB48vGaOKwMAAAAY+liS+dgjicfryvzoMw3AQAAAIZUDyTX99xCnQOpYp3mX2WelnmZvpr1bgAAAIBT1brVozJfpH/PzYFUse6uiWoWAAAAnKo+jfoqHmN+ElWsu+vKXJZ5HAAAAOAYtXp1P0Kdk9nYGVZb5uvY3gEAAIDbdGU+Tf84c+7AjZ1hdWWepQ92fhcAAADgTfsyH5R5Hu5MsDO8evDpb+m3odoAAAAArzws81kcSB6MKta4mjisDAAAAF2Zj+Mx5oNzPHlcXZkH6Y9BAQAAwBbV98T1vbFQZwSqWOOr62XflnmZvpr1bgAAAGD96qmSWrv6U1SvRqOKNa0mqlkAAACs3/dlruIx5qNTxZpWV+ayzOMAAADAOtXq1f0IdSZhY+d82jJfx/YOAAAA69CV+TT948yZiBs759OVeVbmXvokEwAAAJZqX+aDMs/DpAQ751UPST1NvznVBgAAAJalvq99lP5IsgPJZ6CKNR9NHFYGAABgOboyH8djzM/K8eT56Mo8SH9kCgAAAOasvnet72GFOmemijUvdW3t2zIv09/duQgAAADMR61e1drVn6J6NQuqWPPVRDULAACA+dinf+pVF2ZDFWu+ujKXZR4HAAAAzqtWr+pTr7owKzZ2lqEt83Vs7wAAADCtLv2Wzj7Mkhs7y9CVeVbmXvrbOwAAADC2ffotnedhtgQ7y1EPVD1Nv2XVBgAAAMZR338+Sn8k2YHkmVPFWqYmDisDAAAwvK7Mx/EY88VwPHmZujIP0h+vAgAAgCHU95j1vaZQZ0FUsZarrsN9W+Zl+rs7FwEAAIDj1erVH8p8GdWrxVHFWoemzN/jsDIAAADH2ad/6lUXFsnGzjrUdPUvcVgZAACAw9XqVd3U+TEslo2d9WnLfB2HlQEAALhel35LZx8Wz8bO+nRlnpW5F9UsAAAAfu1pmQ/LPA+rINhZp7pGV79Zfyrz+wAAALB19X3iozIP40DyqqhirV9T5ruoZgEAAGxVV+bjeIz5Kr0T1q4r8yD9USwAAAC2pb4XrO8JhTorpYq1DXXN7tsyL9Pf3bkIAAAAa1arV/WJV19G9WrVVLG2pynz9zisDAAAsFb79E+96sLq2djZnpra/iV9qNcGAACANXmcPtT5MWyCjZ1tq1s7dXunCQAAAEvWpQ909mFTbOxs2z/LPCtzL6pZAAAAS/W0zIdlnofNEexQ1/PqD4Gfyvw+AAAALEV9P/eozMM4kLxZqli8rinzXVSzAAAA5q4r80EcSN68dwK/6MpclnkSAAAA5qq+Z3sQoQ5RxeJ635Z5mf7uzkUAAACYg1q9+kOZL6N6xc9UsbhNk/6pWQ4rAwAAnNc+/VOvusBrbOxwm5oG/yV9ANgGAACAc3icPtT5MfAGGzscqm7t1O2dJgAAAEyhSx/o7AM3sLHDof5Z5lmZe1HNAgAAGNvTMh+WeR64hWCHY9S1v/rD5acy75V5NwAAAAypvu96VOZhHEjmAKpYnKop811UswAAAIbyfZmrOJDMEd4JnKYrc1nmSQAAALir+t6qjVCHI6licVfflnmZ/u7ORQAAADhGrV79ocyXUb3iBKpYDKUp83U8Fh0AAOBQ+/RPveoCJ7Kxw1BqyvxN+rCwDQAAALepx5E/S/9eCk5mY4cx1FrW3+OwMgAAwJu69Fs6+8AAbOwwhn+WeVbmXvqQBwAAgORpmQ/LPA8MRLDDWOo6Yf2h9VOZ98q8GwAAgG2q748epa9fOZDMoFSxmEJT5ruoZgEAANvzfZmrOJDMSN4JjK8rc1nmSQAAALajvgdqI9RhRKpYTOnbMi/T3925CAAAwDrV6lW9pfNVVK8YmSoW59CU+Toeiw4AAKzPPv1Tr7rABGzscA41vf4mfbDYBgAAYB3qceTP0r/ngUnY2OHcmjisDAAALFuXfktnH5iYjR3OrSbZz8rcS397BwAAYElqG+HjMs8DZyDYYQ5quPO0zE9l3ivzbgAAAOatvo95VOaPcSCZM1LFYm6aqGYBAADz9n2ZqziQzAy8E5iXrsxlmccBAACYnyfpHwLTBWZAFYu52pd5mf7uzkUAAADOq1avPizzVVSvmBFVLOauKfN1PBYdAAA4n336p151gZmxscPc1VS8XpmvIWQbAACAaT0s81n69yYwOzZ2WJImDisDAADT6NJv6ewDM+Z4MkvSlXmQfoMHAABgLPU9R33vsQ/MnCoWS1OPlD0t81OZ98q8GwAAgGHUutWjMn+MA8kshCoWS9ZENQsAABjG92Wu4kAyC6OKxZJ1ZS7LPA4AAMDpnpS5H6EOC6SKxRrs06frtZp1EQAAgMPU6tWHZb4KLJRgh7V4XuZZ+pS9CQAAwO326UOdfwQWTLDDmtS0vV6vr7ej2gAAAFzvYZnP0r+HgEVzPJm1auKwMgAA8GtdmY9jS4cVcTyZterKPEi/wQMAAFDfG9T3CEIdVkUVizX7V5mnZX5Kf1j53QAAAFtT61aPyvwx/XsEWBVVLLaiiWoWAABsTX167lU8xpwVU8ViK7oyl2UeBwAA2IIn6Z+a2wVWTBWLrdmnT+1rNesiAADA2nTpDyR/FdgAwQ5b9LzMs/S1rN8FAABYi3089YqNEeywVfWA2t/S35lqAwAALN3DMp+lf60Pm+F4MjisDAAAS9bFlg4b5ngy9L8IHpT5JgAAwJLUA8n1tbxQh81SxYLev8o8LfMyfTXr3QAAAHNV61aPynyR/rU8bJYqFvxWE9UsAACYq/qU26t4jDn8H1Us+K2uzGWZxwEAAOakVq/uR6gD/6GKBTfbp/804L0yFwEAAM6lS38g+asAvyLYgds9L/MsfS3rdwEAAKa2j6dewY0EO/B29TDb39LfpGoDAABM5WGZz9K/Jgeu4XgyHKeJw8oAADC2LrZ04CCOJ8NxujIP0h9tAwAAhldfa9fX3EIdOIAqFhzvX2W+LfMyfTXr3QAAAHdV61a1dvWn9K+5gQOoYsHdNFHNAgCAu6pPo72Kx5jD0VSx4G66MpdlHgcAADhFrV7dj1AHTmJjB4bTlvk6tncAAOAQXZlP0z/OHDiRGzswnK7Ms/TBzu8CAADcZF/mgzLPA9yJYAeGVQ++/S39NlwbAADgTQ/TH0l2IBkGoIoF42nisDIAALzSlfk4HmMOg3I8GcbTlXmQ/hgcAABsWX1NXF8bC3VgYKpYMK66XvptmZfpL/1fBAAAtqOeKqi1qz9F9QpGoYoF02mimgUAwHbs0z/1qgswGlUsmE5X5rLM4wAAwLrV6lV96lUXYFQ2duA82jJfx/YOAADr0qXf0tkHmIQbO3AeXZlnZe6lv70DAABLt0+/pfM8wGQEO3A+9ZDc0/Sbc20AAGCZ6uvaR+mPJDuQDBNTxYJ5aOKwMgAAy9OV+TgeYw5n43gyzENX5kH6I3MAALAE9bVrfQ0r1IEzUsWC+ahrq9+WeZn+7s5FAABgfmr1qtau/hTVKzg7VSyYpyaqWQAAzM8+/VOvugCzoIoF89SVuSzzOAAAMA+1elWfetUFmA0bOzB/bZmvY3sHAIDz6NJv6ewDzI4bOzB/XZlnZe6lv70DAABTeVrmwzLPA8ySYAeWoR6oq79Ufyrz+wAAwLjq689HZR7GgWSYNVUsWJ4mDisDADCerszH8RhzWATHk2F5ujIP0h+vAwCAIdXXmPW1plAHFkIVC5aprsN+W+Zl+rs7FwEAgNPV6tUfynwZ1StYFFUsWL6mzN/jsDIAAKfZp3/qVRdgcWzswPLVT1f+kj6obQMAAIer1au6qfNjgEWysQPr0pb5Og4rAwBwuy79ls4+wKLZ2IF16co8K3MvqlkAAFzvaZkPyzwPsHiCHVifukZbf1n/VOb3AQCAXn2d+KjMwziQDKuhigXr1pT5LqpZAABb15X5OB5jDqvzToA168pcpj+KBwDANtXXgg8i1IFVUsWCbfi2zMv0d3cuAgDAFtTqVX3i1ZdRvYLVUsWCbWnK/D0OKwMArN0+/VOvugCrZmMHtqV+avOX9KFuGwAA1uhx+lDnxwCrZ2MHtqtu7dTtnSYAAKxBlz7Q2QfYDBs7sF3/LPOszL2oZgEALN3TMh+WeR5gUwQ7sG11Pbe+CPipzO8DAMDS1Ndzj8o8jAPJsEmqWMArTZnvopoFALAUXZkP4kAybNo7Aeh1ZS7LPAkAAHNXX7M9iFAHNk8VC3jTt2Vepr+7cxEAAOakVq/+UObLqF4BUcUCbtakf2qWw8oAAPOwT//Uqy4AP1PFAm7SpV/vfRwAAM6tHkd2Twf4DRs7wCHq1k7d3mkCAMCUuvRbOvsAXMONHeAQ/yzzrMy9qGYBAEzlaZkPyzwPwA0EO8Ch6qG++uLipzLvlXk3AACMob7uepS+fuVAMnArVSzgFE2Z76KaBQAwtO/LXMUtHeBAjicDp+jKXJZ5EgAAhlJfW7UR6gBHUMUC7uLbMi/T3925CAAAp6jVqz+U+TKqV8CRVLGAITRlvk7/CRMAAIfbp3/qVReAE9jYAYZQP2X6Jn1Y3AYAgEPU48ifpX8tBXASGzvA0Got6+9xWBkA4CZd+i2dfQDuyMYOMLR/lnlW5l76kAcAgF88LfNhmecBGIBgBxhDXSeuL1p+KvNemXcDALBt9fXRo/T1KweSgcGoYgFja8p8F9UsAGC7vi9zFQeSgRG8E4BxdWUuyzwOAMD2PEn/cIkuACNQxQKmsi/zMv3dnYsAAKxbrV7VWzpfRfUKGJEqFjC1pszX8Vh0AGC99umfetUFYGQ2doCp1U+vvkkfLLcBAFiXehz5s/SveQBGZ2MHOKcmDisDAOvQpd/S2QdgQjZ2gHOqn2Q9K3Mv/e0dAIAlqtvIH5d5HoCJCXaAc6vhztMyP5V5r8y7AQBYhvo65lGZP8aBZOBMVLGAOWmimgUALMP3Za7iQDJwZu8EYD66MpdlHgcAYL6epH8IRBeAM1PFAuZoX+Zl+rs7FwEAmIdavfqwzFdRvQJmQhULmLOmzNfxWHQA4Pz26Z961QVgRmzsAHNWPxWrT5moIXQbAIDzeFjms/SvTQBmxcYOsBRNHFYGAKbVpX+M+T8CMFOOJwNL0ZV5kH6DBwBgbPU1R33tIdQBZk0VC1iSeqTwaZmfyrxX5t0AAAyr1q0elfljHEgGFkAVC1iqJqpZAMCwvi9zFQeSgQVRxQKWqitzWeZxAADu7kmZ+xHqAAujigUs3T79p2u1mnURAIDj1OrVh2W+CsACCXaANXhe5ln6T9maAAAcZp8+1HEgGVgswQ6wFvXTtvr0ino7rA0AwO0elvks/WsIgMVyPBlYoyYOKwMA1+vKfBxbOsBKOJ4MrFFX5kH6DR4AgFfqgeT6GkGoA6yGKhawVv8q87TMy/TVrHcDAGxVrVs9KvNF+tcIAKuhigVsQRPVLADYqvr0zKt4jDmwUqpYwBZ0ZS7LPA4AsCW1elWfmtkFYKVUsYAt2af/1O69MhcBANaqS38g+asArJxgB9ia52Wepa9l/S4AwNrs46lXwIYIdoAtqgcU/5b+zlgbAGAtHpb5LP3veoBNcDwZ2LomDisDwNJ1saUDbJTjycDWdWUelPkmAMAS1QPJ9Xe5UAfYJFUsgORfZZ6WeZm+mvVuAIC5q3WrR2W+SP+7HGCTVLEAfq2JahYAzF19yuVVPMYcQBUL4A1dmcsyjwMAzFGtXt2PUAfg/9jYAbhZW+br2N4BgDnoynya/nHmAPzMjR2Am3VlnqUPdn4XAOBc9mU+KPM8APyKYAfgdvUw49/Sbzi2AQCm9rDMZ3EgGeBaqlgAh2visDIATKUr83E8xhzgVo4nAxyuK/Mg/dFGAGA89Xdt/Z0r1AF4C1UsgOPUNfBvy7xMX816NwDAUGoFutau/hTVK4CDqGIBnK6JahYADOX7MlfxGHOAo6hiAZyuK3NZ5nEAgLuo1av7EeoAHM3GDsAw2jJfx/YOAByjK/Np+seZA3ACN3YAhtGVeZY+2PldAIC32Zf5oMzzAHAywQ7AcOrBx7+l34ZsAwDc5GH6I8kOJAPckSoWwDiaOKwMAG/qynwcjzEHGIzjyQDj6Mo8SH8MEgDofyfW341CHYABqWIBjKeul39b5mX6J31cBAC2p1aVa+3qT1G9AhicKhbANJqoZgGwPfv0T73qAsAoVLEAptGVuSzzOACwDbV6VZ961QWA0djYAZheW+br2N4BYJ269Fs6+wAwOjd2AKbXlXlW5l762zsAsBb79Fs6zwPAJAQ7AOdRD0k+Tb852QYAlu9h+iPJDiQDTMiNHYDzehoAWAePMQc4A8EOwHntAgDr0AaAyQl2AM7r/QDAOnwSACbnqVgA59OUeREAWI/LeLw5wKRs7ACcz1UAYF12AWBSgh2A87GyDsDaqBgDTEwVC+A8mqhhAbBO6lgAE7KxA3AealgArJXfcQATEuwAnMdHAYB18jsOYEKqWADTa6KGBcC63SvzYwAYnY0dgOm1AYB12wWASQh2AKbnaVgArJ06FsBEVLEAptVEDQuAbVDHApiAjR2AabUBgG3YBYDRCXYApqWGBcBWqGMBTEAVC2A6TdSwANgWdSyAkdnYAZhOGwDYll0AGJVgB2A6VwGAbVHHAhiZKhbANC7K/BAA2JZaw7qMOhbAaGzsAEzDtg4AW1Q/2PA7EGBEgh2AaXhRC8BWeSIkwIhUsQDGp4YFwJapYwGMyMYOwPjaAMB21Q842gAwCsEOwPjUsADYOk/HAhiJKhbA+GoN6yIAsF3qWAAjsbEDMK66rSPUAWDr6u/C+wFgcIIdgHGpYQFAz9OxAEagigUwLjUsAOjVGta9ADAoGzsA42kj1AGAVzwdC2AEgh2A8ewCALxORRlgYKpYAON5UaYJAPCKOhbAwGzsAIyjjVAHAN6kjgUwMMEOwDh2AQCuo44FMCBVLIBxqGEBwPXUsQAGZGMHYHhthDoAcBN1LIABCXYAhrcLAHAbdSyAgahiAQxPDQsAbqeOBTAQGzsAw7ofoQ4AvI06FsBABDsAw9oFADhEGwDuTBULYFhqWABwmK7MZQC4Exs7AMNRwwKAwzWxtQNwZ4IdgOHsAgAcow0AdyLYARjO+wEAjvFRALgTN3YAhtGkv68DAByn3tnpAsBJbOwADOMqAMApdgHgZIIdgGF8EgDgFKrMAHegigVwd03UsADgLtSxAE5kYwfg7tSwAOBu/C4FOJFgB+DuPNEDAO7G71KAE6liAdxNEzUsABjCvTI/BoCj2NgBuJs2AMAQdgHgaIIdgLvxNCwAGIY6FsAJVLEATtdEDQsAhqSOBXAkGzsAp2sDAAxpFwCOItgBOJ0aFgAMSx0L4EiqWACnaaKGBQBjUMcCOIKNHYDTtAEAxrALAAcT7ACc5ioAwBjUsQCOoIoFcLyLMj8EABhDrWFdRh0L4CA2dgCOZ1sHAMZTP0DxuxbgQIIdgON5sQkA4/LkSYADqWIBHEcNCwDGp44FcCAbOwDHaQMAjK1+kHI/ALyVYAfgOGpYADANdSyAA6hiARyn1rAuAgCMTR0L4AA2dgAOV7d1hDoAMA11LIADCHYADqeGBQDTUscCeAtVLIDDvSjTBACYSq1h3QsAN7KxA3CYNkIdAJharWO1AeBGgh2Aw+wCAJyDKjTALVSxAA6jhgUA56GOBXALGzsAb9dGqAMA56KOBXALwQ7A2+0CAJyTOhbADVSxAN5ODQsAzksdC+AGNnYAbtdGqAMA56aOBXADwQ7A7XYBAOZAHQvgGqpYALdTwwKAeVDHAriGjR2Am92PUAcA5kIdC+Aagh2Am+0CAMxJGwB+RRUL4GZqWAAwL12ZywDwHzZ2AK6nhgUA89PE1g7Arwh2AK63CwAwR20A+A/BDsD13g8AMEd+RwO8xo0dgN9q0t/XAQDmqd7Z6QKAjR2Aa1wFAJizXQD4P4IdgN/6JADAnKljAfxMFQvg15qoYQHAEqhjAcTGDsCb2gAAS6A6DRDBDsCb1LAAYBk+CgCqWACvaaKGBQBLcq/MjwHYMBs7AL9oAwAsyS4AGyfYAfiFGhYALIs6FrB5qlgAvSZqWACwROpYwKbZ2AHotQEAlmgXgA0T7AD01LAAYJnUsYBNU8UCUMMCgKVTxwI2y8YOgBoWACzdVQA2SrAD4MUgACydSjWwWapYwNZdlPkhAMCS1RrWZdSxgA2ysQNsnW0dAFi++kGN3+nAJgl2gK3zIhAA1kEdC9gkVSxg6/4dAGAN1LGATbKxA2yZbR0AWI9ax7ofgI0R7ABbJtgBgHVRxwI2RxUL2LL6NKyLAABroY4FbI6NHWCr6raOUAcA1kUdC9gcwQ6wVWpYALBO6ljApqhiAVv1okwTAGBtag3rXgA2wsYOsEVthDoAsFa1jtUGYCMEO8AW7QIArJnKNbAZqljAFqlhAcC6qWMBm2FjB9iaNkIdAFg7dSxgMwQ7wNbsAgBsgToWsAmqWMDWqGEBwDaoYwGbYGMH2JI2Qh0A2Ap1LGATBDvAluwCAGyJOhaweqpYwJaoYQHAtnRlLgOwYjZ2gK24H6EOAGxNE3UsYOUEO8BW7AIAbFEbgBVTxQK2Qg0LALapizoWsGI2doAtUMMCgO1qYmsHWDHBDrAFnogBANvWBmClBDvAFnwUAGDL3g/ASrmxA6xdk/6+DgCwbfXOTheAlbGxA6ydGhYAUO0CsEKCHWDtPgkAgDoWsFKqWMCaNVHDAgB+oY4FrI6NHWDN2gAA/EJFG1gdwQ6wZmpYAMDrPCkTWB1VLGCtmqhhAQC/da/MjwFYCRs7wFq1AQD4rV0AVkSwA6yVGhYAcB11LGBVVLGANWqihgUA3EwdC1gNGzvAGrUBALjZLgArIdgB1kgNCwC4jToWsBqqWMDaNFHDAgDeTh0LWAUbO8DatAEAeLurAKyAYAdYGy/SAIBDqG4Dq6CKBazJRZkfAgDwdrWGdRl1LGDhbOwAa2JbBwA4VP1AyGsHYPEEO8CaeHEGABxDHQtYPFUsYE1qDesiAACHUccCFs/GDrAWdVtHqAMAHKO+drgfgAUT7ABroYYFAJxCHQtYNFUsYC3UsACAU6hjAYtmYwdYAzUsAOBU6ljAogl2gDVQwwIA7sJrCWCxVLGANXhRpgkAwGlqDeteABbIxg6wdG2EOgDA3dQ6VhuABRLsAEu3CwDA3aljAYukigUsnRoWADAEdSxgkWzsAEvWRqgDAAxDHQtYJMEOsGS7AAAMRx0LWBxVLGDJ1LAAgCGpYwGLY2MHWKo2Qh0AYFjqWMDiCHaApdoFAGB46ljAoqhiAUulhgUAjKErcxmAhbCxAyzR/Qh1AIBxNFHHAhZEsAMs0S4Ah3tS5nEADtcGYCFUsYAlUsMCDtGV+bTM/uf/u97N+HP8/ADeros6FrAQNnaApVHDAg6xL/NBfgl1qqc//2tPA3C7JrZ2gIUQ7ABL0wbgdg/TBzjdNf9e/dc+jmoW8HZtABZAFQtYmv9Nv7UD8KYufWjzjwP/+KbMd7EFCFxvnz4kBpg1GzvAkjQR6gDXqweSH+TwUKfqfv7PPAnAb7UR/AILINgBluQqAL/2Y/oDyZ///M9P+c9//vN/xyn/eWDddgGYOVUsYEnUsIDXfZ8+8O0yjCaqWcCv7aOOBcycjR1gKZoIdYBf1PpU/ZnQZThd+scbO6wMvNKWuQjAjAl2gKVoA9CHL/XT888zni9y81O1gO3ZBWDGBDvAUnwSYOv26Y8d7zO+ffpw52mArfsoADPmxg6wBE2ZFwG27GGZL3MeX5T5nwBbdi8OrAMzZWMHWII2wFZ16bd0zhXqVF+kv73TBdiqXQBmSrADLIEaFmxTPZBcQ51/5Py69H8uTwJskToWMFuqWMDcNVHDgq2pdYdavfpr5mlX5s/xpBzYGnUsYJZs7ABz1wbYkn36zZi/Zr7+mv7PsQuwJbsAzJBgB5g7NSzYjlpzWspjxrv0d3ceB9gKdSxgllSxgDmrNYcfAqxdV+bTTPMY8zG0Zb5OXx0F1k0dC5gdGzvAnF0FWLt9+lrTPsu1T79p9E2AtfPaBJgdwQ4wZ148wXq9OpD8Qdbx6XeX/v6Gahasm4o4MDuqWMBcqWHBenVlPs48HmM+hqbMd1HNgjWqQfRl1LGAGbGxA8yVbR1Yp3oguVav1hrqVF36v8YnAdamfvDkNQowK4IdYK68aIJ1qZ9u1wPJn2cbn3TXv8b611r/mrsAa+I1CjArqljAXNUa1kWANdhn2wFHE9UsWBN1LGBWbOwAc1Q/CRPqwDrUOlI9kNxlu7r0bwIdVoZ1qK9R7gdgJgQ7wBxZcYbl69IHOp+HV76IkAvWwtOxgNlQxQLmSA0Llu1p+uqVmsL1mvQhjzeGsFzqWMBs2NgB5kYNC5arvsF5mP5R5t7s3Kwrs0v/9wpYJnUsYDYEO8DcqGHBMnXpa0ZfhkPVv1f1E/8uwBJ5zQLMgmAHmJv3AyxNPZD8oMw/wrG69H/vngRYGnVKYBYEO8CctPE4YFiSWreqtavPo3p1F/XvXf17uOVHwsMS1TpWG4AzE+wAc7ILsBT79JsmT8NQ/pq+zmbzCZZDHQs4O8EOMCdqWLAMtTbksd3j6NIHZo8DLIE6FnB2gh1gLtqoYcHcdekDnc/D2L6I8AyWQB0LODvBDjAXuwBzVitXdZNkH6ayTx/ufBNgztSxgLP6rwDMw4vY2IE5qod9ay3IY8zPq25J/TnAHNWfk/cCcCaCHWAO2jLfBZibLv1TrxzznYcm/c/KJsDc1O26fQDOQBULmAMrzDA/9UByrV4JdeajS/+/yZMAc+O1DHA2NnaAOVDDgvmolYJP4zHmc7cr8z/xsxPmoitzGYAzsLEDnNv9eGMCc7FPvxEi1Jm/v6avftiognlo4ulYwJkIdoBz2wWYg3og2eO1l6VLH8Q9DjAHbQDOQBULODc1LDivLn31ah+WrG4//j1+nsI5dVHHAs7Axg5wTmpYcF61clU3PvZh6Wolq25cfRPgXJr0r20AJiXYAc6pDXAO9UDyw/SPMv8xrEWXvt76MMC5eDoWMDlVLOCc/jc+2YKpdXFLZwuaMt/FViRMbZ/+ZyzAZGzsAOfSRKgDU3uSvnrVhbXr0t/6eBJgSm0EqsDE/jsA57Er8/sAU6h1qz+U+bLMv8KWfFvmZfog/SLAFH6K22XAhGzsAOfyUYAp7NNv6TwNW/XX9NWQfwSYwvsBmJAbO8A5NOkfcw6M63GZLwK/+KLM/wQY2704Tg9MxMYOcA5tgDF16Tc0vgj82hdxZwmmsAvARAQ7wDl8EmAstXJV37jvA9erlawa/H0TYCwq58BkVLGAqTVRw4Ix1JX/Wr36MnC4z9NXsxxWhuGpYwGTsLEDTK0NMLTv02/pCHU4Vv2aUc2CcewCMAHBDjA1NSwY1pP0gWkXOE1X5jL91xIwHHUsYBKqWMCUmqhhwVDqev+n8RhzhrVLX81qAgxBHQsYnY0dYEptgCHs09dnhDoM7a/pDyvvAwxhF4CRCXaAKalhwd09TP/GuwuMo0v/NfY4wF2pYwGjU8UCplKfuPJDgFN16atX+8B07pf5e1Sz4C7UsYBR2dgBpnIV4FS1clWrV/vAtP6RfnvnmwCn8hoIGJVgB5iKFzVwvPoJb61efRyf9nI+Xfo7IfVr0dchHE8VHRiVKhYwBTUsON736QPRLjAfTZnvopoFx6iB6GUEo8BIbOwAU7CtA8d5kv4pcl1gXrr0b1AdVobD1Q+4vBYCRiPYAabgxQwcpn6aW++ZfB6f7DJvX6Q/5t0FOMT7ARiJKhYwhVrDughwm328UWZ5mjJfp98wA26mjgWMxsYOMLa6rSPUgdvVo7R1U6cLLEuX/mtXNQtuV18L3Q/ACAQ7wNjUsOBmXfo3xV8Glu2L9NsIXYCbeDoWMArBDjC2jwJc55syD9JXsGANuvRB5TcBrmOLGRiFYAcYUxsvYOBN9b5CrV7t4tYC69Ol/9quX+O+vuHX1LGAUQh2gDHtArzu+/RbOqpXrF39Gq9f612A16moA4MT7ABj8mhP+MWT9FtsXWAbuvR3dxxWhl+4swMM7r8DMI62zOcBah3lwzJflflXYHv2ZV6mr6Co57J175b5/yLkBwZkYwcYyy7APg4kQ/XX9IeV9wHUsYBB/VcAxvGiTBPYrno81i0d+K0vyvxPYLvqJue9AAxEsAOMoS3zXWCbujIfl/lHgJs06X9PNIFtssEGDEYVCxjDLrBN36SvXgl14HZd+u+VbwLbpI4FDMbGDjAGNSy2pq7V1yf/qF7B8eqh/VrNcliZLVHHAgYj2AGG1kYNi235Pv0nr12AUzVRzWJ71LGAQahiAUOzWsyWPEn/COcuwF10ZS7Tb77BVnjNBAzCxg4wNDUstqCu0NcDyfsAQ6tvdv8cv0tYvy59oAlwJzZ2gCHVzYUmsG779Edf9wHG8DQqKmxDk77CDnAngh1gSLvAuj1M/4azCzCmLv33mmoWa9cG4I5UsYAhqWGxVl366pXHmMP0mjiszHp1UccC7sjGDjAUNSzWqh5IrtUroQ6cR5f+e/CbwPo08foJuCPBDjCUNrAu9UByrV59/vM/B86nfg/uynwa34+szy4Ad6CKBQzlf9Nv7cAafJ/+yTxdgLlpoprFuuzT35QCOImNHWAITYQ6rEetXtWv5y7AHHXpb5I4rMxatBFUAncg2AGGcBVYvi79J6afB1iCL9IfNe8Cy7cLwIkEO8AQPgos2z59qLMPsCRP03/vPg0s2/sBOJEbO8BdNekfcw5LVQ8kfxlg6b4o8z+B5boXx8GBE9jYAe6qDSxTl/4RykIdWIcv0t/e6QLLtAvACQQ7wF19ElieeiC5hjr/CLAmXfrv7W8Cy6PaDpxEFQu4iyZqWCxLXXGvT9KxpQPrtyvz5zIXgeVQxwKOZmMHuIs2sBzfR/UKtuSv6b/nu8By7AJwJMEOcBdqWCxFrV7djzd4sDVd+rs7jwPLoI4FHE0VCzhVEzUs5q8r82k8xhxIrtJXs5rAvKljAUexsQOcqg3M2z59DWMfgORpmQ9+/keYs10AjiDYAU6lhsWcPUz/Bs4nnsDrujIfRzWLeVPHAo6iigWcoj5h5IfA/HTp37R5jDnwNk2Z76KaxfzUDyUu48MJ4EA2doBTXAXmpx5IrtUroQ5wiC79z4wngXmpH6B5rQUcTLADnMKLDeakfqJZDyR/Hp9uAsepPzPqz45P4+cH86LyDhxMFQs4lhoWc/J9+qCxC8DdNFHNYj7UsYCD2dgBjmVbh7mo9Yn7EeoAw+jSv5F2WJk5UMcCDibYAY7VBs6rS//Eq88DMLwv0v+M6QLn9X4ADqCKBRyr1rAuAuexT//UK6vpwNiaMn+OrQnORx0LOIiNHeAY9cWtUIdzeZj+U3QvcIEpdOmDZNUszqW+5rofgLcQ7ADH8Kkl59ClfyTxlwGY3hfptya6wPQ8HQt4K8EOcIyPAtOqB5JrqPOPAJxPl/5n0ZPAtGxLA28l2AEO1cYLC6ZT61afpj+QrHoFzEH9WVR/JtWfTV1gGupYwFsJdoBD7QLT2Kf/ZPyvAZifv8ZTs5iWKjxwK8EOcCiP3GQKtebgDRMwd136uzsOKzMFd3aAWwl2gEO06R/7CmPp0gc6nwdgOb6IMJrx1TpWG4AbCHaAQ+wC49mnr17tA7A8+/ThzjeB8ahjAQB38qLMv40ZeH6IDR1gXb7Isn4Om+VM/Z0JcK3/CsDt2jLfBYbVlfk4HmMOrE+T/vdmExhW3QzbB+ANqljA2+wCw6oHkmv1SqgDrFGX/mfck8Cw1LGAa9nY+f/bu3crOZIrDcA/lw4MtRUDHoAWTK62GkFxpUl6gLFgCx6gLUDBAkBcrdoDtAdVtACz2mrLDCbAaQD9qK6uR0bm953zH0CaM1Ldi4x7I4DHbOPUkeP4bciv8Yw5sBz9kP+OOspx1Dr6pwB8x8QO8JAumlGO4zrjCfY6AMuxjlezOB6vYwF38mEHeIiRX46hriP4hw2wVLshL4a8CTxfF4DvWMUCHmINi+fYDflbXPQI8FU35F3UVg63y/ihEOBfTOwA93kZjSeH+5hx9eo6AHx1nXGC8X3gMCWmdoDv+LAD3KcPPN3XC5L/+uXvAHxrl7HG/ho4TBeAW6xiAfexhsVT7TJ+0PGMOcB+ypBN1FueZhfrWMAtJnaAu5RoMnmaekFyXb3yUQdgf7uMv51Xgf2V6NOAW/4YgB/1Q/4z8Li6bvVfQ94O+b8A8FT1t/N/hvw94/12PwUe979xjx3whYkd4C6/BB53nfGk+WMAeK51xouVTT6yj58DAHCPMuT/RR5JndAB4DRWaasmyGVSAhATO8CPXgXut8t4ovw6AJzKKuNv7S5wvz4A8WEH+NFfAnerK1d19eo6AJzadcaPO+8Dd/s5AADfKWlrBFnOk88xoQNwSfU3uKW6IeeLy7YBEzvAN7rAt3YZp3TcqQNwOfU3+EWsZvGjPsDi+bAD3PZL4HdXGT/q7ALApe0yfty5CvzOCj0A8C8lbY0ey+lSV69cog0wXf2QbdqqLXK6WMeChTOxA3zVBcbLOuuUzscAMFXrjBcr3wSsY8Hi+bADfPVLWLo38bwuQCt2GT/EvwlLZx0LFu4PARjXsLZhqXZD/hbPmAO06uWQDxnrOcv0pyG/BVgkEztA1YWlqitX9cT3OgC0qq5k1YnL92Gp+gAAi7ZJW5cEyvNTL0h+HQDmpv62t1SP5DjZBFgsq1hAfUnhc1iSXdylAzBnJeM/9EtYirqG9SLWsWCRrGIBnrVelquMq1e7ADBXu4z/yL8KS1EP6vR0ALBQ9Y6VFkaM5XmpU1kaPoDl6TM+kNBKvZLDswkAsDj1dKeVZkWe1+iVALBUJe7TW0LqIc5PARbHKhYsWxfm7te4Twdg6XYZa8GbMGfWsWChfNiBZVP852uXsYl/GwAYreKetbn7OQDAotSR3VbGi2X/fIhRbADuV4as01Ztk/1iHQsAFqRO67TUqMh+zdzrAMB+as1wyDO/dAEAFmGdtpoUeTg3cUEyAE9X4tWsueVdAIBFcEI3n9R7dIxdA/ActZa0VPvk/nwOADB7XdpqUOT+xs0F2AAcSx/TO3NJF2AxvIoFy9SH1l1nfNnkYwDgONYZX1S8Dq1z8AMAM7dNW6dO8m1ckAzAqa3SVm2Ub2MdCwBmrEtbjYn8nm2MVgNwPi/jMKjldAEWwSoWLE8fWvQ+4+rVdQDgPOqLi3U1631okXUsAJipbdo6bVp66ii11SsALq3WIi9qttdDAAAz06WthmTpqSelJQAwDSUOiFpLF2D2rGLBsvShFVcZm7FdAGAadkNeDHkTWmEdCwBmZpu2TpmWmDo23QUApq2PvqKVvgIAmIkubTUiS8wmVq8AaEfJWLtaqLFLThdg1qxiwXIYxZ22XzO+PLILALRhl7F2Wc2ati4AwCxs09bp0lKyjYYLgPaV6DWm3GsAAI17mbYakKVkPeSnAMA8lIy1raVavJR0AWbLKhYsQx+m5LeMq1f9l78DwBzsMta2WuPUt2npAgA07VPaOlWac27igmQA5q/EataUsg0A0KySthqPOedtAGBZVmmrVs85JcAsWcWC+fMa1uXVcfT6asjrAMCyrIb8NV59nII+AECTrGFdNps4IQOAkrEmtlC759yTAACNKWmr4ZhbTOgAwLdWaauWzy0lwOxYxYJ5s4Z1Gbshf447dQDge6shL2I161L0hjBDPuzAvP0lnNv7jB91bgIA3GWXsVa+D+emNwSAhpS0NRrcej7H6hUAPFWtnbWGtlTzW89PAQCa0KetJqPl1OmcEgDgEGXINm3V/pbjIAoAGrFJW01Gq3GPDgAcxypt9QCtZhMAYPJK2mowWkwdG+8CABxTvdx3m7Z6ghZjHQtmxOXJME9dOKXrjJc+XgcAOKaPQ/7jy5+cTh8AYNI2aevUqKXYSweA81ilrR6hpWwCAExWSVuNRSvZDnkZAOCcSqxmnSrWsWAmrGLB/HTh2K4yrl7dBAA4p13GGvw+HFsfAGCS6k56S6dFU069INnqFQBMQ5+xNrfUS0w5mwAAk1NHaltpJqaeOp1TAgBMSYnVrGOlfiSzjgUzYBUL5uVVOIa6elXv09kFAJiS3ZAXQ96E56ofdfSOADAx1rCel23cUQQAragfJWrtbqHHmGo2AQAmwxrW8xubEgCgJWXIh7TVc0wp1rEAYELqqVVLjcSU4oJkAGjbKm31HlOKdSwAmIh12moippBtxrt0AID2lVjNOiTvAgBMguc/n5a3MXoMAHNTa/s6bfUkl451LACYAGtYT2te+gAAc9bHoddT0gUAuKh12moeLpWbuCAZAJaixGrWvnkXAOCinEg9nrcBAJZolbZ6lkvkcwCAi+nSVuNw7mxjvBgAlq6L6Z3H0gUAuIh12moazplNXAYIAIzKkA9pq5c5Z0w3A8CFbNNW03CuvA4AwI9WaaunOVesYwHABXRpq2E4R7ZDXgYA4H4lDsfuShegOf8WoGV9uO1qyJ8zvn4FAHCfXcae4Src9ioAwFlt09Yp0KlSR4f7AAA8XR8vjN7uqQCAM+nSVqNwqtTpnBIAgMOVODD7mi5AU6xiQbv6UMen6306uwAAHG435MWQN8E6FgCcyTZtnf4cM9s4TQIATqPLsvss61gAcAZ1SqWlBuGY2Qz5KQAAp1OGrNNWj3TMdAEATupt2moOjpF6evQ6AADns0pb/dKxsgoAcFLbtNUcPDfbjFNKAADnVrLM3gsAOJGlrWHV6SSrVwDAJdVeZGkT010AgJNYSlNRV6/6AABMR5/lTO+sAgCcxKe01RQckk3GsWcAgKkpWcbHnU8BAI6upK2G4JC8DQDA9K3SVo91SEoAgKOqr0K11Aw8JdvY5QYA2tJl3tM7qwAARzXXNaxNXJAMALSpDFmnrd7rKT0aAHAkJW01AvukXpD8OgAA7VulrT5s35QAAEfRp60m4LFsMz7dDgAwFyXzW81yCAcAR7JJW03AQ6kXJFu9AgDmqPY4tddpqTd7KJsAAM9W0lYDcF/q6tWrAADMX5/5TO84kAOAZ+rTVvG/K5vY0QYAlqVkHo9fWMcCgGfapK3i/33eBgBguVZpq3f7PpsAAAcraavw3852SBcAALq0vZplHQsADtSnraL/NR+iAQAAuK0MWaetnu5rrGMBwIE2aavo1wuSFX4AgPvVXqml/q5mEwDgyUraKvjbIS8DAMBjStpbzTKNDQBP1KedQl8vSFbsAQD2V3un2kO10u+ZygaAJ/qY6Rf4unr1KgAAHKpPG9M7mwAAe6snOC0U9xIAAJ6rDPmUafd+9UDPhDYA7KnPtAv7KgAAHNsq0+4B+wAAe5nqGtZ2SBcAAE6lPkZRe64p9oKbAACPmuoa1ocYvwUAOIcyZJ3p9YPWsQBgD/Uy4qkVcK8gAACcX+3BptQX1nQBAB60znQK9zYuSAYAuKSSaa1mvQsA8KA6ITOFov02Rm0BAKai9mZT6BGtYwHAA6awhvX5y/8HAADT0mca0ztdAIA7rXPZIr2J1SsAgCkrQz7lsj3juwAAd9rmcgV6FQAAWrHK5frGzwEAftDlMoV5G+O0AAAtepnLHQx2AQC+sc75C/KHuPwOAKBlJZfpI98GAPjGNucrxHV89nUAAJiL2tud83VV61gAcEuX8xXhm7ggGQBgjkrOe1jYBQD4p3XOU3zryKzVKwCAeas937l6SwAgpz9ZqaOyrwIAwFL0OU+PCQCL1+W0BXcTq1cAAEtUMvaCp+w1uwDAwq1zukLrgmQAAFY5Xb9pHQuAxdvm+AW2/je7AADA6GVO03daxwJg0WqBPXZx/RAXJAMA8KOS00yLdwGAhTrmiwX1tMTqFQAAj6k9Y+0dj9WHrgIAC7XNcYrpTVyQDADA/kqO14tuAwALdKw1rDr1Y/UKAIBDHGuCvAsALMxzi2gdn30VAAB4nj7Pn95ZBQAW5lMOL5ybWL0CAOB4SsYe8zn9KQAsRsnhRdMFyQAAnMoqh/epJQCwEPXjzFML5TZ2lwEAOL2Sw1azVgGAhXjqGtY6LkgGAOB8SsYe1DoWAHynZP/iWC9ItnoFAMCl1F609qTWsQDgiz77FcWbKIwAAFxeyf6rWQ4lAZi9OqL6WEGsT6FbvQIAYEpWsY4FwMKVPL561QUAAKapz+PTOw4oAZitPg+fbpQAAMC0lTw8hW4dC4DZuq8AKn4AALRmFetYACxIyY9Fr46xdgEAgDaV3L2aZR0LgNnp822xW0fBAwCgfbWnXcdEOgAz93UNq16QrNABADA3tcetva51LABmp2QscDdxQTIAAPNV8vtqlul0OLE/BjiXV0P+/uXP3wIAAPNUe92rIX8Y8u8ZDzYBoHklAACwLCXASf0DYPbdE4hU454AAAAASUVORK5CYII=",
-  "width": 380.6666666666667,
-}
-`;
-
-exports[`assetLoader should inline asset with scales (3) - React Native >=0.72 2`] = `
-"/
-└─ out/
-   └─ main.js"
-`;
-
-exports[`assetLoader should inline asset without scales - React Native <0.72 1`] = `
+exports[`assetLoader should inline asset without scales 1`] = `
 {
   "height": 51,
   "scale": 1,
@@ -470,22 +425,7 @@ exports[`assetLoader should inline asset without scales - React Native <0.72 1`]
 }
 `;
 
-exports[`assetLoader should inline asset without scales - React Native <0.72 2`] = `
-"/
-└─ out/
-   └─ main.js"
-`;
-
-exports[`assetLoader should inline asset without scales - React Native >=0.72 1`] = `
-{
-  "height": 51,
-  "scale": 1,
-  "uri": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAASkAAAAzCAMAAAD8fQ75AAAAAXNSR0IB2cksfwAAAAlwSFlzAAALEwAACxMBAJqcGAAAAYxQTFRF////REF2BQFInZu3cnCYgoCjg4GkQ0B1oZ+6IyBeDwxO8/T7dn/MwMTog4KkEA1PYGnEBxajHCqrv8PnmJ7YlpzYeYHNER+nGiiqwsXoGymr/f3+YWvFy83rfIPOCRikNkK04+X1+vv9Chmk4eP04eDpwL/RxMPUhIOlbmuUycjXq6rCtrXJhoSma2mTeHace3mea2iSoaC6RUJ3bGqT7+/0qKe/f32hlJvXGSeqaWeRFRFT0M/djYur4N/ooqG6lZzYDBulGSap3+HzeoLOxsrq4OLzm6DZ5eTs5+fuiYenqafAenidDQpNamiS09Lf9vb5iYepDQlOysnYiIanuLfLoqC6ZmSPCwdMUlCBp6W+s7HHu7rNYmCM+fr9y87s8/P6d3/Ma3TIaXLHsa/GanPHpaO9dnSbkJfWDRulVV/A/Pz+Kjew0NLt2tzxKDWvJjOvys7s2dzx0NPu2NvxxcjpSlW8T0x+zcza0tHe9/f55uXs6Ofu8vL22tnk8/P21dTg9fX4zs3b397nc16LtQAAA1RJREFUeJztm0tIVFEYx+/nnRkfl1QI3LiIBq+bCjQqetcqQhIke1jQuG3VImpVQRJFLaJFtAgKBskWlZULUYra9KBaSEFFlOAiIqIUsofVONrVud953Hs8c2ZsfND3X/3ne8z57s+LnMucCxbJTDDbA8wbESlTaUiBMgdpdJEx/VfbKX0+NqrPR3+jK/ljWsml7ikeYbbsl2/kOR2Ab8pFciYVwwWmTar8uz5fYFIVCESa04kCwKCqlUhJc3qgvAsv+qJoJVLinJOgPEU+h1uJlDCn40Cmqxg+hlqJFJ8T7yhPpeMhVESKzVkNP3hhqf0+0EqkOCkbhnkWBgKtRIrPGR+NDmEy0h9sDdFwMQJT7Dxfo1uSjdRLfX7ZK3RLUzG2FrxAx69/+XN09T95v9MXrlz5FV2lcv9Y/pRZxX/0eBW8yeTCoMKk1j7xzRp4qFrr32nDI3Qi8o1sVX79mx6g43e0p6JwZS27wmx3tHKXUO3CxB+lHu6F64mUVBmPDwxZFe5dRT2Rkis9VOnaO6p6IhWojLvjSlBEyqAyIyJFpOYQqa1Zdo4LevT5hl50NULUZV0qUg1vhdL+cGUOpBq7fbNtiAcXwu2p6qdBqs7R56tu6fOF2KPnQIrdkU2feLBvS9dU9dMgNRefZvIhJUpz0URKEpFSiEgZrk6kTFcnUqarEynT1YmU6eozSaq5W59fkaV/x010MWW+8Tq6XTfQ7RQ3hoxfXqRarvlmt7BD3g6dON2VQP2ce+5TaQaf+/Z1+Gb140A9kSJS85dUAiApBYiUWgm7q2ksKUaIlFIJ+/5w3WIJFZFSaQKUZdXF00ke+39I7bX1+eJLzGZAeahqUkkWLAQp/hvy5hFLobKLzM4gKfM9OoKSURWCFFeepxdnmdT+HnaIpAXggm+JFIpNkCjv4NGWyHnfESkUn+AAtKNthXNoiRRKmOBg2kfVap9lQSKFEifwUYmgiBSTNMEkKgkUkWKS936HUu0yKCLFFNglH4bL8lsW5qRWRdEtuiqE16FZfybck+d7MzmQcpsxA6dUa3EdSevzne/kz07lB+nzUfaG0Wn9F1nH+CnQNiHs7vHNs14rJPV0JcfRtQEeGbVPCgUn8KR1cHp6a81YRMpUfwHvTJdSiEnodgAAAABJRU5ErkJggg==",
-  "width": 297,
-}
-`;
-
-exports[`assetLoader should inline asset without scales - React Native >=0.72 2`] = `
+exports[`assetLoader should inline asset without scales 2`] = `
 "/
 └─ out/
    └─ main.js"

--- a/packages/repack/src/loaders/assetsLoader/convertToRemoteAssets.ts
+++ b/packages/repack/src/loaders/assetsLoader/convertToRemoteAssets.ts
@@ -42,6 +42,7 @@ export function convertToRemoteAssets({
 
   return dedent`
     var AssetSourceResolver = require('react-native/Libraries/Image/AssetSourceResolver');
+    if (AssetSourceResolver.__esModule) AssetSourceResolver = AssetSourceResolver.default;
     var resolver = new AssetSourceResolver(undefined, undefined, ${asset});
 
     module.exports = resolver.scaledAssetPath();

--- a/packages/repack/src/loaders/assetsLoader/convertToRemoteAssets.ts
+++ b/packages/repack/src/loaders/assetsLoader/convertToRemoteAssets.ts
@@ -42,7 +42,7 @@ export function convertToRemoteAssets({
 
   return dedent`
     var AssetSourceResolver = require('react-native/Libraries/Image/AssetSourceResolver');
-    if (AssetSourceResolver.__esModule) AssetSourceResolver = AssetSourceResolver.default;
+    if ('default' in AssetSourceResolver) AssetSourceResolver = AssetSourceResolver.default;
     var resolver = new AssetSourceResolver(undefined, undefined, ${asset});
 
     module.exports = resolver.scaledAssetPath();

--- a/packages/repack/src/loaders/assetsLoader/inlineAssets.ts
+++ b/packages/repack/src/loaders/assetsLoader/inlineAssets.ts
@@ -44,6 +44,7 @@ export function inlineAssets({
     var AssetSourceResolver = require('react-native/Libraries/Image/AssetSourceResolver');
 
     if (PixelRatio.__esModule) PixelRatio = PixelRatio.default;
+    if (AssetSourceResolver.__esModule) AssetSourceResolver = AssetSourceResolver.default;
     var prefferedScale = AssetSourceResolver.pickScale(${scales}, PixelRatio.get());
 
     module.exports = ${JSON.stringify(sourceSet)}[prefferedScale];

--- a/packages/repack/src/loaders/assetsLoader/inlineAssets.ts
+++ b/packages/repack/src/loaders/assetsLoader/inlineAssets.ts
@@ -40,10 +40,9 @@ export function inlineAssets({
    * ESM for PixelRatio, so we need to check if PixelRatio is an ESM module and if so, adjust the import.
    */
   return dedent`
-    var PixelRatio = require('react-native/Libraries/Utilities/PixelRatio');
+    var PixelRatio = require('react-native').PixelRatio;
     var AssetSourceResolver = require('react-native/Libraries/Image/AssetSourceResolver');
 
-    if ('default' in PixelRatio) PixelRatio = PixelRatio.default;
     if ('default' in AssetSourceResolver) AssetSourceResolver = AssetSourceResolver.default;
     var prefferedScale = AssetSourceResolver.pickScale(${scales}, PixelRatio.get());
 

--- a/packages/repack/src/loaders/assetsLoader/inlineAssets.ts
+++ b/packages/repack/src/loaders/assetsLoader/inlineAssets.ts
@@ -43,8 +43,8 @@ export function inlineAssets({
     var PixelRatio = require('react-native/Libraries/Utilities/PixelRatio');
     var AssetSourceResolver = require('react-native/Libraries/Image/AssetSourceResolver');
 
-    if (PixelRatio.__esModule) PixelRatio = PixelRatio.default;
-    if (AssetSourceResolver.__esModule) AssetSourceResolver = AssetSourceResolver.default;
+    if ('default' in PixelRatio) PixelRatio = PixelRatio.default;
+    if ('default' in AssetSourceResolver) AssetSourceResolver = AssetSourceResolver.default;
     var prefferedScale = AssetSourceResolver.pickScale(${scales}, PixelRatio.get());
 
     module.exports = ${JSON.stringify(sourceSet)}[prefferedScale];

--- a/packages/repack/src/modules/DevServerClient.ts
+++ b/packages/repack/src/modules/DevServerClient.ts
@@ -85,6 +85,7 @@ class DevServerClient {
 
 const client = new DevServerClient();
 
+// React Native < 0.79
 export function setup() {}
 export function enable() {}
 export function disable() {}
@@ -93,3 +94,13 @@ export function log(level: string, data: any[]) {
   client.log(level, data);
 }
 export function unstable_notifyFuseboxConsoleEnabled() {}
+
+// React Native >= 0.79
+export default {
+  setup,
+  enable,
+  disable,
+  registerBundle,
+  log,
+  unstable_notifyFuseboxConsoleEnabled,
+};

--- a/packages/repack/src/modules/WebpackHMRClient.ts
+++ b/packages/repack/src/modules/WebpackHMRClient.ts
@@ -10,8 +10,8 @@ interface RNDevSettings {
   reload(): void;
 }
 
-interface RNLogBoxData {
-  clear(): void;
+interface RNLogBox {
+  clearAllLogs(): void;
 }
 
 class HMRClient {
@@ -153,17 +153,13 @@ class HMRClient {
 
 if (__DEV__ && module.hot) {
   const reload = () => {
-    let DevSettings: RNDevSettings;
-    if (__REACT_NATIVE_MINOR_VERSION__ >= 79) {
-      DevSettings =
-        require('react-native/Libraries/Utilities/DevSettings').default;
-    } else {
-      DevSettings = require('react-native/Libraries/Utilities/DevSettings');
-    }
+    const DevSettings: RNDevSettings = require('react-native').DevSettings;
     DevSettings.reload();
   };
 
   const dismissErrors = () => {
+    const LogBox: RNLogBox = require('react-native').LogBox;
+
     if (__PLATFORM__ === 'ios') {
       const NativeRedBox =
         require('react-native/Libraries/NativeModules/specs/NativeRedBox').default;
@@ -173,14 +169,8 @@ if (__DEV__ && module.hot) {
         require('react-native/Libraries/Core/NativeExceptionsManager').default;
       NativeExceptionsManager?.dismissRedbox();
     }
-    let LogBoxData: RNLogBoxData;
-    if (__REACT_NATIVE_MINOR_VERSION__ >= 79) {
-      LogBoxData =
-        require('react-native/Libraries/LogBox/Data/LogBoxData').default;
-    } else {
-      LogBoxData = require('react-native/Libraries/LogBox/Data/LogBoxData');
-    }
-    LogBoxData.clear();
+
+    LogBox.clearAllLogs();
   };
 
   const showLoadingView = (text: string, type: 'load' | 'refresh') => {

--- a/packages/repack/src/modules/WebpackHMRClient.ts
+++ b/packages/repack/src/modules/WebpackHMRClient.ts
@@ -1,9 +1,17 @@
 import type { HMRMessage } from '../types.js';
 import { getDevServerLocation } from './getDevServerLocation.js';
 
-interface LoadingViewModule {
+interface RNLoadingView {
   hide(): void;
   showMessage(text: string, type: string): void;
+}
+
+interface RNDevSettings {
+  reload(): void;
+}
+
+interface RNLogBoxData {
+  clear(): void;
 }
 
 class HMRClient {
@@ -145,7 +153,13 @@ class HMRClient {
 
 if (__DEV__ && module.hot) {
   const reload = () => {
-    const DevSettings = require('react-native/Libraries/Utilities/DevSettings');
+    let DevSettings: RNDevSettings;
+    if (__REACT_NATIVE_MINOR_VERSION__ >= 79) {
+      DevSettings =
+        require('react-native/Libraries/Utilities/DevSettings').default;
+    } else {
+      DevSettings = require('react-native/Libraries/Utilities/DevSettings');
+    }
     DevSettings.reload();
   };
 
@@ -159,13 +173,22 @@ if (__DEV__ && module.hot) {
         require('react-native/Libraries/Core/NativeExceptionsManager').default;
       NativeExceptionsManager?.dismissRedbox();
     }
-    const LogBoxData = require('react-native/Libraries/LogBox/Data/LogBoxData');
+    let LogBoxData: RNLogBoxData;
+    if (__REACT_NATIVE_MINOR_VERSION__ >= 79) {
+      LogBoxData =
+        require('react-native/Libraries/LogBox/Data/LogBoxData').default;
+    } else {
+      LogBoxData = require('react-native/Libraries/LogBox/Data/LogBoxData');
+    }
     LogBoxData.clear();
   };
 
   const showLoadingView = (text: string, type: 'load' | 'refresh') => {
-    let LoadingView: LoadingViewModule;
-    if (__REACT_NATIVE_MINOR_VERSION__ >= 75) {
+    let LoadingView: RNLoadingView;
+    if (__REACT_NATIVE_MINOR_VERSION__ >= 79) {
+      LoadingView =
+        require('react-native/Libraries/Utilities/DevLoadingView').default;
+    } else if (__REACT_NATIVE_MINOR_VERSION__ >= 75) {
       LoadingView = require('react-native/Libraries/Utilities/DevLoadingView');
     } else {
       LoadingView = require('react-native/Libraries/Utilities/LoadingView');
@@ -175,8 +198,11 @@ if (__DEV__ && module.hot) {
   };
 
   const hideLoadingView = () => {
-    let LoadingView: LoadingViewModule;
-    if (__REACT_NATIVE_MINOR_VERSION__ >= 75) {
+    let LoadingView: RNLoadingView;
+    if (__REACT_NATIVE_MINOR_VERSION__ >= 79) {
+      LoadingView =
+        require('react-native/Libraries/Utilities/DevLoadingView').default;
+    } else if (__REACT_NATIVE_MINOR_VERSION__ >= 75) {
       LoadingView = require('react-native/Libraries/Utilities/DevLoadingView');
     } else {
       LoadingView = require('react-native/Libraries/Utilities/LoadingView');


### PR DESCRIPTION
### Summary

Part of #1118 

- [x] - handled all cases where in RN 0.79 some modules are now exported through `export default`
- [x] - use public RN API for `PixelRatio`, `DevSettings` and `LogBox`

### Test plan

- [x] - new project with 0.79 works
- [x] - current testers with RN < 0.79 work 
