### PR TITLE
chore: bump versions in init

### DIFF
--- a/.changeset/chilled-bats-draw.md
+++ b/.changeset/chilled-bats-draw.md
@@ -1,0 +1,5 @@
+---
+"@callstack/repack-init": patch
+---
+
+Bump versions of dependencies for `repack-init`

--- a/packages/init/versions.json
+++ b/packages/init/versions.json
@@ -1,10 +1,10 @@
 {
   "rspack": {
-    "@rspack/core": "^1.2.8",
-    "@swc/helpers": "^0.5.15"
+    "@rspack/core": "^1.3.4",
+    "@swc/helpers": "^0.5.17"
   },
   "webpack": {
     "terser-webpack-plugin": "^5.3.14",
-    "webpack": "^5.98.0"
+    "webpack": "^5.99.5"
   }
 }


### PR DESCRIPTION
### Summary

Bumped versions of dependencies that are installed with a new project when using `repack-init`

### Test plan

n/a
