### PR TITLE
fix: upgrade nimbus jose android dependency

### DIFF
--- a/.changeset/public-mugs-smile.md
+++ b/.changeset/public-mugs-smile.md
@@ -1,0 +1,5 @@
+---
+"@callstack/repack": patch
+---
+
+upgraded nimbus jose to latest v9

--- a/packages/repack/android/build.gradle
+++ b/packages/repack/android/build.gradle
@@ -196,5 +196,5 @@ dependencies {
     implementation 'com.facebook.react:react-android:+'
     implementation "com.squareup.okhttp3:okhttp:4.9.2"
     implementation "com.squareup.okhttp3:okhttp-urlconnection:4.9.2"
-    implementation 'com.nimbusds:nimbus-jose-jwt:9.31'
+    implementation 'com.nimbusds:nimbus-jose-jwt:9.48'
 }


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary
We did additional tests and it seems related to the old version of the jwt library.
This upgrade also fixes a vulnerability with all the versions of the library < 9.37.2 (see [here](https://mvnrepository.com/artifact/com.nimbusds/nimbus-jose-jwt?))
Closes #1198

### Test plan

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->

n/a
