### PR TITLE
fix: use readFileSync instead of require in `validatePlugins`

### DIFF
--- a/.changeset/good-mirrors-bow.md
+++ b/.changeset/good-mirrors-bow.md
@@ -1,0 +1,5 @@
+---
+"@callstack/repack": patch
+---
+
+Fix failure to read project package json when validating plugins

--- a/packages/repack/src/commands/common/config/validatePlugins.ts
+++ b/packages/repack/src/commands/common/config/validatePlugins.ts
@@ -1,3 +1,4 @@
+import fs from 'node:fs';
 import path from 'node:path';
 import { bold } from 'colorette';
 
@@ -34,8 +35,9 @@ export async function validatePlugins(
   );
 
   try {
-    const packageJson = require(path.join(rootDir, 'package.json'));
-    dependencies = Object.keys(packageJson.dependencies || {});
+    const packageJsonPath = path.join(rootDir, 'package.json');
+    const packageJson = fs.readFileSync(packageJsonPath, 'utf-8');
+    dependencies = Object.keys(JSON.parse(packageJson).dependencies || {});
   } catch (error) {
     if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
       console.debug(


### PR DESCRIPTION
### Summary

- [x] - fixed behaviour of `validatePlugins` where it fails to read `package.json` when node version has support for `require(esm)`

### Test plan

- [x] - testers work
