### PR TITLE
fix: dont use JSON parse if symbolicate payload is of type json

### DIFF
--- a/.changeset/strong-chefs-stare.md
+++ b/.changeset/strong-chefs-stare.md
@@ -1,0 +1,5 @@
+---
+"@callstack/repack-dev-server": patch
+---
+
+Support `application/json` type of payload for `/symbolicate` requests


### PR DESCRIPTION
### Summary

RN 0.79 changed payload type from `text/plain` to `application/json` for symbolication requests so this PR adds support for that while maintaining backwards compatibility for previous RN versions with `text/plain`

### Test plan

- [x] - testers work