### PR TITLE
fix: enqueue resolvers before `ScriptManager` init

### DIFF
--- a/.changeset/cold-kids-yawn.md
+++ b/.changeset/cold-kids-yawn.md
@@ -1,0 +1,5 @@
+---
+"@callstack/repack": patch
+---
+
+Fix registering resolvers for remotes in ResolverPlugin

--- a/.changeset/cold-kids-yawn.md
+++ b/.changeset/cold-kids-yawn.md
@@ -2,4 +2,4 @@
 "@callstack/repack": patch
 ---
 
-Fix registering resolvers for remotes in ResolverPlugin
+Fix registering resolvers for remotes in ResolverPlugin when ScriptManager is not yet initialized

--- a/packages/repack/src/modules/FederationRuntimePlugins/ResolverPlugin.ts
+++ b/packages/repack/src/modules/FederationRuntimePlugins/ResolverPlugin.ts
@@ -87,14 +87,12 @@ const registerResolver = async (
 
 const RepackResolverPlugin: (
   config?: RepackResolverPluginConfiguration
-) => FederationRuntimePlugin = (config) => {
-  return {
-    name: 'repack-resolver-plugin',
-    registerRemote: (args) => {
-      registerResolver(args.remote, config);
-      return args;
-    },
-  };
-};
+) => FederationRuntimePlugin = (config) => ({
+  name: 'repack-resolver-plugin',
+  registerRemote: (args) => {
+    registerResolver(args.remote, config);
+    return args;
+  },
+});
 
 export default RepackResolverPlugin;

--- a/packages/repack/src/modules/FederationRuntimePlugins/__tests__/CorePlugin.test.ts
+++ b/packages/repack/src/modules/FederationRuntimePlugins/__tests__/CorePlugin.test.ts
@@ -29,7 +29,7 @@ webpackRequireMock.l = () => {};
 webpackRequireMock.u = (id: string) => `${id}.chunk.bundle`;
 webpackRequireMock.p = () => '';
 webpackRequireMock.repack = {
-  shared: { scriptManager: undefined },
+  shared: { scriptManager: undefined, enqueuedResolvers: [] },
 };
 
 globalThis.__webpack_require__ = webpackRequireMock;

