### PR TITLE
fix: expose missing `NATIVEWIND_OS` in NativeWind plugin

### DIFF
--- a/.changeset/plugin-nativewind.md
+++ b/.changeset/plugin-nativewind.md
@@ -1,25 +1,6 @@
 ---
+'@callstack/repack': patch
 '@callstack/repack-plugin-nativewind': patch
 ---
 
----
-
-### Details
-
-- **File Modified:** `packages/plugin-nativewind/src/plugin.ts`
-- **Summary of Change:**  
-  The plugin now ensures the `NATIVEWIND_OS` environment variable is set based on the platform name from `compiler.options.name` if it is not already defined. This is done during the initialization of the `NativeWindPlugin`, after dependency checks.
-- **Code Added:**
-  ```ts
-  /** Set the platform if not present*/
-  const platformName = compiler.options.name;
-  if (process.env.NATIVEWIND_OS === undefined) {
-      process.env.NATIVEWIND_OS = platformName;
-  }
-  ```
-- **Purpose:**  
-  This change guarantees platform detection for NativeWind, reducing manual environment configuration and improving reliability across different build platforms.
-
-- **Relevant PR:** [#1173](https://github.com/callstack/repack/pull/1173)
-
----
+Fix platform detection for NativeWind via `NATIVEWIND_OS` env var

--- a/.changeset/plugin-nativewind.md
+++ b/.changeset/plugin-nativewind.md
@@ -1,0 +1,25 @@
+---
+'@callstack/repack-plugin-nativewind': patch
+---
+
+---
+
+### Details
+
+- **File Modified:** `packages/plugin-nativewind/src/plugin.ts`
+- **Summary of Change:**  
+  The plugin now ensures the `NATIVEWIND_OS` environment variable is set based on the platform name from `compiler.options.name` if it is not already defined. This is done during the initialization of the `NativeWindPlugin`, after dependency checks.
+- **Code Added:**
+  ```ts
+  /** Set the platform if not present*/
+  const platformName = compiler.options.name;
+  if (process.env.NATIVEWIND_OS === undefined) {
+      process.env.NATIVEWIND_OS = platformName;
+  }
+  ```
+- **Purpose:**  
+  This change guarantees platform detection for NativeWind, reducing manual environment configuration and improving reliability across different build platforms.
+
+- **Relevant PR:** [#1173](https://github.com/callstack/repack/pull/1173)
+
+---

--- a/packages/plugin-nativewind/src/plugin.ts
+++ b/packages/plugin-nativewind/src/plugin.ts
@@ -109,7 +109,7 @@ export class NativeWindPlugin implements RspackPluginInstance {
     /** Set the platform if not present*/
     const platformName = compiler.options.name;
     if (process.env.NATIVEWIND_OS === undefined) {
-        process.env.NATIVEWIND_OS = platformName;
+      process.env.NATIVEWIND_OS = platformName;
     }
 
     /**

--- a/packages/plugin-nativewind/src/plugin.ts
+++ b/packages/plugin-nativewind/src/plugin.ts
@@ -9,10 +9,6 @@ import type {
 import type { CssToReactNativeRuntimeOptions } from 'react-native-css-interop/css-to-rn';
 
 interface NativeWindPluginOptions {
-  /** Force the platform passed to nativewind/preset.
-  *  "native" (default) | "web" | undefined (use env as-is)
-  */
-  presetPlatform?: 'native' | 'web' | undefined;
   /**
    * Whether to check if the required dependencies are installed in the project.
    * If not, an error will be thrown. Defaults to `true`.
@@ -111,19 +107,11 @@ export class NativeWindPlugin implements RspackPluginInstance {
     if (this.options.checkDependencies) {
       this.ensureNativewindDependenciesInstalled(compiler.context);
     }
-    /** Pick the platform */
-    const platform = this.options.presetPlatform ?? 'native';
+    /** Set the platform if not present*/
+    const platformName = compiler.options.name;
     if (process.env.NATIVEWIND_OS === undefined) {
-        process.env.NATIVEWIND_OS = platform;
+        process.env.NATIVEWIND_OS = platformName;
     }
-
-    /** Expose it at compile-time so tailwind.config.js can read it*/
-    compiler.options.plugins ||= [];
-    compiler.options.plugins.push(
-        new DefinePlugin({
-            'process.env.NATIVEWIND_OS': JSON.stringify(process.env.NATIVEWIND_OS),
-        }),
-    );
 
     /**
      * First, we need to process the CSS files using PostCSS.

--- a/packages/plugin-nativewind/src/plugin.ts
+++ b/packages/plugin-nativewind/src/plugin.ts
@@ -1,5 +1,6 @@
 import type {
   Compiler,
+  DefinePlugin,
   RspackPluginInstance,
   RuleSetUse,
   RuleSetUseItem,
@@ -8,6 +9,10 @@ import type {
 import type { CssToReactNativeRuntimeOptions } from 'react-native-css-interop/css-to-rn';
 
 interface NativeWindPluginOptions {
+  /** Force the platform passed to nativewind/preset.
+  *  "native" (default) | "web" | undefined (use env as-is)
+  */
+  presetPlatform?: 'native' | 'web' | undefined;
   /**
    * Whether to check if the required dependencies are installed in the project.
    * If not, an error will be thrown. Defaults to `true`.
@@ -106,6 +111,19 @@ export class NativeWindPlugin implements RspackPluginInstance {
     if (this.options.checkDependencies) {
       this.ensureNativewindDependenciesInstalled(compiler.context);
     }
+    /** Pick the platform */
+    const platform = this.options.presetPlatform ?? 'native';
+    if (process.env.NATIVEWIND_OS === undefined) {
+        process.env.NATIVEWIND_OS = platform;
+    }
+
+    /** Expose it at compile-time so tailwind.config.js can read it*/
+    compiler.options.plugins ||= [];
+    compiler.options.plugins.push(
+        new DefinePlugin({
+            'process.env.NATIVEWIND_OS': JSON.stringify(process.env.NATIVEWIND_OS),
+        }),
+    );
 
     /**
      * First, we need to process the CSS files using PostCSS.

--- a/packages/plugin-nativewind/src/plugin.ts
+++ b/packages/plugin-nativewind/src/plugin.ts
@@ -1,6 +1,5 @@
 import type {
   Compiler,
-  DefinePlugin,
   RspackPluginInstance,
   RuleSetUse,
   RuleSetUseItem,


### PR DESCRIPTION
### Problem statement

nativewind/preset chooses web, when process.env.NATIVEWIND_OS !== "native" or is undefined.
The Re-Pack plug-in never sets that variable, so Tailwind’s web defaults win and the angle variables
 (--tw-rotate, --tw-skew-x/y) are emitted as bare 0 → Android crashes.

Metro does set the var (via withNativeWind()), so the two bundlers behave differently.

### Proposed fix

Force the platform passed to nativewind/preset.
   *  "native" (default) | "web" | undefined (use env as-is)

### Why this solves the root bug (no work-arounds)

* When Tailwind runs, the **native** preset adds
  `--tw-rotate: 0deg; --tw-skew-x:0deg; --tw-skew-y:0deg` to the reset layer,
  so the generated CSS already has the correct units.
* The loader no longer needs to post-process `cssToReactNativeRuntime` output,
  and palette colours work unchanged.
   