### PR TITLE
feat: declare support for RN 0.81

### DIFF
--- a/.changeset/thin-turkeys-bathe.md
+++ b/.changeset/thin-turkeys-bathe.md
@@ -3,4 +3,4 @@
 "@callstack/repack": minor
 ---
 
-Declare support for React Native 0.80
+Declare support for React Native 0.81

--- a/packages/init/versions.json
+++ b/packages/init/versions.json
@@ -1,5 +1,5 @@
 {
-  "react-native": "0.80",
+  "react-native": "0.81",
   "rspack": {
     "@rspack/core": "^1.3.4",
     "@swc/helpers": "^0.5.17"


### PR DESCRIPTION
### Summary

- [x] - allow installing React Native 0.81 through `@callstack/repack-init`

### Test plan

n/a
