### PR TITLE
feat: enable parallel loader by default

### DIFF
--- a/.changeset/twelve-rats-draw.md
+++ b/.changeset/twelve-rats-draw.md
@@ -1,0 +1,5 @@
+---
+"@callstack/repack": minor
+---
+
+Enable `experiments.parallelLoader` by default for Rspack configurations

--- a/apps/tester-app/rspack.config.mjs
+++ b/apps/tester-app/rspack.config.mjs
@@ -20,9 +20,6 @@ export default Repack.defineRspackConfig((env) => {
     mode,
     context,
     entry: './index.js',
-    experiments: {
-      parallelLoader: true,
-    },
     resolve: {
       ...Repack.getResolveOptions({ enablePackageExports: true }),
     },

--- a/apps/tester-federation-v2/configs/rspack.host-app.mts
+++ b/apps/tester-federation-v2/configs/rspack.host-app.mts
@@ -9,9 +9,6 @@ export default Repack.defineRspackConfig((env) => {
     mode,
     context,
     entry: './src/host/index.js',
-    experiments: {
-      parallelLoader: true,
-    },
     resolve: {
       ...Repack.getResolveOptions({ enablePackageExports: true }),
     },

--- a/apps/tester-federation-v2/configs/rspack.mini-app.mts
+++ b/apps/tester-federation-v2/configs/rspack.mini-app.mts
@@ -9,9 +9,6 @@ export default Repack.defineRspackConfig((env) => {
     mode,
     context,
     entry: './src/mini/index.js',
-    experiments: {
-      parallelLoader: true,
-    },
     resolve: {
       ...Repack.getResolveOptions({ enablePackageExports: true }),
     },

--- a/apps/tester-federation/configs/rspack.host-app.mts
+++ b/apps/tester-federation/configs/rspack.host-app.mts
@@ -10,9 +10,6 @@ export default Repack.defineRspackConfig((env) => {
     mode,
     context,
     entry: './src/host/index.js',
-    experiments: {
-      parallelLoader: true,
-    },
     resolve: {
       ...Repack.getResolveOptions({ enablePackageExports: true }),
     },

--- a/apps/tester-federation/configs/rspack.mini-app.mts
+++ b/apps/tester-federation/configs/rspack.mini-app.mts
@@ -10,9 +10,6 @@ export default Repack.defineRspackConfig((env) => {
     mode,
     context,
     entry: './src/mini/index.js',
-    experiments: {
-      parallelLoader: true,
-    },
     resolve: {
       ...Repack.getResolveOptions({ enablePackageExports: true }),
     },

--- a/packages/repack/src/commands/common/config/getRepackConfig.ts
+++ b/packages/repack/src/commands/common/config/getRepackConfig.ts
@@ -1,13 +1,21 @@
 import { getMinimizerConfig } from './getMinimizerConfig.js';
 
+function getExperimentsConfig(bundler: 'rspack' | 'webpack') {
+  if (bundler === 'rspack') {
+    return { parallelLoader: true };
+  }
+}
+
 export async function getRepackConfig(
   bundler: 'rspack' | 'webpack',
   rootDir: string
 ) {
+  const experiments = getExperimentsConfig(bundler);
   const minimizerConfiguration = await getMinimizerConfig(bundler, rootDir);
 
   return {
     devtool: 'source-map',
+    experiments,
     output: {
       clean: true,
       hashFunction: 'xxhash64',

--- a/website/src/latest/docs/guides/configuration.mdx
+++ b/website/src/latest/docs/guides/configuration.mdx
@@ -238,22 +238,43 @@ Remember that if you define the same options in your configuration file (e.g. `r
 
 These are the base defaults that Re.Pack provides regardless of the command being run:
 
-```js
-{
-  devtool: "source-map",
-  output: {
-    clean: true,
-    hashFunction: "xxhash64",
-    filename: "index.bundle",
-    chunkFilename: "[name].chunk.bundle",
-    path: "[context]/build/generated/[platform]",
-    publicPath: "noop:///",
-  },
-  optimization: {
-    chunkIds: "named",
-  },
-}
-```
+<Tabs>
+  <Tab label="Rspack">
+    <CodeBlock language="js">{`{
+    devtool: "source-map",
+    experiments: {
+      parallelLoader: true,
+    },
+    output: {
+      clean: true,
+      hashFunction: "xxhash64",
+      filename: "index.bundle",
+      chunkFilename: "[name].chunk.bundle",
+      path: "[context]/build/generated/[platform]",
+      publicPath: "noop:///",
+    },
+    optimization: {
+      chunkIds: "named",
+    },
+}`}</CodeBlock>
+  </Tab>
+  <Tab label="webpack">
+    <CodeBlock language="js">{`{
+    devtool: "source-map",
+    output: {
+      clean: true,
+      hashFunction: "xxhash64",
+      filename: "index.bundle",
+      chunkFilename: "[name].chunk.bundle",
+      path: "[context]/build/generated/[platform]",
+      publicPath: "noop:///",
+    },
+    optimization: {
+      chunkIds: "named",
+    },
+}`}</CodeBlock>
+  </Tab>
+</Tabs>
 
 ## Configuration enhancements
 


### PR DESCRIPTION
### Summary

This PR enables `experiments.parallelLoader` by default for Rspack configurations.

### Test plan

- [x] - testers work
