### PR TITLE
fix: add missing SWC rules

### DIFF
--- a/.changeset/bumpy-bags-beam.md
+++ b/.changeset/bumpy-bags-beam.md
@@ -1,0 +1,5 @@
+---
+"@callstack/repack": patch
+---
+
+Add `transform-parameters` and `transform-function-name` to the SWC preset

--- a/packages/repack/src/utils/getSwcLoaderOptions.ts
+++ b/packages/repack/src/utils/getSwcLoaderOptions.ts
@@ -19,6 +19,11 @@ function getEnvironmentPreset() {
       'transform-spread',
       'transform-object-rest-spread',
       'transform-class-static-block',
+      // class transform injects 'use strict' at all times, enabled to prevent parser errors with non-simple params like rest params
+      // reference: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Errors/Strict_non_simple_params
+      'transform-parameters',
+      // compat mostly for symbol-keyed methods
+      'transform-function-name',
     ],
   };
 }


### PR DESCRIPTION
### Summary

- [x] - add `transform-parameters` - needed when transforming classes where methods have default or rest args - prevents ["use strict" not allowed Hermes parsing error](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Errors/Strict_non_simple_params)
- [x] - add `transform-function-name` - compat for older Hermes versions

### Test plan

- [x] - testers work
