### PR TITLE
feat: support React Native 0.80 in DevTools

### DIFF
--- a/.changeset/gentle-pandas-pull.md
+++ b/.changeset/gentle-pandas-pull.md
@@ -1,0 +1,6 @@
+---
+"@callstack/repack-dev-server": minor
+"@callstack/repack": minor
+---
+
+Support RN 80 in React Native DevTools integration

--- a/packages/dev-server/package.json
+++ b/packages/dev-server/package.json
@@ -31,7 +31,7 @@
     "@babel/code-frame": "^7.26.2",
     "@fastify/middie": "^8.3.0",
     "@fastify/sensible": "^5.5.0",
-    "@react-native/dev-middleware": "^0.78.0",
+    "@react-native/dev-middleware": "^0.80.0",
     "fastify": "^4.24.3",
     "fastify-favicon": "^4.3.0",
     "fastify-plugin": "^4.5.1",

--- a/packages/dev-server/src/createServer.ts
+++ b/packages/dev-server/src/createServer.ts
@@ -1,4 +1,5 @@
 import { Writable } from 'node:stream';
+import util from 'node:util';
 import middie from '@fastify/middie';
 import fastifySensible from '@fastify/sensible';
 import { createDevMiddleware } from '@react-native/dev-middleware';
@@ -72,17 +73,28 @@ export async function createServer(config: Server.Config) {
     projectRoot: options.rootDir,
     serverBaseUrl: options.url,
     logger: {
-      error: instance.log.error,
-      warn: instance.log.warn,
-      info: (...message) => {
-        if (!handledDevMiddlewareNotice) {
-          if (message.join().includes('JavaScript logs have moved!')) {
-            handledDevMiddlewareNotice = true;
+      error: (...msg) => {
+        const message = util.format(...msg);
+        instance.log.error(message);
+      },
+      warn: (...msg) => {
+        const message = util.format(...msg);
+        instance.log.warn(message);
+      },
+      info: (...msg) => {
+        const message = util.format(...msg);
+        try {
+          if (!handledDevMiddlewareNotice) {
+            if (message.includes('JavaScript logs have moved!')) {
+              handledDevMiddlewareNotice = true;
+              return;
+            }
+          } else {
+            instance.log.debug(message);
             return;
           }
-        } else {
-          instance.log.debug(message);
-          return;
+        } catch (e) {
+          console.log(e);
         }
       },
     },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -402,8 +402,8 @@ importers:
         specifier: ^5.5.0
         version: 5.6.0
       '@react-native/dev-middleware':
-        specifier: ^0.78.0
-        version: 0.78.0
+        specifier: ^0.80.0
+        version: 0.80.0
       fastify:
         specifier: ^4.24.3
         version: 4.28.1
@@ -2550,16 +2550,8 @@ packages:
       '@react-native-community/cli':
         optional: true
 
-  '@react-native/debugger-frontend@0.78.0':
-    resolution: {integrity: sha512-KQYD9QlxES/VdmXh9EEvtZCJK1KAemLlszQq4dpLU1stnue5N8dnCY6A7PpStMf5UtAMk7tiniQhaicw0uVHgQ==}
-    engines: {node: '>=18'}
-
   '@react-native/debugger-frontend@0.80.0':
     resolution: {integrity: sha512-lpu9Z3xtKUaKFvEcm5HSgo1KGfkDa/W3oZHn22Zy0WQ9MiOu2/ar1txgd1wjkoNiK/NethKcRdCN7mqnc6y2mA==}
-    engines: {node: '>=18'}
-
-  '@react-native/dev-middleware@0.78.0':
-    resolution: {integrity: sha512-zEafAZdOz4s37Jh5Xcv4hJE5qZ6uNxgrTLcpjDOJnQG6dO34/BoZeXvDrjomQFNn6ogdysR51mKJStaQ3ixp5A==}
     engines: {node: '>=18'}
 
   '@react-native/dev-middleware@0.80.0':
@@ -3337,9 +3329,6 @@ packages:
 
   '@types/ms@0.7.34':
     resolution: {integrity: sha512-nG96G3Wp6acyAgJqGasjODb+acrI7KltPiRxzHPXnP3NgI28bpQDRv53olbqGXbfcgF5aiiHmO3xpwEpS5Ld9g==}
-
-  '@types/node-forge@1.3.11':
-    resolution: {integrity: sha512-FQx220y22OKNTqaByeBGqHWYz4cl94tpcxeFdvBo3wjG6XPBuZ0BNgNZRV5J5TFmmcsJ4IzsLkmGRiQbnYsBEQ==}
 
   '@types/node@12.20.55':
     resolution: {integrity: sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==}
@@ -6306,10 +6295,6 @@ packages:
       encoding:
         optional: true
 
-  node-forge@1.3.1:
-    resolution: {integrity: sha512-dPEtOeMvF9VMcYV/1Wb8CPoVAXtp6MKMlcbAt4ddqmGqUJ6fQZFXkNZNkNlfevtNkGtaSoXf/vNNNSvgrdXwtA==}
-    engines: {node: '>= 6.13.0'}
-
   node-int64@0.4.0:
     resolution: {integrity: sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==}
 
@@ -7200,10 +7185,6 @@ packages:
 
   selderee@0.11.0:
     resolution: {integrity: sha512-5TF+l7p4+OsnP8BCCvSyZiSPc4x4//p5uPwK8TCnVPJYRmU2aYKMpOXvw8zM5a5JvuuCGN1jmsMwuU2W02ukfA==}
-
-  selfsigned@2.4.1:
-    resolution: {integrity: sha512-th5B4L2U+eGLq1TVh7zNRGBapioSORUeymIydxgFpwww9d2qyKvtuPU2jJuHvYAwwqi2Y596QBL3eEqcPEYL8Q==}
-    engines: {node: '>=10'}
 
   semver@5.7.2:
     resolution: {integrity: sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==}
@@ -10493,28 +10474,7 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@react-native/debugger-frontend@0.78.0': {}
-
   '@react-native/debugger-frontend@0.80.0': {}
-
-  '@react-native/dev-middleware@0.78.0':
-    dependencies:
-      '@isaacs/ttlcache': 1.4.1
-      '@react-native/debugger-frontend': 0.78.0
-      chrome-launcher: 0.15.2
-      chromium-edge-launcher: 0.2.0
-      connect: 3.7.0
-      debug: 2.6.9
-      invariant: 2.2.4
-      nullthrows: 1.1.1
-      open: 7.4.2
-      selfsigned: 2.4.1
-      serve-static: 1.16.2
-      ws: 6.2.3
-    transitivePeerDependencies:
-      - bufferutil
-      - supports-color
-      - utf-8-validate
 
   '@react-native/dev-middleware@0.80.0':
     dependencies:
@@ -11431,10 +11391,6 @@ snapshots:
   '@types/mime-types@2.1.4': {}
 
   '@types/ms@0.7.34': {}
-
-  '@types/node-forge@1.3.11':
-    dependencies:
-      '@types/node': 20.14.11
 
   '@types/node@12.20.55': {}
 
@@ -15218,8 +15174,6 @@ snapshots:
     dependencies:
       whatwg-url: 5.0.0
 
-  node-forge@1.3.1: {}
-
   node-int64@0.4.0: {}
 
   node-machine-id@1.1.12: {}
@@ -16301,11 +16255,6 @@ snapshots:
   selderee@0.11.0:
     dependencies:
       parseley: 0.12.1
-
-  selfsigned@2.4.1:
-    dependencies:
-      '@types/node-forge': 1.3.11
-      node-forge: 1.3.1
 
   semver@5.7.2: {}
 


### PR DESCRIPTION
### Summary

Upgrade React Native DevTools integration to support RN 0.80 and fix logger compatibility - the logs are now formatted with `util.format` from Node

- [x] Bump `@react-native/dev-middleware` to version `^0.80`
- [x] Refactor logger implementation to handle message formatting requirements

### Test plan

- [x] - testers work
