### PR TITLE
fix plugin-nativewind: accumulate compiled nativewind styles 

### DIFF
--- a/packages/plugin-nativewind/src/loader.ts
+++ b/packages/plugin-nativewind/src/loader.ts
@@ -23,6 +23,17 @@ export default function nativeWindLoader(
     const jsCss = cssToReactNativeRuntime(source, options);
     const code = dedent`
       import { StyleSheet } from "nativewind";
+      
+      const originalRegisterCompiled = StyleSheet.registerCompiled;
+      let rules = {}
+      
+      // Monkey patch StyleSheet.registerCompiled to merge rules across multiple MFE
+      StyleSheet.registerCompiled = (compiledStyles) => {
+        rules = Object.assign(compiledStyles.rules, rules);
+        compiledStyles.rules = rules;
+        return originalRegisterCompiled(compiledStyles)
+      }
+      
       StyleSheet.registerCompiled((${stringify(jsCss)}));
     `;
     callback(null, code);


### PR DESCRIPTION
Solves having multiple MFE sharing rules generated by nativewind

### Summary

Solves: https://github.com/callstack/repack/discussions/1032 

### Test plan

1. Have 1. MFE - declare nativewind and tailwind there
2. Have 2. MFE - declare a separate nativewind configuration or use different utility classes not used in 1st 
3. Connect 1 and 2 to Host app. Previously, one MFE override the other due to registerCompile calling anew. Now they are reusing previous state  
