### PR TITLE
fix: exclude transform-typescript when present

### DIFF
--- a/.changeset/funny-clubs-see.md
+++ b/.changeset/funny-clubs-see.md
@@ -1,0 +1,5 @@
+---
+"@callstack/repack": patch
+---
+
+Let SWC handle `transform-typescript` when using `babel-swc-loader`

--- a/packages/repack/src/loaders/babelSwcLoader/swc.ts
+++ b/packages/repack/src/loaders/babelSwcLoader/swc.ts
@@ -41,6 +41,7 @@ const SWC_SUPPORTED_CUSTOM_RULES = new Set([
   'transform-react-jsx',
   'transform-modules-commonjs',
   'proposal-export-default-from',
+  'transform-typescript',
 ]);
 
 function getTransformRuntimeConfig(
@@ -224,6 +225,13 @@ function getTransformForOfConfig(
   };
 }
 
+function getTransformTypescriptConfig(
+  swcConfig: SwcLoaderOptions
+): SwcLoaderOptions {
+  // passthrough
+  return swcConfig;
+}
+
 const SWC_SUPPORTED_CONFIGURABLE_RULES_MAP = {
   'transform-class-properties': getTransformClassPropertiesConfig,
   'transform-private-methods': getTransformPrivateMethodsPropertyConfig,
@@ -244,6 +252,7 @@ const SWC_SUPPORTED_CUSTOM_RULES_MAP = {
   'transform-react-jsx-source': getTransformReactDevelopmentConfig,
   'transform-modules-commonjs': getTransformModulesCommonjsConfig,
   'proposal-export-default-from': getTransformExportDefaultFromConfig,
+  'transform-typescript': getTransformTypescriptConfig,
 };
 
 export function getSupportedSwcNormalTransforms(


### PR DESCRIPTION
### Summary

Exclude `transform-typescript` from babel rules when detected through `babel-swc-loader`

### Test plan

- [x] - testers work
