### PR TITLE
fix: add `react-native-modal-datetime-picker` to flow libs

### DIFF
--- a/.changeset/late-dragons-fail.md
+++ b/.changeset/late-dragons-fail.md
@@ -1,0 +1,5 @@
+---
+"@callstack/repack": patch
+---
+
+Add `react-native-modal-datetime-picker` to list of libs with flow types

--- a/packages/repack/src/utils/getFlowTransformRules.ts
+++ b/packages/repack/src/utils/getFlowTransformRules.ts
@@ -22,6 +22,7 @@ const FLOW_TYPED_MODULES = [
   'react-native-view-shot',
   '@react-native-community/push-notification-ios',
   'react-native-keyboard-aware-scroll-view',
+  'react-native-modal-datetime-picker',
 ];
 
 /**


### PR DESCRIPTION
### Summary

Add `react-native-modal-datetime-picker` to list of libs with flow types

### Test plan

n/a
