### PR TITLE
refactor: allow passing referenceUrl to prefetchScript

### DIFF
--- a/.changeset/tasty-snails-lie.md
+++ b/.changeset/tasty-snails-lie.md
@@ -1,0 +1,5 @@
+---
+"@callstack/repack": patch
+---
+
+Allow passing `referenceUrl` to `ScriptManager.prefetchScript`

--- a/packages/repack/src/modules/ScriptManager/ScriptManager.ts
+++ b/packages/repack/src/modules/ScriptManager/ScriptManager.ts
@@ -692,14 +692,20 @@ export class ScriptManager extends EventEmitter {
   async prefetchScript(
     scriptId: string,
     caller?: string,
-    webpackContext = getWebpackContext()
+    webpackContext = getWebpackContext(),
+    referenceUrl?: string
   ) {
     const uniqueId = Script.getScriptUniqueId(scriptId, caller);
     if (this.scriptsPromises[uniqueId]) {
       return this.scriptsPromises[uniqueId];
     }
     const loadProcess = async () => {
-      const script = await this.resolveScript(scriptId, caller, webpackContext);
+      const script = await this.resolveScript(
+        scriptId,
+        caller,
+        webpackContext,
+        referenceUrl
+      );
 
       try {
         this.emit('prefetching', script.toObject());


### PR DESCRIPTION
### Summary

Pass `referenceUrl` to `prefetchScript` so that it's signature is equal to that of `loadScript` and behaves similarly when resolving scripts

### Test plan

n/a
