### PR TITLE
fix: async config return type

### DIFF
--- a/packages/repack/src/utils/defineConfig.ts
+++ b/packages/repack/src/utils/defineConfig.ts
@@ -11,7 +11,7 @@ export type RepackRspackConfigFn = (env: EnvOptions) => RepackRspackConfig;
 
 export type RepackRspackConfigAsyncFn = (
   env: EnvOptions
-) => Promise<RspackConfiguration>;
+) => Promise<RepackRspackConfig>;
 
 export type RepackRspackConfigExport =
   | RepackRspackConfig


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->
This pull request updates the return type of the async config function for RsPack. Currently, it is declared as RspackConfiguration, but it should be RepackRspackConfig to align with the other elements in the config type union.

### Test plan

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
Use an async function to configure the test app. Note that it currently doesn't accept the correct configuration. Check out this branch to see the difference.