### PR TITLE
feat: update new project templates for Re.Pack 5.2

### DIFF
--- a/.changeset/ripe-humans-press.md
+++ b/.changeset/ripe-humans-press.md
@@ -1,0 +1,5 @@
+---
+"@callstack/repack": minor
+---
+
+Update new project templates for Re.Pack 5.2

--- a/templates/rspack.config.cjs
+++ b/templates/rspack.config.cjs
@@ -15,7 +15,15 @@ module.exports = {
   },
   module: {
     rules: [
-      ...Repack.getJsTransformRules(),
+      {
+        test: /\.[cm]?[jt]sx?$/,
+        type: 'javascript/auto',
+        use: {
+          loader: '@callstack/repack/babel-swc-loader',
+          parallel: true,
+          options: {},
+        },
+      },
       ...Repack.getAssetTransformRules(),
     ],
   },

--- a/templates/rspack.config.mjs
+++ b/templates/rspack.config.mjs
@@ -20,7 +20,15 @@ export default {
   },
   module: {
     rules: [
-      ...Repack.getJsTransformRules(),
+      {
+        test: /\.[cm]?[jt]sx?$/,
+        type: 'javascript/auto',
+        use: {
+          loader: '@callstack/repack/babel-swc-loader',
+          parallel: true,
+          options: {},
+        },
+      },
       ...Repack.getAssetTransformRules(),
     ],
   },

--- a/templates/webpack.config.cjs
+++ b/templates/webpack.config.cjs
@@ -1,5 +1,4 @@
 const Repack = require('@callstack/repack');
-const TerserPlugin = require('terser-webpack-plugin');
 
 /**
  * Webpack configuration enhanced with Re.Pack defaults for React Native.
@@ -18,23 +17,13 @@ module.exports = {
     rules: [
       {
         test: /\.[cm]?[jt]sx?$/,
-        use: 'babel-loader',
         type: 'javascript/auto',
+        use: {
+          loader: '@callstack/repack/babel-swc-loader',
+          options: {},
+        },
       },
       ...Repack.getAssetTransformRules(),
-    ],
-  },
-  optimization: {
-    minimizer: [
-      new TerserPlugin({
-        test: /\.(js)?bundle(\?.*)?$/i,
-        extractComments: false,
-        terserOptions: {
-          format: {
-            comments: false,
-          },
-        },
-      }),
     ],
   },
   plugins: [new Repack.RepackPlugin()],

--- a/templates/webpack.config.mjs
+++ b/templates/webpack.config.mjs
@@ -1,7 +1,6 @@
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import * as Repack from '@callstack/repack';
-import TerserPlugin from 'terser-webpack-plugin';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -23,23 +22,13 @@ export default {
     rules: [
       {
         test: /\.[cm]?[jt]sx?$/,
-        use: 'babel-loader',
         type: 'javascript/auto',
+        use: {
+          loader: '@callstack/repack/babel-swc-loader',
+          options: {},
+        },
       },
       ...Repack.getAssetTransformRules(),
-    ],
-  },
-  optimization: {
-    minimizer: [
-      new TerserPlugin({
-        test: /\.(js)?bundle(\?.*)?$/i,
-        extractComments: false,
-        terserOptions: {
-          format: {
-            comments: false,
-          },
-        },
-      }),
     ],
   },
   plugins: [new Repack.RepackPlugin()],


### PR DESCRIPTION
### Summary

Updated all templates to reflect changes in Re.Pack 5.2:

- [x] - Rspack projects now use parallel `babel-swc-loader` by default
- [x] - Webpack projects now use `babel-swc-loader` by default instead of `babel-loader` 
- [x] - Webpack projects no longer need to explicitly configure Terser plugin 

### Test plan

n/a
