### PR TITLE
fix: Add file protocol support for script loading in ScriptManager

### DIFF
--- a/packages/repack/android/src/main/java/com/callstack/repack/ScriptManagerModule.kt
+++ b/packages/repack/android/src/main/java/com/callstack/repack/ScriptManagerModule.kt
@@ -65,6 +65,10 @@ class ScriptManagerModule(reactContext: ReactApplicationContext) : ScriptManager
                     remoteLoader.prefetch(config, promise)
                 }
 
+                config.url.protocol == "file" -> {
+                    fileSystemLoader.prefetch(config, promise)
+                }
+
                 else -> {
                     promise.reject(
                             ScriptLoadingError.UnsupportedScheme.code,

--- a/packages/repack/ios/ScriptManager.mm
+++ b/packages/repack/ios/ScriptManager.mm
@@ -114,7 +114,10 @@ RCT_EXPORT_METHOD(prefetchScript
                  resolve(nil);
                }
              }];
-      } else {
+      } else if ([[config.url scheme] isEqualToString:@"file"]) {
+        [self executeFromFilesystem:config resolve:resolve reject:reject];
+      }
+      else {
         reject(
             UnsupportedScheme,
             [NSString stringWithFormat:@"Scheme in URL '%@' is not supported", config.url.absoluteString],


### PR DESCRIPTION
### Summary

This pull request adds support for the file protocol in the ScriptManager module for both Android (ScriptManagerModule.kt) and iOS (ScriptManager.mm). The change enables loading scripts directly from the local filesystem, addressing scenarios where scripts are stored locally rather than fetched remotely via HTTP/HTTPS. 

This enhances the flexibility of the script loading mechanism in Re.pack.The changes include:

On Android: Added a condition in ScriptManagerModule.kt to handle file protocol URLs by delegating to fileSystemLoader.load.
On iOS: Added a condition in ScriptManager.mm to handle file protocol URLs by calling executeFromFilesystem.

resolve https://github.com/callstack/repack/issues/1148
### Test plan
build a bundle mini app then load it locally