### PR TITLE
docs: fix V4 links

### DIFF
--- a/website/src/latest/docs/features/_meta.json
+++ b/website/src/latest/docs/features/_meta.json
@@ -1,7 +1,6 @@
 [
   "code-splitting",
   "module-federation",
-  "module-resolution",
   "dev-server",
   "flow-support",
   "devtools",

--- a/website/src/latest/docs/features/module-federation.md
+++ b/website/src/latest/docs/features/module-federation.md
@@ -1,7 +1,7 @@
 # Module Federation
 
 :::warning Notice:
-The documentation for Re.Pack 5 is currently under development and some of the pages aren't ready yet.
+The documentation for Re.Pack 5 is currently under development and is not ready yet.
 
-Please use [latest stable version of Re.Pack 4.x documentation](https://re-pack.dev/docs/getting-started) for now.
+Please refer to [Re.Pack 4.x Module Federation documentation](https://v4.re-pack.dev/docs/module-federation) for now, but please keep in mind that it's not up to date with the latest changes in Re.Pack 5.
 :::

--- a/website/src/latest/docs/features/module-resolution.md
+++ b/website/src/latest/docs/features/module-resolution.md
@@ -1,7 +1,1 @@
 # Module resolution
-
-:::warning Notice:
-The documentation for Re.Pack 5 is currently under development and some of the pages aren't ready yet.
-
-Please use [latest stable version of Re.Pack 4.x documentation](https://re-pack.dev/docs/getting-started) for now.
-:::

--- a/website/src/latest/docs/getting-started/_meta.json
+++ b/website/src/latest/docs/getting-started/_meta.json
@@ -1,1 +1,1 @@
-["introduction", "quick-start", "microfrontends", "bundlers"]
+["introduction", "quick-start", "microfrontends"]

--- a/website/src/latest/docs/getting-started/bundlers.md
+++ b/website/src/latest/docs/getting-started/bundlers.md
@@ -1,7 +1,1 @@
 # Rspack & webpack
-
-:::warning Notice:
-The documentation for Re.Pack 5 is currently under development and some of the pages aren't ready yet.
-
-Please use [latest stable version of Re.Pack 4.x documentation](https://re-pack.dev/docs/getting-started) for now.
-:::


### PR DESCRIPTION
### Summary

- [x] - hide `Rspack & webpack` & `Module resolution` pages from sidebar
- [x] - remove broken v4 links
- [x] - point to correct address of Re.Pack 4 MF docs 

### Test plan

n/a
