### PR TITLE
fix: `REPACK_VERBOSE` env not affecting dev server logs

### DIFF
--- a/.changeset/little-turkeys-go.md
+++ b/.changeset/little-turkeys-go.md
@@ -1,0 +1,5 @@
+---
+"@callstack/repack": patch
+---
+
+Fix `REPACK_VERBOSE` not affecting dev server logs

--- a/packages/repack/src/commands/rspack/start.ts
+++ b/packages/repack/src/commands/rspack/start.ts
@@ -1,6 +1,7 @@
 import type { Configuration } from '@rspack/core';
 import packageJson from '../../../package.json';
-import { CLIError } from '../../helpers/index.js';
+import { VERBOSE_ENV_KEY } from '../../env.js';
+import { CLIError, isTruthyEnv } from '../../helpers/index.js';
 import {
   ConsoleReporter,
   FileReporter,
@@ -57,15 +58,16 @@ export async function start(
   // expose selected args as environment variables
   setupEnvironment(args);
 
+  const isVerbose = isTruthyEnv(process.env[VERBOSE_ENV_KEY]);
   const devServerOptions = configs[0].devServer ?? {};
-  const showHttpRequests = args.verbose || args.logRequests;
+  const showHttpRequests = isVerbose || args.logRequests;
 
   // dynamically import dev middleware to match version of react-native
   const devMiddleware = await getDevMiddleware(cliConfig.reactNativePath);
 
   const reporter = composeReporters(
     [
-      new ConsoleReporter({ asJson: args.json, isVerbose: args.verbose }),
+      new ConsoleReporter({ asJson: args.json, isVerbose: isVerbose }),
       args.logFile ? new FileReporter({ filename: args.logFile }) : undefined,
     ].filter(Boolean) as Reporter[]
   );

--- a/packages/repack/src/commands/webpack/start.ts
+++ b/packages/repack/src/commands/webpack/start.ts
@@ -1,7 +1,8 @@
 import type { Server } from '@callstack/repack-dev-server';
 import type { Configuration, StatsCompilation } from 'webpack';
 import packageJson from '../../../package.json';
-import { CLIError } from '../../helpers/index.js';
+import { VERBOSE_ENV_KEY } from '../../env.js';
+import { CLIError, isTruthyEnv } from '../../helpers/index.js';
 import {
   ConsoleReporter,
   FileReporter,
@@ -59,15 +60,16 @@ export async function start(
   // expose selected args as environment variables
   setupEnvironment(args);
 
+  const isVerbose = isTruthyEnv(process.env[VERBOSE_ENV_KEY]);
   const devServerOptions = configs[0].devServer ?? {};
-  const showHttpRequests = args.verbose || args.logRequests;
+  const showHttpRequests = isVerbose || args.logRequests;
 
   // dynamically import dev middleware to match version of react-native
   const devMiddleware = await getDevMiddleware(cliConfig.reactNativePath);
 
   const reporter = composeReporters(
     [
-      new ConsoleReporter({ asJson: args.json, isVerbose: args.verbose }),
+      new ConsoleReporter({ asJson: args.json, isVerbose: isVerbose }),
       args.logFile ? new FileReporter({ filename: args.logFile }) : undefined,
     ].filter(Boolean) as Reporter[]
   );


### PR DESCRIPTION
### Summary

- [x] - fixes an issue where dev server logs would be unaffected by `REPACK_VERBOSE` flag

### Test plan

n/a
