### PR TITLE
feat: support custom middleware through `setupMiddlewares`

### DIFF
--- a/.changeset/twenty-pets-wear.md
+++ b/.changeset/twenty-pets-wear.md
@@ -1,0 +1,6 @@
+---
+"@callstack/repack-dev-server": minor
+"@callstack/repack": minor
+---
+
+Add support for adding custom middlewares to the DevServer through `setupMiddlewares` configuration option

--- a/packages/dev-server/src/createServer.ts
+++ b/packages/dev-server/src/createServer.ts
@@ -177,10 +177,14 @@ export async function createServer(config: Server.Config) {
     instance
   );
 
-  // Register any additional custom middlewares returned by the function
+  // Register middlewares
   finalMiddlewares.forEach((middleware) => {
     if (typeof middleware === 'object') {
-      instance.use(middleware.middleware);
+      if (middleware.path !== undefined) {
+        instance.use(middleware.path, middleware.middleware);
+      } else {
+        instance.use(middleware.middleware);
+      }
     } else {
       instance.use(middleware);
     }

--- a/packages/dev-server/src/utils/normalizeOptions.ts
+++ b/packages/dev-server/src/utils/normalizeOptions.ts
@@ -1,7 +1,12 @@
 import type { ServerOptions as HttpsServerOptions } from 'node:https';
 import type * as DevMiddleware from '@react-native/dev-middleware';
 import type { Options as ProxyOptions } from 'http-proxy-middleware';
-import type { DevServerOptions, Server } from '../types.js';
+import type {
+  DevServerOptions,
+  Middleware,
+  Server,
+  SetupMiddlewaresFunction,
+} from '../types.js';
 
 function normalizeHttpsOptions(serverOptions: DevServerOptions['server']) {
   if (
@@ -43,6 +48,7 @@ export interface NormalizedOptions {
   disableRequestLogging: boolean;
   devMiddleware: typeof DevMiddleware;
   rootDir: string;
+  setupMiddlewares: SetupMiddlewaresFunction;
 }
 
 export function normalizeOptions(options: Server.Options): NormalizedOptions {
@@ -55,6 +61,10 @@ export function normalizeOptions(options: Server.Options): NormalizedOptions {
   const url = `${protocol}://${host}:${options.port}`;
 
   const proxy = normalizeProxyOptions(options.proxy, url);
+
+  // passthrough
+  const setupMiddlewares =
+    options.setupMiddlewares ?? ((middlewares: Middleware[]) => middlewares);
 
   return {
     // webpack dev server compatible options
@@ -70,5 +80,7 @@ export function normalizeOptions(options: Server.Options): NormalizedOptions {
     disableRequestLogging: !options.logRequests,
     // project options
     rootDir: options.rootDir,
+    // custom middleware setup
+    setupMiddlewares,
   };
 }

--- a/packages/dev-server/src/utils/normalizeOptions.ts
+++ b/packages/dev-server/src/utils/normalizeOptions.ts
@@ -38,6 +38,13 @@ function normalizeProxyOptions(
   return undefined;
 }
 
+function normalizeSetupMiddlewares(
+  setupMiddlewares?: DevServerOptions['setupMiddlewares']
+) {
+  // create a passthrough function if no setupMiddlewares is provided
+  return setupMiddlewares ?? ((middlewares: Middleware[]) => middlewares);
+}
+
 export interface NormalizedOptions {
   host: string;
   port: number;
@@ -61,10 +68,7 @@ export function normalizeOptions(options: Server.Options): NormalizedOptions {
   const url = `${protocol}://${host}:${options.port}`;
 
   const proxy = normalizeProxyOptions(options.proxy, url);
-
-  // passthrough
-  const setupMiddlewares =
-    options.setupMiddlewares ?? ((middlewares: Middleware[]) => middlewares);
+  const setupMiddlewares = normalizeSetupMiddlewares(options.setupMiddlewares);
 
   return {
     // webpack dev server compatible options


### PR DESCRIPTION
### Summary

  This PR introduces a new `devServer.setupMiddlewares` configuration option that allows developers to customize the middleware stack in the DevServer.

  - [x] - New `setupMiddlewares` function option that receives built-in middlewares list and the Fastify server instance and returns adjusted list of middlewares
  - [x] - Built-in middlewares (`@react-native/dev-middleware` & proxy middlewares) are now exposed as named middleware objects
  - [x] - Developers can reorder, modify, or add custom middlewares to the DevServer pipeline

### Usage
#### Basic Setup

```javascript
// rspack.config.mjs
export default {
  // ...
  devServer: {
    setupMiddlewares: (middlewares, devServer) => {
      // Your middleware setup code here
      return middlewares;
    },
  },
};
```

#### Example 1: Direct Route with devServer

Add routes directly to the Fastify instance:

```javascript
// rspack.config.mjs
export default {
  devServer: {
    setupMiddlewares: (middlewares, devServer) => {
      devServer.get('/setup-middleware/some/path', (_, response) => {
        response.send('setup-middlewares option GET');
      });

      return middlewares;
    },
  },
};
```

#### Example 2: High Priority Middleware (First in Chain)

Use `unshift()` to run middleware before all other middlewares:

```javascript
// rspack.config.mjs
export default {
  devServer: {
    setupMiddlewares: (middlewares, devServer) => {
      middlewares.unshift({
        name: 'first-in-array',
        path: '/foo/path', // path is optional
        middleware: (req, res) => {
          res.send('Foo!');
        },
      });

      return middlewares;
    },
  },
};
```

#### Example 3: Low Priority Middleware (Last in Chain)

Use `push()` to run middleware after all other middlewares:

```javascript
// rspack.config.mjs
export default {
  devServer: {
    setupMiddlewares: (middlewares, devServer) => {
      middlewares.push({
        name: 'hello-world-test-one',
        path: '/foo/bar', // path is optional
        middleware: (req, res) => {
          res.send('Foo Bar!');
        },
      });

      return middlewares;
    },
  },
};
```

#### Example 4: Simple Function Middleware

Pass middleware function directly without wrapper object:

```javascript
// rspack.config.mjs
export default {
  devServer: {
    setupMiddlewares: (middlewares, devServer) => {
      middlewares.push((req, res) => {
        res.send('Hello World!');
      });

      return middlewares;
    },
  },
};
```

#### Example 5: Custom Route with Logging

Access the Fastify instance for routes and logging:

```javascript
// rspack.config.mjs
export default {
  devServer: {
    setupMiddlewares: (middlewares, devServer) => {
      devServer.get('/test', (_, response) => {
        response.send('GET test response');
        devServer.log.info('GET /test called');
      });

      return middlewares;
    },
  },
};
```

### Test plan

- [x] - existing middlewares work
- [x] - testers with custom middleware work
