### PR TITLE
feat: add commands to open Android Emulator and iOS Simulator

### DIFF
--- a/.changeset/fruity-phones-boil.md
+++ b/.changeset/fruity-phones-boil.md
@@ -1,0 +1,5 @@
+---
+"@callstack/repack": minor
+---
+
+add commands to open Android Emulator and iOS Simulator

--- a/packages/repack/package.json
+++ b/packages/repack/package.json
@@ -75,6 +75,7 @@
     }
   },
   "dependencies": {
+    "@clack/prompts": "^0.9.1",
     "@callstack/repack-dev-server": "workspace:*",
     "@discoveryjs/json-ext": "^0.5.7",
     "@rspack/plugin-react-refresh": "1.0.0",

--- a/packages/repack/src/commands/common/__tests__/setupInteractions.test.ts
+++ b/packages/repack/src/commands/common/__tests__/setupInteractions.test.ts
@@ -277,7 +277,7 @@ describe('setupInteractions', () => {
         );
         expect(mockProcess.stdout.write).toHaveBeenNthCalledWith(
           6,
-          ' s: Open iOS Simulator\n'
+          ' s: Open iOS Simulator (unsupported, on non-macOS platforms)\n'
         );
         expect(mockProcess.stdout.write).toHaveBeenNthCalledWith(
           7,

--- a/packages/repack/src/commands/common/__tests__/setupInteractions.test.ts
+++ b/packages/repack/src/commands/common/__tests__/setupInteractions.test.ts
@@ -245,6 +245,8 @@ describe('setupInteractions', () => {
             onOpenDevMenu() {},
             onReload() {},
             onAdbReverse() {},
+            onOpenEmulator() {},
+            onOpenSimulator() {},
           },
           {
             logger: mockLogger,
@@ -271,6 +273,14 @@ describe('setupInteractions', () => {
         );
         expect(mockProcess.stdout.write).toHaveBeenNthCalledWith(
           5,
+          ' e: Open Android Emulator\n'
+        );
+        expect(mockProcess.stdout.write).toHaveBeenNthCalledWith(
+          6,
+          ' s: Open iOS Simulator\n'
+        );
+        expect(mockProcess.stdout.write).toHaveBeenNthCalledWith(
+          7,
           '\nPress Ctrl+c or Ctrl+z to quit the dev server\n\n'
         );
       });

--- a/packages/repack/src/commands/common/openEmulator.ts
+++ b/packages/repack/src/commands/common/openEmulator.ts
@@ -1,0 +1,78 @@
+import { execSync, spawn } from 'node:child_process';
+
+function getRunningEmulators(): string[] {
+  try {
+    const adbOutput = execSync('adb devices').toString();
+    const lines = adbOutput.split('\n').slice(1); // Skip the first line (header)
+    return lines
+      .map((line) => {
+        const match = line.match(/emulator-(\d+)/);
+        if (match) {
+          // Get the AVD name for this port
+          try {
+            const port = match[1];
+            const avdInfo = execSync(`adb -s emulator-${port} emu avd name`)
+              .toString()
+              .replace('OK', '')
+              .trim();
+            return avdInfo;
+          } catch {
+            return null;
+          }
+        }
+        return null;
+      })
+      .filter((name): name is string => name !== null);
+  } catch {
+    return [];
+  }
+}
+
+export async function openEmulator() {
+  const emulator = execSync('emulator -list-avds');
+  const avds = emulator.toString().split('\n').filter(Boolean);
+  const avd = avds?.[0];
+  if (!avd) {
+    throw new Error('No Android Virtual Device found');
+  }
+
+  const { select, isCancel, log } = await import('@clack/prompts');
+
+  const runningEmulators = getRunningEmulators();
+
+  if (runningEmulators.length > 0) {
+    log.info('Running emulators:');
+    runningEmulators.map((avd) => {
+      log.success(`${avd} is running`);
+    });
+    log.info('');
+  }
+
+  // show prompt to select avd use @clack/prompts
+  const selectedAvd = await select({
+    message: 'Select an Android Virtual Device',
+    options: avds
+      .filter((avd) => !runningEmulators.includes(avd))
+      .map((avd) => {
+        return {
+          label: avd,
+          value: avd,
+        };
+      }),
+  });
+
+  if (isCancel(selectedAvd)) {
+    throw new Error('No Android Virtual Device selected');
+  }
+
+  // Spawn emulator process with proper detachment
+  const emulatorProcess = spawn('emulator', ['-avd', selectedAvd.toString()], {
+    detached: true,
+    stdio: 'ignore',
+  });
+
+  log.success(`${selectedAvd} is running`);
+
+  // Unref the process to allow the parent to exit independently
+  emulatorProcess.unref();
+}

--- a/packages/repack/src/commands/common/openEmulator.ts
+++ b/packages/repack/src/commands/common/openEmulator.ts
@@ -1,4 +1,5 @@
 import { execSync, spawn } from 'node:child_process';
+import { isCancel, log, select } from '@clack/prompts';
 
 function getRunningEmulators(): string[] {
   try {
@@ -35,8 +36,6 @@ export async function openEmulator() {
   if (!avd) {
     throw new Error('No Android Virtual Device found');
   }
-
-  const { select, isCancel, log } = await import('@clack/prompts');
 
   const runningEmulators = getRunningEmulators();
 

--- a/packages/repack/src/commands/common/openSimulator.ts
+++ b/packages/repack/src/commands/common/openSimulator.ts
@@ -1,4 +1,5 @@
 import { execSync } from 'node:child_process';
+import { isCancel, log, select } from '@clack/prompts';
 
 interface Simulator {
   name: string;
@@ -40,8 +41,6 @@ export async function openSimulator() {
         }
       });
     }
-
-    const { select, isCancel, log } = await import('@clack/prompts');
 
     // Log running simulators
     if (runningSimulators.length > 0) {

--- a/packages/repack/src/commands/common/openSimulator.ts
+++ b/packages/repack/src/commands/common/openSimulator.ts
@@ -1,0 +1,82 @@
+import { execSync } from 'node:child_process';
+
+interface Simulator {
+  name: string;
+  udid: string;
+  state: string;
+  isAvailable: boolean;
+}
+
+export async function openSimulator() {
+  try {
+    // Get list of available simulators
+    const devices = execSync(
+      'xcrun simctl list devices available --json'
+    ).toString();
+    const parsedDevices = JSON.parse(devices);
+    const runtimes = Object.keys(parsedDevices.devices);
+
+    // Collect all available simulators
+    const availableSimulators: Simulator[] = [];
+    const runningSimulators: Simulator[] = [];
+
+    for (const runtime of runtimes) {
+      const simulators = parsedDevices.devices[runtime];
+      simulators.forEach((sim: any) => {
+        if (sim.isAvailable !== false) {
+          // Add if simulator is available
+          const simulator = {
+            name: `${sim.name} (${runtime})`,
+            udid: sim.udid,
+            state: sim.state,
+            isAvailable: true,
+          };
+
+          if (sim.state !== 'Shutdown') {
+            runningSimulators.push(simulator);
+          } else {
+            availableSimulators.push(simulator);
+          }
+        }
+      });
+    }
+
+    const { select, isCancel, log } = await import('@clack/prompts');
+
+    // Log running simulators
+    if (runningSimulators.length > 0) {
+      log.info('Running simulators:');
+      runningSimulators.forEach((sim) => {
+        log.success(`  • ${sim.name}`);
+      });
+      log.info(''); // Empty line for better readability
+    }
+
+    if (availableSimulators.length === 0) {
+      throw new Error('No available (shutdown) iOS Simulators found');
+    }
+
+    // Show prompt to select simulator (only showing shutdown simulators)
+    const selectedSimulator = await select({
+      message: 'Select an iOS Simulator',
+      options: availableSimulators.map((sim) => ({
+        label: sim.name,
+        value: sim.udid,
+      })),
+    });
+
+    if (isCancel(selectedSimulator)) {
+      throw new Error('No iOS Simulator selected');
+    }
+
+    // Boot the simulator
+    execSync(`xcrun simctl boot ${selectedSimulator}`);
+    // Open Simulator.app
+    execSync('open -a Simulator');
+  } catch (error) {
+    if (error instanceof Error) {
+      throw new Error(`Failed to open iOS Simulator: ${error.message}`);
+    }
+    throw error;
+  }
+}

--- a/packages/repack/src/commands/common/setupInteractions.ts
+++ b/packages/repack/src/commands/common/setupInteractions.ts
@@ -111,9 +111,12 @@ export function setupInteractions(
       helpName: 'Open Android Emulator',
     },
     s: {
-      action: handlers.onOpenSimulator,
+      action:
+        process.platform === 'darwin' ? handlers.onOpenSimulator : undefined,
       postPerformMessage: 'Opening iOS Simulator',
       helpName: 'Open iOS Simulator',
+      actionUnsupportedExplanation:
+        process.platform !== 'darwin' ? 'on non-macOS platforms' : undefined,
     },
   };
 

--- a/packages/repack/src/commands/common/setupInteractions.ts
+++ b/packages/repack/src/commands/common/setupInteractions.ts
@@ -22,6 +22,8 @@ export function setupInteractions(
     onOpenDevMenu?: () => void;
     onOpenDevTools?: () => void;
     onAdbReverse?: () => void;
+    onOpenEmulator?: () => void;
+    onOpenSimulator?: () => void;
   },
   options?: {
     logger?: Logger;
@@ -102,6 +104,16 @@ export function setupInteractions(
       action: handlers.onAdbReverse,
       postPerformMessage: 'Running adb reverse',
       helpName: 'Run adb reverse',
+    },
+    e: {
+      action: handlers.onOpenEmulator,
+      postPerformMessage: 'Opening Android Emulator',
+      helpName: 'Open Android Emulator',
+    },
+    s: {
+      action: handlers.onOpenSimulator,
+      postPerformMessage: 'Opening iOS Simulator',
+      helpName: 'Open iOS Simulator',
     },
   };
 

--- a/packages/repack/src/commands/rspack/start.ts
+++ b/packages/repack/src/commands/rspack/start.ts
@@ -17,10 +17,11 @@ import {
 } from '../common/index.js';
 import { runAdbReverse } from '../common/index.js';
 import logo from '../common/logo.js';
+import { openEmulator } from '../common/openEmulator.js';
+import { openSimulator } from '../common/openSimulator.js';
 import { setupEnvironment } from '../common/setupEnvironment.js';
 import type { CliConfig, StartArguments } from '../types.js';
 import { Compiler } from './Compiler.js';
-
 /**
  * Start command that runs a development server.
  * It runs `@callstack/repack-dev-server` to provide Development Server functionality
@@ -114,6 +115,12 @@ export async function start(
                 logger: ctx.log,
                 verbose: true,
               });
+            },
+            onOpenEmulator() {
+              void openEmulator();
+            },
+            onOpenSimulator() {
+              void openSimulator();
             },
           },
           { logger: ctx.log }

--- a/packages/repack/src/commands/webpack/start.ts
+++ b/packages/repack/src/commands/webpack/start.ts
@@ -19,6 +19,8 @@ import {
   setupInteractions,
 } from '../common/index.js';
 import logo from '../common/logo.js';
+import { openEmulator } from '../common/openEmulator.js';
+import { openSimulator } from '../common/openSimulator.js';
 import { setupEnvironment } from '../common/setupEnvironment.js';
 import type { CliConfig, StartArguments } from '../types.js';
 import { Compiler } from './Compiler.js';
@@ -112,6 +114,12 @@ export async function start(
                 logger: ctx.log,
                 verbose: true,
               });
+            },
+            onOpenEmulator() {
+              void openEmulator();
+            },
+            onOpenSimulator() {
+              void openSimulator();
             },
           },
           { logger: ctx.log }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -533,6 +533,9 @@ importers:
       '@callstack/repack-dev-server':
         specifier: workspace:*
         version: link:../dev-server
+      '@clack/prompts':
+        specifier: ^0.9.1
+        version: 0.9.1
       '@discoveryjs/json-ext':
         specifier: ^0.5.7
         version: 0.5.7


### PR DESCRIPTION
This commands are useful for open emulator/simulator faster and easier. similar what expo does.

<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

* Added `openEmulator` and `openSimulator` functions to manage emulator and simulator processes.
* Updated dependencies to include `@clack/prompts` for user prompts.

<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->

### Test plan
i was tested it by my own app and TesterApp too.
- run start command
- press e for emulator, then select from list of available emulators
- press s for simulator, then select from list of available simulators

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