--- a/packages/repack/src/modules/FederationRuntimePlugins/__tests__/ResolverPlugin.test.ts
+++ b/packages/repack/src/modules/FederationRuntimePlugins/__tests__/ResolverPlugin.test.ts
@@ -38,185 +38,237 @@ const mockRemoteInfo = {
 };
 
 describe('RepackResolverPlugin', () => {
-  beforeEach(() => {
-    ScriptManager.init();
-
-    // mock the error handler to disable polluting the console
-    // @ts-expect-error private method
-    ScriptManager.shared.handleError = () => {
-      throw new Error('mocked error');
-    };
-  });
-
-  afterEach(() => {
-    // reset ScriptManager instance
-    webpackRequireMock.repack.shared.scriptManager = undefined;
-  });
-
-  it('should resolve a script through a manifest', async () => {
-    const plugin = RepackResolverPlugin();
-    // trigger the plugin to register the resolver
-    plugin.registerRemote!({ remote: mockRemoteInfo } as any);
-
-    // manually resolve the script to verify the result
-    const script = await ScriptManager.shared.resolveScript(
-      'remote1',
-      undefined,
-      webpackRequireMock,
-      'https://example-entry.com/remoteEntry.js'
-    );
-
-    expect(script.locator.url).toBe(
-      'https://example-manifest.com/remote1/remoteEntry.js'
-    );
-  });
-
-  it('should resolve a script through remote entry', async () => {
-    const plugin = RepackResolverPlugin();
-    // trigger the plugin to register the resolver
-    plugin.registerRemote!({
-      remote: { ...mockRemoteInfo, version: undefined },
-    } as any);
-
-    // manually resolve the script to verify the result
-    const script = await ScriptManager.shared.resolveScript(
-      'remote1',
-      undefined,
-      webpackRequireMock,
-      'https://example-entry.com/remoteEntry.js'
-    );
-
-    expect(script.locator.url).toBe(
-      'https://example-entry.com/remote1/remoteEntry.js'
-    );
-  });
-
-  it('should allow custom configuration when used in runtime with a config object', async () => {
-    const config = { headers: { Authorization: 'Bearer token' } };
-    const plugin = RepackResolverPlugin(config);
-    // trigger the plugin to register the resolver
-    plugin.registerRemote!({ remote: mockRemoteInfo } as any);
-
-    // manually resolve the script to verify the result
-    const script = await ScriptManager.shared.resolveScript(
-      'asset',
-      'remote1',
-      webpackRequireMock,
-      'https://example-entry.com/remote1/asset.js'
-    );
-
-    expect(script.locator.headers).toEqual({ authorization: 'Bearer token' });
-  });
-
-  it('should allow custom configuration when used in runtime with a config function', async () => {
-    const config = async (url: string): Promise<ScriptLocator> => ({
-      url,
-      headers: { Authorization: 'Bearer token' },
+  describe('with ScriptManager not initialized', () => {
+    afterEach(() => {
+      // reset ScriptManager instance
+      webpackRequireMock.repack.shared.scriptManager = undefined;
     });
-    const plugin = RepackResolverPlugin(config);
-    // trigger the plugin to register the resolver
-    plugin.registerRemote!({ remote: mockRemoteInfo } as any);
 
-    // manually resolve the script to verify the result
-    const script = await ScriptManager.shared.resolveScript(
-      'asset',
-      'remote1',
-      webpackRequireMock,
-      'https://example-entry.com/remote1/asset.js'
-    );
+    it('should register queued resolvers when ScriptManager is initialized', async () => {
+      const plugin = RepackResolverPlugin();
+      const enqueuedResolvers =
+        webpackRequireMock.repack.shared.enqueuedResolvers;
+      // trigger the plugin to register the resolver
+      plugin.registerRemote!({ remote: mockRemoteInfo } as any);
+      expect(enqueuedResolvers).toHaveLength(1);
 
-    expect(script.locator.headers).toEqual({ authorization: 'Bearer token' });
-  });
-
-  it('should throw error when reference URL is missing', async () => {
-    const plugin = RepackResolverPlugin();
-    // trigger the plugin to register the resolver
-    plugin.registerRemote!({ remote: mockRemoteInfo } as any);
-
-    // manually resolve the script to verify the result (should throw)
-    await expect(
-      ScriptManager.shared.resolveScript(
+      ScriptManager.init();
+      // manually resolve the script to verify the result
+      const script = await ScriptManager.shared.resolveScript(
         'remote1',
         undefined,
-        webpackRequireMock
-      )
-    ).rejects.toThrow();
-  });
+        webpackRequireMock,
+        'https://example-entry.com/remoteEntry.js'
+      );
 
-  it('should rebase URLs with custom configuration', async () => {
-    const config = { headers: { Authorization: 'Bearer token' } };
-    const plugin = RepackResolverPlugin(config);
-    // trigger the plugin to register the resolver
-    plugin.registerRemote!({ remote: mockRemoteInfo } as any);
-
-    // manually resolve the script to verify the result
-    const script = await ScriptManager.shared.resolveScript(
-      'chunk1',
-      'remote1',
-      webpackRequireMock,
-      'https://example-entry.com/remote1/assets/chunk1.js'
-    );
-
-    expect(script.locator.url).toBe(
-      'https://example-manifest.com/remote1/chunk1.js'
-    );
-    expect(script.locator.headers).toEqual({ authorization: 'Bearer token' });
-    expect(script.locator.fetch).toBe(true);
-  });
-
-  it('should not resolve scripts for other remotes', async () => {
-    // Add a default resolver to handle other remotes
-    const defaultResolverMock = jest.fn().mockResolvedValue({
-      url: 'http://default.com/script.js',
+      expect(script.locator.url).toBe(
+        'https://example-manifest.com/remote1/remoteEntry.js'
+      );
     });
 
-    ScriptManager.shared.addResolver(defaultResolverMock);
+    it('should clear the resolver queue on ScriptManager initialization', () => {
+      const plugin = RepackResolverPlugin();
+      const enqueuedResolvers =
+        webpackRequireMock.repack.shared.enqueuedResolvers;
+      // trigger the plugin to register the resolver
+      plugin.registerRemote!({ remote: mockRemoteInfo } as any);
+      expect(enqueuedResolvers).toHaveLength(1);
+      ScriptManager.init();
+      expect(enqueuedResolvers).toHaveLength(0);
+    });
 
-    const plugin = RepackResolverPlugin();
-    // trigger the plugin to register the resolver
-    plugin.registerRemote!({ remote: mockRemoteInfo } as any);
-
-    // manually resolve the script to verify the result
-    const script = await ScriptManager.shared.resolveScript('other-remote');
-
-    expect(defaultResolverMock).toHaveBeenCalled();
-    expect(script.locator.url).toBe('http://default.com/script.js');
+    it('should throw error when ScriptManager is not initialized', () => {
+      const plugin = RepackResolverPlugin();
+      const enqueuedResolvers =
+        webpackRequireMock.repack.shared.enqueuedResolvers;
+      // trigger the plugin to register the resolver
+      plugin.registerRemote!({ remote: mockRemoteInfo } as any);
+      expect(enqueuedResolvers).toHaveLength(1);
+      expect(() => ScriptManager.shared.resolveScript('remote1')).toThrow();
+    });
   });
 
-  it('should rebase the URL from reference URL to entry URL', async () => {
-    const plugin = RepackResolverPlugin();
-    // trigger the plugin to register the resolver
-    plugin.registerRemote!({
-      remote: {
-        name: 'remote1',
-        entry: 'https://example.com/ios/remote1/entry.container.js.bundle',
-        version: 'https://example-manifest.com/remote1/mf-manifest.json',
-      },
-    } as any);
+  describe('with ScriptManager initialized', () => {
+    beforeEach(() => {
+      ScriptManager.init();
 
-    // manually resolve the script to verify the result
-    const script1 = await ScriptManager.shared.resolveScript(
-      'remote1',
-      undefined,
-      webpackRequireMock,
-      'https://example.com/ios/remote1/entry.container.js.bundle'
-    );
+      // mock the error handler to disable polluting the console
+      // @ts-expect-error private method
+      ScriptManager.shared.handleError = () => {
+        throw new Error('mocked error');
+      };
+    });
 
-    // container entry is expected to be at the same level as manifest
-    expect(script1.locator.url).toBe(
-      'https://example-manifest.com/remote1/entry.container.js.bundle'
-    );
+    afterEach(() => {
+      // reset ScriptManager instance
+      webpackRequireMock.repack.shared.scriptManager = undefined;
+    });
 
-    const script2 = await ScriptManager.shared.resolveScript(
-      'asset',
-      'remote1',
-      webpackRequireMock,
-      'http://localhost:8081/ios/remote1/asset.js'
-    );
+    it('should resolve a script through a manifest', async () => {
+      const plugin = RepackResolverPlugin();
+      // trigger the plugin to register the resolver
+      plugin.registerRemote!({ remote: mockRemoteInfo } as any);
 
-    // all other assets are expected to be at the same level as manifest
-    expect(script2.locator.url).toBe(
-      'https://example-manifest.com/remote1/asset.js'
-    );
+      // manually resolve the script to verify the result
+      const script = await ScriptManager.shared.resolveScript(
+        'remote1',
+        undefined,
+        webpackRequireMock,
+        'https://example-entry.com/remoteEntry.js'
+      );
+
+      expect(script.locator.url).toBe(
+        'https://example-manifest.com/remote1/remoteEntry.js'
+      );
+    });
+
+    it('should resolve a script through remote entry', async () => {
+      const plugin = RepackResolverPlugin();
+      // trigger the plugin to register the resolver
+      plugin.registerRemote!({
+        remote: { ...mockRemoteInfo, version: undefined },
+      } as any);
+
+      // manually resolve the script to verify the result
+      const script = await ScriptManager.shared.resolveScript(
+        'remote1',
+        undefined,
+        webpackRequireMock,
+        'https://example-entry.com/remoteEntry.js'
+      );
+
+      expect(script.locator.url).toBe(
+        'https://example-entry.com/remote1/remoteEntry.js'
+      );
+    });
+
+    it('should allow custom configuration when used in runtime with a config object', async () => {
+      const config = { headers: { Authorization: 'Bearer token' } };
+      const plugin = RepackResolverPlugin(config);
+      // trigger the plugin to register the resolver
+      plugin.registerRemote!({ remote: mockRemoteInfo } as any);
+
+      // manually resolve the script to verify the result
+      const script = await ScriptManager.shared.resolveScript(
+        'asset',
+        'remote1',
+        webpackRequireMock,
+        'https://example-entry.com/remote1/asset.js'
+      );
+
+      expect(script.locator.headers).toEqual({ authorization: 'Bearer token' });
+    });
+
+    it('should allow custom configuration when used in runtime with a config function', async () => {
+      const config = async (url: string): Promise<ScriptLocator> => ({
+        url,
+        headers: { Authorization: 'Bearer token' },
+      });
+      const plugin = RepackResolverPlugin(config);
+      // trigger the plugin to register the resolver
+      plugin.registerRemote!({ remote: mockRemoteInfo } as any);
+
+      // manually resolve the script to verify the result
+      const script = await ScriptManager.shared.resolveScript(
+        'asset',
+        'remote1',
+        webpackRequireMock,
+        'https://example-entry.com/remote1/asset.js'
+      );
+
+      expect(script.locator.headers).toEqual({ authorization: 'Bearer token' });
+    });
+
+    it('should throw error when reference URL is missing', async () => {
+      const plugin = RepackResolverPlugin();
+      // trigger the plugin to register the resolver
+      plugin.registerRemote!({ remote: mockRemoteInfo } as any);
+
+      // manually resolve the script to verify the result (should throw)
+      await expect(
+        ScriptManager.shared.resolveScript(
+          'remote1',
+          undefined,
+          webpackRequireMock
+        )
+      ).rejects.toThrow();
+    });
+
+    it('should rebase URLs with custom configuration', async () => {
+      const config = { headers: { Authorization: 'Bearer token' } };
+      const plugin = RepackResolverPlugin(config);
+      // trigger the plugin to register the resolver
+      plugin.registerRemote!({ remote: mockRemoteInfo } as any);
+
+      // manually resolve the script to verify the result
+      const script = await ScriptManager.shared.resolveScript(
+        'chunk1',
+        'remote1',
+        webpackRequireMock,
+        'https://example-entry.com/remote1/assets/chunk1.js'
+      );
+
+      expect(script.locator.url).toBe(
+        'https://example-manifest.com/remote1/chunk1.js'
+      );
+      expect(script.locator.headers).toEqual({ authorization: 'Bearer token' });
+      expect(script.locator.fetch).toBe(true);
+    });
+
+    it('should not resolve scripts for other remotes', async () => {
+      // Add a default resolver to handle other remotes
+      const defaultResolverMock = jest.fn().mockResolvedValue({
+        url: 'http://default.com/script.js',
+      });
+
+      ScriptManager.shared.addResolver(defaultResolverMock);
+
+      const plugin = RepackResolverPlugin();
+      // trigger the plugin to register the resolver
+      plugin.registerRemote!({ remote: mockRemoteInfo } as any);
+
+      // manually resolve the script to verify the result
+      const script = await ScriptManager.shared.resolveScript('other-remote');
+
+      expect(defaultResolverMock).toHaveBeenCalled();
+      expect(script.locator.url).toBe('http://default.com/script.js');
+    });
+
+    it('should rebase the URL from reference URL to entry URL', async () => {
+      const plugin = RepackResolverPlugin();
+      // trigger the plugin to register the resolver
+      plugin.registerRemote!({
+        remote: {
+          name: 'remote1',
+          entry: 'https://example.com/ios/remote1/entry.container.js.bundle',
+          version: 'https://example-manifest.com/remote1/mf-manifest.json',
+        },
+      } as any);
+
+      // manually resolve the script to verify the result
+      const script1 = await ScriptManager.shared.resolveScript(
+        'remote1',
+        undefined,
+        webpackRequireMock,
+        'https://example.com/ios/remote1/entry.container.js.bundle'
+      );
+
+      // container entry is expected to be at the same level as manifest
+      expect(script1.locator.url).toBe(
+        'https://example-manifest.com/remote1/entry.container.js.bundle'
+      );
+
+      const script2 = await ScriptManager.shared.resolveScript(
+        'asset',
+        'remote1',
+        webpackRequireMock,
+        'http://localhost:8081/ios/remote1/asset.js'
+      );
+
+      // all other assets are expected to be at the same level as manifest
+      expect(script2.locator.url).toBe(
+        'https://example-manifest.com/remote1/asset.js'
+      );
+    });
   });
 });

--- a/packages/repack/src/modules/FederationRuntimePlugins/__tests__/ResolverPlugin.test.ts
+++ b/packages/repack/src/modules/FederationRuntimePlugins/__tests__/ResolverPlugin.test.ts
@@ -26,7 +26,7 @@ webpackRequireMock.l = () => {};
 webpackRequireMock.u = (id: string) => `${id}.chunk.bundle`;
 webpackRequireMock.p = () => '';
 webpackRequireMock.repack = {
-  shared: { scriptManager: undefined },
+  shared: { scriptManager: undefined, enqueuedResolvers: [] },
 };
 
 globalThis.__webpack_require__ = webpackRequireMock;

--- a/packages/repack/src/modules/ScriptManager/ScriptManager.ts
+++ b/packages/repack/src/modules/ScriptManager/ScriptManager.ts
@@ -207,6 +207,15 @@ export class ScriptManager extends EventEmitter {
     }
 
     __webpack_require__.repack.shared.scriptManager = this;
+
+    const enqueuedResolvers =
+      __webpack_require__.repack.shared.enqueuedResolvers;
+    while (enqueuedResolvers.length) {
+      // process deferred resolvers in First-In-First-Out (FIFO) order to maintain
+      // the sequence in which they were registered before ScriptManager initialization
+      const [resolver, options] = enqueuedResolvers.shift()!;
+      this.addResolver(resolver, options);
+    }
   }
 
   private hookMap = {

--- a/packages/repack/src/modules/ScriptManager/__tests__/ScriptManager.test.ts
+++ b/packages/repack/src/modules/ScriptManager/__tests__/ScriptManager.test.ts
@@ -26,7 +26,7 @@ webpackRequire.l = () => {};
 webpackRequire.u = (id: string) => `${id}.chunk.bundle`;
 webpackRequire.p = () => '';
 webpackRequire.repack = {
-  shared: { scriptManager: undefined },
+  shared: { scriptManager: undefined, enqueuedResolvers: [] },
 };
 
 globalThis.__webpack_require__ = webpackRequire;

--- a/packages/repack/src/modules/ScriptManager/__tests__/ScriptManagerHooks.test.ts
+++ b/packages/repack/src/modules/ScriptManager/__tests__/ScriptManagerHooks.test.ts
@@ -24,7 +24,7 @@ webpackRequire.l = () => {};
 webpackRequire.u = (id: string) => `${id}.chunk.bundle`;
 webpackRequire.p = () => '';
 webpackRequire.repack = {
-  shared: { scriptManager: undefined },
+  shared: { scriptManager: undefined, enqueuedResolvers: [] },
 };
 
 globalThis.__webpack_require__ = webpackRequire;

--- a/packages/repack/src/plugins/RepackTargetPlugin/implementation/init.ts
+++ b/packages/repack/src/plugins/RepackTargetPlugin/implementation/init.ts
@@ -5,6 +5,7 @@ module.exports = function () {
     shared: ($globalObject$.__repack__ && $globalObject$.__repack__.shared) ||
       (__webpack_require__.repack && __webpack_require__.repack.shared) || {
         scriptManager: undefined,
+        deferredResolvers: [],
       },
   };
 

--- a/packages/repack/src/plugins/RepackTargetPlugin/implementation/init.ts
+++ b/packages/repack/src/plugins/RepackTargetPlugin/implementation/init.ts
@@ -5,7 +5,7 @@ module.exports = function () {
     shared: ($globalObject$.__repack__ && $globalObject$.__repack__.shared) ||
       (__webpack_require__.repack && __webpack_require__.repack.shared) || {
         scriptManager: undefined,
-        deferredResolvers: [],
+        enqueuedResolvers: [],
       },
   };
 

--- a/packages/repack/src/types/runtime-globals.d.ts
+++ b/packages/repack/src/types/runtime-globals.d.ts
@@ -43,6 +43,10 @@ declare namespace RepackRuntimeGlobals {
       scriptManager?: import(
         '../modules/ScriptManager/ScriptManager.js'
       ).ScriptManager;
+      enqueuedResolvers: [
+        import('../modules/ScriptManager/types.js').ScriptLocatorResolver,
+        { key?: string },
+      ][];
     };
   }
 


### PR DESCRIPTION
### Summary

`registerRemote` is a sync hook and previous approach with adding resolvers asynchronously proves very brittle as seen in https://github.com/ZephyrCloudIO/zephyr-repack-example

The hook is triggered very early in the runtime, before initialisation of RN Core & ScriptManager. Since there is no reliable way to wait for ScriptManager to be initialised, in ResolverPlugin we now check whether the `ScriptManager` instance is present in runtime: 
- if ScriptManager is initialized, we add resolver normally just as before
- if ScriptManager is not initialised, we add a resolver to queue that will be consumed at the end of ScriptManager initialisation sequence (ctor).

The queue is an internal runtime mechanism and is not exposed to the user. 

Ideally, in the future, we could be replace it by generating a virtual module based on the build config for Module Federation - we know that `registerRemote` will be triggered only by the defined remotes in build config. Runtime calls of `registerRemote` in the userland should not be of any concern since they will happen after initialisation of `ScriptManager`

### Test plan

- [x] - tests pass
- [x] - testers work 
