### PR TITLE
fix: android build after changes to FileSystemScriptLoader

### DIFF
--- a/.changeset/salty-rockets-kiss.md
+++ b/.changeset/salty-rockets-kiss.md
@@ -1,0 +1,5 @@
+---
+"@callstack/repack": patch
+---
+
+Fix type mismatch in FileSystemScriptLoader on Android

--- a/packages/repack/android/src/main/java/com/callstack/repack/FileSystemScriptLoader.kt
+++ b/packages/repack/android/src/main/java/com/callstack/repack/FileSystemScriptLoader.kt
@@ -7,9 +7,9 @@ import java.io.FileInputStream
 
 class FileSystemScriptLoader(private val reactContext: ReactContext, private val nativeLoader: NativeScriptLoader) {
     fun verifyBundle(code: ByteArray, config: ScriptConfig): ByteArray {
-        val (bundle, token) = code?.let {
+        val (bundle, token) = code.let {
             CodeSigningUtils.extractBundleAndToken(code)
-        } ?: Pair(null, null)
+        }
 
         if (config.verifyScriptSignature == "strict" || (config.verifyScriptSignature == "lax" && token != null)) {
             CodeSigningUtils.verifyBundle(reactContext, token, bundle)
@@ -31,7 +31,7 @@ class FileSystemScriptLoader(private val reactContext: ReactContext, private val
                 val inputStream = reactContext.assets.open(assetName)
                 code = inputStream.use { it.readBytes() }
             }
-            val bundle: ByteArray = verifyBundle(code, config)
+            val bundle = verifyBundle(code, config)
             nativeLoader.evaluate(bundle, config.sourceUrl, promise)
         } catch (error: Exception) {
             promise.reject(


### PR DESCRIPTION
### Summary

- [x] - fixes type mismatch on Android introduced by https://github.com/callstack/repack/pull/1186

### Test plan

- [x] - tester app compiles on Android
