### PR TITLE
feat: enable persistent cache by default in start command

### DIFF
--- a/.changeset/perfect-news-jog.md
+++ b/.changeset/perfect-news-jog.md
@@ -1,0 +1,5 @@
+---
+"@callstack/repack": minor
+---
+
+Enable persistent cache by default in `start` command

--- a/.changeset/spicy-spiders-help.md
+++ b/.changeset/spicy-spiders-help.md
@@ -1,0 +1,5 @@
+---
+"@callstack/repack": minor
+---
+
+Support resetting transformation cache via `--reset-cache` flag

--- a/packages/repack/src/commands/common/config/getCommandConfig.ts
+++ b/packages/repack/src/commands/common/config/getCommandConfig.ts
@@ -1,13 +1,19 @@
 import { DEFAULT_HOSTNAME, DEFAULT_PORT } from '../../consts.js';
 
-function getStartCommandDefaults() {
+function getCacheConfig(bundler: 'rspack' | 'webpack') {
+  if (bundler === 'rspack') {
+    return {
+      cache: true,
+      experiments: { cache: { type: 'persistent' } },
+    };
+  }
+
+  return { cache: { type: 'filesystem' } };
+}
+
+function getStartCommandDefaults(bundler: 'rspack' | 'webpack') {
   return {
-    cache: true,
-    experiments: {
-      cache: {
-        type: 'persistent',
-      },
-    },
+    ...getCacheConfig(bundler),
     mode: 'development',
     devServer: {
       host: DEFAULT_HOSTNAME,
@@ -31,9 +37,12 @@ function getBundleCommandDefaults() {
   };
 }
 
-export function getCommandConfig(command: 'start' | 'bundle') {
+export function getCommandConfig(
+  command: 'start' | 'bundle',
+  bundler: 'rspack' | 'webpack'
+) {
   if (command === 'start') {
-    return getStartCommandDefaults();
+    return getStartCommandDefaults(bundler);
   }
 
   if (command === 'bundle') {

--- a/packages/repack/src/commands/common/config/getCommandConfig.ts
+++ b/packages/repack/src/commands/common/config/getCommandConfig.ts
@@ -2,6 +2,12 @@ import { DEFAULT_HOSTNAME, DEFAULT_PORT } from '../../consts.js';
 
 function getStartCommandDefaults() {
   return {
+    cache: true,
+    experiments: {
+      cache: {
+        type: 'persistent',
+      },
+    },
     mode: 'development',
     devServer: {
       host: DEFAULT_HOSTNAME,

--- a/packages/repack/src/commands/common/config/makeCompilerConfig.ts
+++ b/packages/repack/src/commands/common/config/makeCompilerConfig.ts
@@ -40,7 +40,7 @@ export async function makeCompilerConfig<C extends ConfigurationObject>(
   // get cli overrides which take precedence over values from config files
   const cliConfigOverrides = getCliOverrides<C>({ args, command });
   // get defaults for use with specific commands
-  const commandConfig = getCommandConfig(command);
+  const commandConfig = getCommandConfig(command, bundler);
 
   // get defaults that will be applied on top of built-in ones (Rspack/webpack)
   const repackConfig = getRepackConfig();

--- a/packages/repack/src/commands/common/index.ts
+++ b/packages/repack/src/commands/common/index.ts
@@ -2,6 +2,7 @@ export * from './adaptFilenameToPlatform.js';
 export * from './getMimeType.js';
 export * from './runAdbReverse.js';
 export * from './parseFileUrl.js';
+export * from './resetPersistentCache.js';
 export * from './setupInteractions.js';
 export * from './setupStatsWriter.js';
 

--- a/packages/repack/src/commands/common/resetPersistentCache.ts
+++ b/packages/repack/src/commands/common/resetPersistentCache.ts
@@ -101,9 +101,18 @@ export function resetPersistentCache({
 
   const warn = (msg: string) => console.warn(colorette.yellow(msg));
 
-  cachePaths.forEach((cachePath) => {
-    if (!fs.existsSync(cachePath)) return;
+  for (const cachePath of cachePaths) {
+    if (!fs.existsSync(cachePath)) continue;
     const relativeCachePath = path.relative(rootDir, cachePath);
+
+    if (relativeCachePath.startsWith('..')) {
+      warn(
+        `Cache path "${relativeCachePath}" is outside of the project directory. ` +
+          'Resetting cache outside of the project directory is not supported. ' +
+          'Please delete the cache directory manually.\n'
+      );
+      continue;
+    }
 
     try {
       fs.rmSync(cachePath, { recursive: true });
@@ -111,5 +120,5 @@ export function resetPersistentCache({
     } catch {
       warn(`Failed to delete cache at ${relativeCachePath}\n`);
     }
-  });
+  }
 }

--- a/packages/repack/src/commands/common/resetPersistentCache.ts
+++ b/packages/repack/src/commands/common/resetPersistentCache.ts
@@ -1,0 +1,108 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import type { Configuration as RspackConfiguration } from '@rspack/core';
+import type { Configuration as WebpackConfiguration } from 'webpack';
+
+type RspackCacheOptions = NonNullable<
+  RspackConfiguration['experiments']
+>['cache'];
+type WebpackCacheOptions = WebpackConfiguration['cache'];
+
+function getDefaultCacheDirectory(bundler: 'rspack' | 'webpack') {
+  return path.join('node_modules', '.cache', bundler);
+}
+
+function getCustomCacheDirectory(candidate: string, rootDir: string): string {
+  if (path.isAbsolute(candidate)) return candidate;
+  return path.resolve(rootDir, candidate);
+}
+
+function getRspackCachePaths(
+  rootDir: string,
+  cacheConfigs: RspackCacheOptions[]
+): Set<string> {
+  const cachePaths = new Set<string>();
+
+  for (const cacheConfig of cacheConfigs) {
+    if (
+      typeof cacheConfig === 'object' &&
+      'storage' in cacheConfig &&
+      cacheConfig.storage?.directory
+    ) {
+      const candidateDir = cacheConfig.storage.directory;
+      cachePaths.add(getCustomCacheDirectory(candidateDir, rootDir));
+    } else {
+      cachePaths.add(getDefaultCacheDirectory('rspack'));
+    }
+  }
+
+  return cachePaths;
+}
+
+function getWebpackCachePaths(
+  rootDir: string,
+  cacheConfigs: WebpackCacheOptions[]
+): Set<string> {
+  const cachePaths = new Set<string>();
+
+  for (const cacheConfig of cacheConfigs) {
+    if (
+      typeof cacheConfig === 'object' &&
+      'cacheLocation' in cacheConfig &&
+      cacheConfig.cacheLocation
+    ) {
+      const candidateDir = path.dirname(cacheConfig.cacheLocation);
+      cachePaths.add(getCustomCacheDirectory(candidateDir, rootDir));
+    } else if (
+      typeof cacheConfig === 'object' &&
+      'cacheDirectory' in cacheConfig &&
+      cacheConfig.cacheDirectory
+    ) {
+      const candidateDir = cacheConfig.cacheDirectory;
+      cachePaths.add(getCustomCacheDirectory(candidateDir, rootDir));
+    } else {
+      cachePaths.add(getDefaultCacheDirectory('rspack'));
+    }
+  }
+
+  return cachePaths;
+}
+
+function deleteCacheDirectory(cachePath: string): void {
+  if (!fs.existsSync(cachePath)) return;
+
+  try {
+    fs.rmSync(cachePath, { recursive: true });
+  } catch (error) {
+    console.warn(`Failed to delete cache at ${cachePath}:`, error);
+  }
+}
+
+export function resetPersistentCache(config: {
+  bundler: 'rspack';
+  rootDir: string;
+  cacheConfigs: RspackCacheOptions[];
+}): void;
+
+export function resetPersistentCache(config: {
+  bundler: 'webpack';
+  rootDir: string;
+  cacheConfigs: WebpackCacheOptions[];
+}): void;
+
+export function resetPersistentCache({
+  bundler,
+  rootDir,
+  cacheConfigs,
+}: {
+  bundler: 'rspack' | 'webpack';
+  rootDir: string;
+  cacheConfigs: unknown;
+}) {
+  const cachePaths =
+    bundler === 'rspack'
+      ? getRspackCachePaths(rootDir, cacheConfigs as RspackCacheOptions[])
+      : getWebpackCachePaths(rootDir, cacheConfigs as WebpackCacheOptions[]);
+
+  cachePaths.forEach(deleteCacheDirectory);
+}

--- a/packages/repack/src/commands/options.ts
+++ b/packages/repack/src/commands/options.ts
@@ -27,10 +27,9 @@ export const startCommandOptions = [
     name: '--no-interactive',
     description: 'Disables interactive mode',
   },
-  // noop, but kept for compatibility
   {
     name: '--reset-cache, --resetCache',
-    description: '(unsupported) Resets the transformation cache',
+    description: 'Resets the transformation cache',
   },
   // options specific to Re.Pack
   {
@@ -114,10 +113,9 @@ export const bundleCommandOptions = [
     description:
       'Directory name where to store assets referenced in the bundle',
   },
-  // noop, needed for compatibility
   {
     name: '--reset-cache',
-    description: '(unsupported) Resets the transformation cache',
+    description: 'Resets the transformation cache',
   },
   // noop, needed for compatibility
   {

--- a/packages/repack/src/commands/rspack/bundle.ts
+++ b/packages/repack/src/commands/rspack/bundle.ts
@@ -2,7 +2,11 @@ import { type Configuration, rspack } from '@rspack/core';
 import type { Stats } from '@rspack/core';
 import { CLIError } from '../common/cliError.js';
 import { makeCompilerConfig } from '../common/config/makeCompilerConfig.js';
-import { normalizeStatsOptions, writeStats } from '../common/index.js';
+import {
+  normalizeStatsOptions,
+  resetPersistentCache,
+  writeStats,
+} from '../common/index.js';
 import { setupEnvironment } from '../common/setupEnvironment.js';
 import type { BundleArguments, CliConfig } from '../types.js';
 
@@ -33,6 +37,14 @@ export async function bundle(
 
   if (!args.entryFile && !config.entry) {
     throw new CLIError("Option '--entry-file <path>' argument is missing");
+  }
+
+  if (args.resetCache) {
+    resetPersistentCache({
+      bundler: 'rspack',
+      rootDir: cliConfig.root,
+      cacheConfigs: [config.experiments?.cache],
+    });
   }
 
   const errorHandler = async (error: Error | null, stats?: Stats) => {

--- a/packages/repack/src/commands/rspack/start.ts
+++ b/packages/repack/src/commands/rspack/start.ts
@@ -16,6 +16,7 @@ import {
 } from '../common/index.js';
 import { runAdbReverse } from '../common/index.js';
 import logo from '../common/logo.js';
+import { resetPersistentCache } from '../common/resetPersistentCache.js';
 import { setupEnvironment } from '../common/setupEnvironment.js';
 import type { CliConfig, StartArguments } from '../types.js';
 import { Compiler } from './Compiler.js';
@@ -63,6 +64,14 @@ export async function start(
   );
 
   process.stdout.write(logo(packageJson.version, 'Rspack'));
+
+  if (args.resetCache) {
+    resetPersistentCache({
+      bundler: 'rspack',
+      rootDir: cliConfig.root,
+      cacheConfigs: configs.map((config) => config.experiments?.cache),
+    });
+  }
 
   const compiler = new Compiler(configs, reporter, cliConfig.root);
 

--- a/packages/repack/src/commands/rspack/start.ts
+++ b/packages/repack/src/commands/rspack/start.ts
@@ -12,11 +12,11 @@ import { makeCompilerConfig } from '../common/config/makeCompilerConfig.js';
 import {
   getMimeType,
   parseFileUrl,
+  resetPersistentCache,
   setupInteractions,
 } from '../common/index.js';
 import { runAdbReverse } from '../common/index.js';
 import logo from '../common/logo.js';
-import { resetPersistentCache } from '../common/resetPersistentCache.js';
 import { setupEnvironment } from '../common/setupEnvironment.js';
 import type { CliConfig, StartArguments } from '../types.js';
 import { Compiler } from './Compiler.js';

--- a/packages/repack/src/commands/types.ts
+++ b/packages/repack/src/commands/types.ts
@@ -10,6 +10,7 @@ export interface BundleArguments {
   assetsDest?: string;
   json?: string;
   stats?: string;
+  resetCache?: boolean;
   verbose?: boolean;
   watch?: boolean;
   config?: string;
@@ -27,6 +28,7 @@ export interface StartArguments {
   logFile?: string;
   logRequests?: boolean;
   platform?: string;
+  resetCache?: boolean;
   reversePort?: boolean;
   verbose?: boolean;
   config?: string;

--- a/packages/repack/src/commands/webpack/bundle.ts
+++ b/packages/repack/src/commands/webpack/bundle.ts
@@ -1,7 +1,11 @@
 import webpack, { type Configuration } from 'webpack';
 import { CLIError } from '../common/cliError.js';
 import { makeCompilerConfig } from '../common/config/makeCompilerConfig.js';
-import { normalizeStatsOptions, writeStats } from '../common/index.js';
+import {
+  normalizeStatsOptions,
+  resetPersistentCache,
+  writeStats,
+} from '../common/index.js';
 import { setupEnvironment } from '../common/setupEnvironment.js';
 import type { BundleArguments, CliConfig } from '../types.js';
 /**
@@ -31,6 +35,14 @@ export async function bundle(
 
   if (!args.entryFile && !config.entry) {
     throw new CLIError("Option '--entry-file <path>' argument is missing");
+  }
+
+  if (args.resetCache) {
+    resetPersistentCache({
+      bundler: 'webpack',
+      rootDir: cliConfig.root,
+      cacheConfigs: [config.cache],
+    });
   }
 
   const errorHandler = async (error: Error | null, stats?: webpack.Stats) => {

--- a/packages/repack/src/commands/webpack/start.ts
+++ b/packages/repack/src/commands/webpack/start.ts
@@ -14,6 +14,7 @@ import { makeCompilerConfig } from '../common/config/makeCompilerConfig.js';
 import {
   getMimeType,
   parseFileUrl,
+  resetPersistentCache,
   runAdbReverse,
   setupInteractions,
 } from '../common/index.js';
@@ -65,6 +66,14 @@ export async function start(
   );
 
   process.stdout.write(logo(packageJson.version, 'webpack'));
+
+  if (args.resetCache) {
+    resetPersistentCache({
+      bundler: 'webpack',
+      rootDir: cliConfig.root,
+      cacheConfigs: configs.map((config) => config.cache),
+    });
+  }
 
   const compiler = new Compiler(
     args,

--- a/website/src/latest/api/cli/bundle.mdx
+++ b/website/src/latest/api/cli/bundle.mdx
@@ -21,7 +21,6 @@ import { PackageManagerTabs } from 'rspress/theme';
 
 To stay compatible with the `@react-native-community/cli` command, the following flags are included but are not functional:
 
-- `--reset-cache`
 - `--config-cmd`
 
 :::
@@ -101,6 +100,12 @@ Example:
 }} />
 
 More details: [Rspack documentation](https://rspack.dev/config/stats)
+
+### `--reset-cache`
+
+- Type: `boolean`
+
+Resets the transformation cache.
 
 ### `--verbose`
 

--- a/website/src/latest/api/cli/start.mdx
+++ b/website/src/latest/api/cli/start.mdx
@@ -19,15 +19,6 @@ import { PackageManagerTabs } from 'rspress/theme';
 
 ## Options
 
-:::info
-
-To stay compatible with the `@react-native-community/cli` command, the following flags are included but are not functional:
-
-- `--reset-cache`
-- `--resetCache`
-
-:::
-
 ### `--port`
 
 - Type: `number`
@@ -94,6 +85,12 @@ Run the dev server for the specified platform only. By default, the dev server w
 - Type: `boolean`
 
 Disables running ADB reverse automatically when bundling for Android.
+
+### `--reset-cache`, `--resetCache`
+
+- Type: `boolean`
+
+Resets the transformation cache.
 
 ### `--verbose`
 


### PR DESCRIPTION
## Summary

This PR add persistent caching by default for `start` command, and adds support for resetting the transformation cache via a old-new `--reset-cache` flag. 

**Users can opt out of persistent cache by setting `cache: false` in the project configuration.**

## Details

- Enabled persistent cache by default in `start` command
- Implemented `--reset-cache` flag functionality for both `start` and `bundle` commands
  - Added cache reset utility that handles both Rspack and Webpack cache directories
  - Supports both default and custom cache locations
  - Provides clear warnings when cache reset fails or when cache is outside project directory
- Updated documentation to reflect new functionality
  - Removed "unsupported" notes from `--reset-cache` flag descriptions
  - Added new documentation sections explaining the cache reset feature

## Test Plan

- [x] - testers work 