### PR TITLE
feat: support 16kb page sizes on Android

### DIFF
--- a/.changeset/khaki-teams-enjoy.md
+++ b/.changeset/khaki-teams-enjoy.md
@@ -1,0 +1,5 @@
+---
+"@callstack/repack": minor
+---
+
+Support 16kb page alignment on Android

--- a/packages/repack/android/CMakeLists.txt
+++ b/packages/repack/android/CMakeLists.txt
@@ -55,3 +55,8 @@ target_link_libraries(
         fbjni::fbjni
         ReactAndroid::jsi
 )
+
+# Enable Android 16kb native library alignment
+if(CMAKE_ANDROID_NDK_VERSION VERSION_LESS "27")
+        target_link_options(${PACKAGE_NAME} PRIVATE "-Wl,-z,max-page-size=16384")
+endif()

--- a/packages/repack/android/build.gradle
+++ b/packages/repack/android/build.gradle
@@ -106,7 +106,8 @@ android {
             cmake {
                 cppFlags "-O2 -frtti -fexceptions -Wall -Wno-unused-variable -fstack-protector-all"
                 arguments "-DANDROID_STL=c++_shared",
-                        "-DREACT_NATIVE_DIR=${REACT_NATIVE_DIR}"
+                          "-DREACT_NATIVE_DIR=${REACT_NATIVE_DIR}",
+                          "-DANDROID_SUPPORT_FLEXIBLE_PAGE_SIZES=ON"
                 abiFilters(*reactNativeArchitectures())
             }
         }


### PR DESCRIPTION
### Summary

Closes #1191

Analyze apk result:
<img width="1301" alt="image" src="https://github.com/user-attachments/assets/caf9cbc7-f39f-460e-af2b-e6059c6e5541" />

### Test plan

- [x] - tester app launches without 4kb compat mode
- [x] - analyze APK in Android Studio reports 16kb alignment