### PR TITLE
chore: pin plugin versions to current version of Re.Pack

### DIFF
--- a/packages/plugin-expo-modules/package.json
+++ b/packages/plugin-expo-modules/package.json
@@ -33,7 +33,7 @@
     "node": ">=18"
   },
   "peerDependencies": {
-    "@callstack/repack": "^5.0.6"
+    "@callstack/repack": "workspace:*"
   },
   "devDependencies": {
     "@callstack/repack": "workspace:*",

--- a/packages/plugin-nativewind/package.json
+++ b/packages/plugin-nativewind/package.json
@@ -42,7 +42,7 @@
     "dedent": "^0.7.0"
   },
   "peerDependencies": {
-    "@callstack/repack": ">=5.0.6",
+    "@callstack/repack": "workspace:*",
     "nativewind": ">=4.1.23",
     "react-native-css-interop": ">=0.1.22",
     "postcss": ">=8.4.31",

--- a/packages/plugin-reanimated/package.json
+++ b/packages/plugin-reanimated/package.json
@@ -39,7 +39,7 @@
   "dependencies": {},
   "peerDependencies": {
     "@babel/core": "^7.20",
-    "@callstack/repack": "^5.0.6"
+    "@callstack/repack": "workspace:*"
   },
   "devDependencies": {
     "@callstack/repack": "workspace:*",


### PR DESCRIPTION
### Summary

since we're releasing plugins all at once, it makes sense to have the peerDependency set to the same version

### Test plan

n/a
