### PR TITLE
chore: use node 20+ for development

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   verify:
-    name: Test - Node ${{ matrix.node_version }}
+    name: Verify [Node ${{ matrix.node_version }}]
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,6 +12,7 @@ on:
 
 jobs:
   verify:
+    name: Test - Node ${{ matrix.node_version }}
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        node_version: ['20', '22', '24']
+        node_version: ['18', '20', '22', '24']
         os: [ubuntu-latest]
 
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        node_version: ['18', '20', '22.6']
+        node_version: ['20', '22', '24']
         os: [ubuntu-latest]
 
     steps:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ We want this community to be friendly and respectful to each other. Please read 
 
 ## Requirements
 
-- Node 18+
+- Node 20+
 - pnpm 8 (use it via `corepack install`)
 
 ## Our Development Process

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ We want this community to be friendly and respectful to each other. Please read 
 
 ## Requirements
 
-- Node 20+
+- Node 20+ (although Node 18 is still supported but has now reached EOL)
 - pnpm 8 (use it via `corepack install`)
 
 ## Our Development Process

--- a/package.json
+++ b/package.json
@@ -1,6 +1,10 @@
 {
   "name": "repack",
   "private": true,
+  "packageManager": "pnpm@9.5.0",
+  "engines": {
+    "node": ">=20"
+  },
   "scripts": {
     "prepare": "is-in-ci || husky",
     "build": "nx run-many -t build",
@@ -31,7 +35,6 @@
     "nx": "19.7.3",
     "typescript": "catalog:"
   },
-  "packageManager": "pnpm@9.5.0",
   "pnpm": {
     "patchedDependencies": {
       "@rspress/plugin-llms@2.0.0-beta.3": "patches/@rspress__plugin-llms@2.0.0-beta.3.patch"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,8 +16,8 @@ catalogs:
       specifier: ~0.5.17
       version: 0.5.17
     '@types/node':
-      specifier: ^18
-      version: 18.19.41
+      specifier: ^20
+      version: 20.14.11
     react:
       specifier: 19.0.0
       version: 19.0.0
@@ -416,7 +416,7 @@ importers:
         version: 7.0.6
       '@types/node':
         specifier: 'catalog:'
-        version: 18.19.41
+        version: 20.14.11
       '@types/ws':
         specifier: ^8.18.0
         version: 8.18.0
@@ -444,7 +444,7 @@ importers:
         version: 0.6.3(typescript@5.8.3)
       '@types/node':
         specifier: 'catalog:'
-        version: 18.19.41
+        version: 20.14.11
       '@types/semver':
         specifier: ^7.5.8
         version: 7.5.8
@@ -489,7 +489,7 @@ importers:
         version: 1.4.2(@swc/helpers@0.5.17)
       '@types/node':
         specifier: 'catalog:'
-        version: 18.19.41
+        version: 20.14.11
 
   packages/plugin-nativewind:
     dependencies:
@@ -508,7 +508,7 @@ importers:
         version: 0.7.2
       '@types/node':
         specifier: 'catalog:'
-        version: 18.19.41
+        version: 20.14.11
       nativewind:
         specifier: ^4.1.23
         version: 4.1.23(react-native-reanimated@3.17.4(@babel/core@7.25.2)(react-native@0.79.1(@babel/core@7.25.2)(@react-native-community/cli@18.0.0(typescript@5.8.3))(@types/react@19.0.10)(react@19.1.0))(react@19.1.0))(react-native@0.79.1(@babel/core@7.25.2)(@react-native-community/cli@18.0.0(typescript@5.8.3))(@types/react@19.0.10)(react@19.1.0))(react@19.1.0)(tailwindcss@3.4.17)
@@ -529,7 +529,7 @@ importers:
         version: 7.20.5
       '@types/node':
         specifier: 'catalog:'
-        version: 18.19.41
+        version: 20.14.11
 
   packages/repack:
     dependencies:
@@ -644,7 +644,7 @@ importers:
         version: 2.1.4
       '@types/node':
         specifier: 'catalog:'
-        version: 18.19.41
+        version: 20.14.11
       '@types/react-dom':
         specifier: ^17.0.7
         version: 17.0.25
@@ -659,7 +659,7 @@ importers:
         version: 1.8.0
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(@types/node@18.19.41)
+        version: 29.7.0(@types/node@20.14.11)
       react:
         specifier: 'catalog:'
         version: 19.0.0
@@ -685,8 +685,8 @@ importers:
         specifier: ^29.5.12
         version: 29.5.14
       '@types/node':
-        specifier: ^18
-        version: 18.19.41
+        specifier: 'catalog:'
+        version: 20.14.11
       babel-jest:
         specifier: ^29.7.0
         version: 29.7.0(@babel/core@7.25.2)
@@ -701,7 +701,7 @@ importers:
         version: 5.18.1
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(@types/node@18.19.41)
+        version: 29.7.0(@types/node@20.14.11)
       memfs:
         specifier: ^4.11.1
         version: 4.17.0
@@ -716,7 +716,7 @@ importers:
         version: link:../../packages/repack
       '@types/node':
         specifier: 'catalog:'
-        version: 18.19.41
+        version: 20.14.11
       enhanced-resolve:
         specifier: ^5.18.1
         version: 5.18.1
@@ -728,7 +728,7 @@ importers:
         version: 5.8.3
       vitest:
         specifier: 'catalog:'
-        version: 2.0.5(@types/node@18.19.41)(lightningcss@1.28.2)(terser@5.31.3)
+        version: 2.0.5(@types/node@20.14.11)(lightningcss@1.28.2)(terser@5.31.3)
 
   website:
     dependencies:
@@ -755,8 +755,8 @@ importers:
         version: 0.3.0(react@19.1.0)(rspress@2.0.0-beta.3(@types/react@18.3.3)(acorn@8.14.0)(webpack@5.99.5))
     devDependencies:
       '@types/node':
-        specifier: ^18
-        version: 18.19.41
+        specifier: 'catalog:'
+        version: 20.14.11
       '@types/react':
         specifier: ^18.2.64
         version: 18.3.3
@@ -3384,9 +3384,6 @@ packages:
 
   '@types/node@12.20.55':
     resolution: {integrity: sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==}
-
-  '@types/node@18.19.41':
-    resolution: {integrity: sha512-LX84pRJ+evD2e2nrgYCHObGWkiQJ1mL+meAgbvnwk/US6vmMY7S2ygBTGV2Jw91s9vUsLSXeDEkUHZIJGLrhsg==}
 
   '@types/node@20.14.11':
     resolution: {integrity: sha512-kprQpL8MMeszbz6ojB5/tU8PLN4kesnN8Gjzw349rDlNgsSzg90lAVj3llK99Dh7JON+t9AuscPPFW6mPbTnSA==}
@@ -9580,7 +9577,7 @@ snapshots:
   '@jest/console@29.7.0':
     dependencies:
       '@jest/types': 29.6.3
-      '@types/node': 18.19.41
+      '@types/node': 20.14.11
       chalk: 4.1.2
       jest-message-util: 29.7.0
       jest-util: 29.7.0
@@ -9593,14 +9590,14 @@ snapshots:
       '@jest/test-result': 29.7.0
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 18.19.41
+      '@types/node': 20.14.11
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       ci-info: 3.9.0
       exit: 0.1.2
       graceful-fs: 4.2.11
       jest-changed-files: 29.7.0
-      jest-config: 29.7.0(@types/node@18.19.41)
+      jest-config: 29.7.0(@types/node@20.14.11)
       jest-haste-map: 29.7.0
       jest-message-util: 29.7.0
       jest-regex-util: 29.6.3
@@ -9629,7 +9626,7 @@ snapshots:
     dependencies:
       '@jest/fake-timers': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 18.19.41
+      '@types/node': 20.14.11
       jest-mock: 29.7.0
 
   '@jest/expect-utils@29.7.0':
@@ -9647,7 +9644,7 @@ snapshots:
     dependencies:
       '@jest/types': 29.6.3
       '@sinonjs/fake-timers': 10.3.0
-      '@types/node': 18.19.41
+      '@types/node': 20.14.11
       jest-message-util: 29.7.0
       jest-mock: 29.7.0
       jest-util: 29.7.0
@@ -9669,7 +9666,7 @@ snapshots:
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
       '@jridgewell/trace-mapping': 0.3.25
-      '@types/node': 18.19.41
+      '@types/node': 20.14.11
       chalk: 4.1.2
       collect-v8-coverage: 1.0.2
       exit: 0.1.2
@@ -9742,7 +9739,7 @@ snapshots:
     dependencies:
       '@types/istanbul-lib-coverage': 2.0.6
       '@types/istanbul-reports': 3.0.4
-      '@types/node': 18.19.41
+      '@types/node': 20.14.11
       '@types/yargs': 15.0.19
       chalk: 4.1.2
 
@@ -9751,7 +9748,7 @@ snapshots:
       '@jest/schemas': 29.6.3
       '@types/istanbul-lib-coverage': 2.0.6
       '@types/istanbul-reports': 3.0.4
-      '@types/node': 18.19.41
+      '@types/node': 20.14.11
       '@types/yargs': 17.0.33
       chalk: 4.1.2
 
@@ -11450,13 +11447,13 @@ snapshots:
 
   '@types/connect@3.4.38':
     dependencies:
-      '@types/node': 18.19.41
+      '@types/node': 20.14.11
 
   '@types/cookie@0.4.1': {}
 
   '@types/cors@2.8.17':
     dependencies:
-      '@types/node': 18.19.41
+      '@types/node': 20.14.11
 
   '@types/debug@4.1.12':
     dependencies:
@@ -11485,11 +11482,11 @@ snapshots:
   '@types/fs-extra@11.0.4':
     dependencies:
       '@types/jsonfile': 6.1.4
-      '@types/node': 18.19.41
+      '@types/node': 20.14.11
 
   '@types/graceful-fs@4.1.9':
     dependencies:
-      '@types/node': 18.19.41
+      '@types/node': 20.14.11
 
   '@types/gradient-string@1.1.6':
     dependencies:
@@ -11505,7 +11502,7 @@ snapshots:
 
   '@types/http-proxy@1.17.16':
     dependencies:
-      '@types/node': 18.19.41
+      '@types/node': 20.14.11
 
   '@types/istanbul-lib-coverage@2.0.6': {}
 
@@ -11526,11 +11523,11 @@ snapshots:
 
   '@types/jsonfile@6.1.4':
     dependencies:
-      '@types/node': 18.19.41
+      '@types/node': 20.14.11
 
   '@types/jsonwebtoken@9.0.6':
     dependencies:
-      '@types/node': 18.19.41
+      '@types/node': 20.14.11
 
   '@types/mdast@3.0.15':
     dependencies:
@@ -11548,13 +11545,9 @@ snapshots:
 
   '@types/node-forge@1.3.11':
     dependencies:
-      '@types/node': 18.19.41
+      '@types/node': 20.14.11
 
   '@types/node@12.20.55': {}
-
-  '@types/node@18.19.41':
-    dependencies:
-      undici-types: 5.26.5
 
   '@types/node@20.14.11':
     dependencies:
@@ -11605,7 +11598,7 @@ snapshots:
 
   '@types/ws@8.18.0':
     dependencies:
-      '@types/node': 18.19.41
+      '@types/node': 20.14.11
 
   '@types/yargs-parser@21.0.3': {}
 
@@ -12203,7 +12196,7 @@ snapshots:
 
   chrome-launcher@0.15.2:
     dependencies:
-      '@types/node': 18.19.41
+      '@types/node': 20.14.11
       escape-string-regexp: 4.0.0
       is-wsl: 2.2.0
       lighthouse-logger: 1.4.2
@@ -12214,7 +12207,7 @@ snapshots:
 
   chromium-edge-launcher@0.2.0:
     dependencies:
-      '@types/node': 18.19.41
+      '@types/node': 20.14.11
       escape-string-regexp: 4.0.0
       is-wsl: 2.2.0
       lighthouse-logger: 1.4.2
@@ -12417,13 +12410,13 @@ snapshots:
     optionalDependencies:
       typescript: 5.8.3
 
-  create-jest@29.7.0(@types/node@18.19.41):
+  create-jest@29.7.0(@types/node@20.14.11):
     dependencies:
       '@jest/types': 29.6.3
       chalk: 4.1.2
       exit: 0.1.2
       graceful-fs: 4.2.11
-      jest-config: 29.7.0(@types/node@18.19.41)
+      jest-config: 29.7.0(@types/node@20.14.11)
       jest-util: 29.7.0
       prompts: 2.4.2
     transitivePeerDependencies:
@@ -12655,7 +12648,7 @@ snapshots:
     dependencies:
       '@types/cookie': 0.4.1
       '@types/cors': 2.8.17
-      '@types/node': 18.19.41
+      '@types/node': 20.14.11
       accepts: 1.3.8
       base64id: 2.0.0
       cookie: 0.4.2
@@ -13765,7 +13758,7 @@ snapshots:
       '@jest/expect': 29.7.0
       '@jest/test-result': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 18.19.41
+      '@types/node': 20.14.11
       chalk: 4.1.2
       co: 4.6.0
       dedent: 1.5.3
@@ -13785,16 +13778,16 @@ snapshots:
       - babel-plugin-macros
       - supports-color
 
-  jest-cli@29.7.0(@types/node@18.19.41):
+  jest-cli@29.7.0(@types/node@20.14.11):
     dependencies:
       '@jest/core': 29.7.0
       '@jest/test-result': 29.7.0
       '@jest/types': 29.6.3
       chalk: 4.1.2
-      create-jest: 29.7.0(@types/node@18.19.41)
+      create-jest: 29.7.0(@types/node@20.14.11)
       exit: 0.1.2
       import-local: 3.1.0
-      jest-config: 29.7.0(@types/node@18.19.41)
+      jest-config: 29.7.0(@types/node@20.14.11)
       jest-util: 29.7.0
       jest-validate: 29.7.0
       yargs: 17.7.2
@@ -13804,7 +13797,7 @@ snapshots:
       - supports-color
       - ts-node
 
-  jest-config@29.7.0(@types/node@18.19.41):
+  jest-config@29.7.0(@types/node@20.14.11):
     dependencies:
       '@babel/core': 7.25.2
       '@jest/test-sequencer': 29.7.0
@@ -13829,7 +13822,7 @@ snapshots:
       slash: 3.0.0
       strip-json-comments: 3.1.1
     optionalDependencies:
-      '@types/node': 18.19.41
+      '@types/node': 20.14.11
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
@@ -13858,7 +13851,7 @@ snapshots:
       '@jest/environment': 29.7.0
       '@jest/fake-timers': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 18.19.41
+      '@types/node': 20.14.11
       jest-mock: 29.7.0
       jest-util: 29.7.0
 
@@ -13868,7 +13861,7 @@ snapshots:
     dependencies:
       '@jest/types': 29.6.3
       '@types/graceful-fs': 4.1.9
-      '@types/node': 18.19.41
+      '@types/node': 20.14.11
       anymatch: 3.1.3
       fb-watchman: 2.0.2
       graceful-fs: 4.2.11
@@ -13907,7 +13900,7 @@ snapshots:
   jest-mock@29.7.0:
     dependencies:
       '@jest/types': 29.6.3
-      '@types/node': 18.19.41
+      '@types/node': 20.14.11
       jest-util: 29.7.0
 
   jest-pnp-resolver@1.2.3(jest-resolve@29.7.0):
@@ -13942,7 +13935,7 @@ snapshots:
       '@jest/test-result': 29.7.0
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 18.19.41
+      '@types/node': 20.14.11
       chalk: 4.1.2
       emittery: 0.13.1
       graceful-fs: 4.2.11
@@ -13970,7 +13963,7 @@ snapshots:
       '@jest/test-result': 29.7.0
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 18.19.41
+      '@types/node': 20.14.11
       chalk: 4.1.2
       cjs-module-lexer: 1.3.1
       collect-v8-coverage: 1.0.2
@@ -14016,7 +14009,7 @@ snapshots:
   jest-util@29.7.0:
     dependencies:
       '@jest/types': 29.6.3
-      '@types/node': 18.19.41
+      '@types/node': 20.14.11
       chalk: 4.1.2
       ci-info: 3.9.0
       graceful-fs: 4.2.11
@@ -14035,7 +14028,7 @@ snapshots:
     dependencies:
       '@jest/test-result': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 18.19.41
+      '@types/node': 20.14.11
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       emittery: 0.13.1
@@ -14044,23 +14037,23 @@ snapshots:
 
   jest-worker@27.5.1:
     dependencies:
-      '@types/node': 18.19.41
+      '@types/node': 20.14.11
       merge-stream: 2.0.0
       supports-color: 8.1.1
 
   jest-worker@29.7.0:
     dependencies:
-      '@types/node': 18.19.41
+      '@types/node': 20.14.11
       jest-util: 29.7.0
       merge-stream: 2.0.0
       supports-color: 8.1.1
 
-  jest@29.7.0(@types/node@18.19.41):
+  jest@29.7.0(@types/node@20.14.11):
     dependencies:
       '@jest/core': 29.7.0
       '@jest/types': 29.6.3
       import-local: 3.1.0
-      jest-cli: 29.7.0(@types/node@18.19.41)
+      jest-cli: 29.7.0(@types/node@20.14.11)
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros
@@ -17190,24 +17183,6 @@ snapshots:
       unist-util-stringify-position: 4.0.0
       vfile-message: 4.0.2
 
-  vite-node@2.0.5(@types/node@18.19.41)(lightningcss@1.28.2)(terser@5.31.3):
-    dependencies:
-      cac: 6.7.14
-      debug: 4.4.0
-      pathe: 1.1.2
-      tinyrainbow: 1.2.0
-      vite: 5.4.3(@types/node@18.19.41)(lightningcss@1.28.2)(terser@5.31.3)
-    transitivePeerDependencies:
-      - '@types/node'
-      - less
-      - lightningcss
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-
   vite-node@2.0.5(@types/node@20.14.11)(lightningcss@1.28.2)(terser@5.31.3):
     dependencies:
       cac: 6.7.14
@@ -17226,17 +17201,6 @@ snapshots:
       - supports-color
       - terser
 
-  vite@5.4.3(@types/node@18.19.41)(lightningcss@1.28.2)(terser@5.31.3):
-    dependencies:
-      esbuild: 0.21.5
-      postcss: 8.5.1
-      rollup: 4.21.2
-    optionalDependencies:
-      '@types/node': 18.19.41
-      fsevents: 2.3.3
-      lightningcss: 1.28.2
-      terser: 5.31.3
-
   vite@5.4.3(@types/node@20.14.11)(lightningcss@1.28.2)(terser@5.31.3):
     dependencies:
       esbuild: 0.21.5
@@ -17247,39 +17211,6 @@ snapshots:
       fsevents: 2.3.3
       lightningcss: 1.28.2
       terser: 5.31.3
-
-  vitest@2.0.5(@types/node@18.19.41)(lightningcss@1.28.2)(terser@5.31.3):
-    dependencies:
-      '@ampproject/remapping': 2.3.0
-      '@vitest/expect': 2.0.5
-      '@vitest/pretty-format': 2.0.5
-      '@vitest/runner': 2.0.5
-      '@vitest/snapshot': 2.0.5
-      '@vitest/spy': 2.0.5
-      '@vitest/utils': 2.0.5
-      chai: 5.1.1
-      debug: 4.4.0
-      execa: 8.0.1
-      magic-string: 0.30.17
-      pathe: 1.1.2
-      std-env: 3.7.0
-      tinybench: 2.9.0
-      tinypool: 1.0.1
-      tinyrainbow: 1.2.0
-      vite: 5.4.3(@types/node@18.19.41)(lightningcss@1.28.2)(terser@5.31.3)
-      vite-node: 2.0.5(@types/node@18.19.41)(lightningcss@1.28.2)(terser@5.31.3)
-      why-is-node-running: 2.3.0
-    optionalDependencies:
-      '@types/node': 18.19.41
-    transitivePeerDependencies:
-      - less
-      - lightningcss
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
 
   vitest@2.0.5(@types/node@20.14.11)(lightningcss@1.28.2)(terser@5.31.3):
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -8,7 +8,7 @@ catalog:
   "@rspack/core": ^1.4.2
   "@rslib/core": ^0.6.3
   "@swc/helpers": ~0.5.17
-  "@types/node": ^18
+  "@types/node": ^20
   "terser-webpack-plugin": ^5.3.14
   "typescript": ^5.8.3
   "webpack": ^5.99.5

--- a/tests/metro-compat/package.json
+++ b/tests/metro-compat/package.json
@@ -17,7 +17,7 @@
   "devDependencies": {
     "@callstack/repack": "workspace:*",
     "@types/jest": "^29.5.12",
-    "@types/node": "^18",
+    "@types/node": "catalog:",
     "babel-jest": "^29.7.0",
     "babel-plugin-module-resolver": "^5.0.0",
     "babel-plugin-syntax-hermes-parser": "^0.20.1",

--- a/tests/metro-compat/package.json
+++ b/tests/metro-compat/package.json
@@ -7,7 +7,7 @@
   "private": true,
   "engineStrict": true,
   "engines": {
-    "node": ">=18"
+    "node": ">=20"
   },
   "scripts": {
     "test": "jest --noStackTrace",

--- a/website/package.json
+++ b/website/package.json
@@ -2,6 +2,9 @@
   "name": "website",
   "version": "0.0.1",
   "private": true,
+  "engines": {
+    "node": ">=20"
+  },
   "scripts": {
     "start": "rspress dev",
     "export": "rspress build",
@@ -22,8 +25,5 @@
     "@types/node": "catalog:",
     "@types/react": "^18.2.64",
     "typescript": "catalog:"
-  },
-  "engines": {
-    "node": ">=22"
   }
 }

--- a/website/package.json
+++ b/website/package.json
@@ -19,7 +19,7 @@
     "rspress-plugin-vercel-analytics": "^0.3.0"
   },
   "devDependencies": {
-    "@types/node": "^18",
+    "@types/node": "catalog:",
     "@types/react": "^18.2.64",
     "typescript": "catalog:"
   },


### PR DESCRIPTION
### Summary

This PR bumps Node 18 to Node 20 in the repo but does not influence the actual published packages since that would be a breaking change.

- [x] - move from node 18 to node 20 where applicable
- [x] - add Node 24 to test action 
- [x] - align `engines` field in internal packages

### Test plan

- [x] - CI jobs pass
