### PR TITLE
fix: lock version of `react-native` installed by `init`

### DIFF
--- a/.changeset/fruity-shrimps-shave.md
+++ b/.changeset/fruity-shrimps-shave.md
@@ -1,0 +1,5 @@
+---
+"@callstack/repack-init": patch
+---
+
+Fix `@callstack/repack-init` installing unsupported versions of `react-native`

--- a/packages/init/src/tasks/createNewProject.ts
+++ b/packages/init/src/tasks/createNewProject.ts
@@ -1,5 +1,6 @@
 import path from 'node:path';
 import { execa } from 'execa';
+import versionsJson from '../../versions.json' with { type: 'json' };
 import type { PackageManager } from '../types/pm.js';
 import { RepackInitError } from '../utils/error.js';
 import spinner from '../utils/spinner.js';
@@ -17,6 +18,8 @@ export default async function createNewProject(
       projectName,
       '--directory',
       path.join(cwd, projectName),
+      '--version',
+      versionsJson['react-native'],
       '--skip-install',
       '--skip-git-init',
     ];

--- a/packages/init/versions.json
+++ b/packages/init/versions.json
@@ -1,5 +1,5 @@
 {
-  "react-native": "0.79.x",
+  "react-native": "0.79",
   "rspack": {
     "@rspack/core": "^1.3.4",
     "@swc/helpers": "^0.5.17"

--- a/packages/init/versions.json
+++ b/packages/init/versions.json
@@ -1,4 +1,5 @@
 {
+  "react-native": "0.79.x",
   "rspack": {
     "@rspack/core": "^1.3.4",
     "@swc/helpers": "^0.5.17"


### PR DESCRIPTION
### Summary

To prevent incompatibilities with cutting-edge versions of `react-native` and creating broken projects, `@callstack/repack-init` is now locked onto explicitly stated latest supported version of `react-native`.

### Test plan

- [x] - init installs latest supported version locally
