### PR TITLE
fix: use consitent name as caller regardless of loader

### DIFF
--- a/.changeset/rare-gifts-sip.md
+++ b/.changeset/rare-gifts-sip.md
@@ -1,0 +1,5 @@
+---
+"@callstack/repack": patch
+---
+
+Use consistent name as a caller for babel & swc

--- a/packages/repack/src/loaders/babelLoader/babelLoader.ts
+++ b/packages/repack/src/loaders/babelLoader/babelLoader.ts
@@ -124,7 +124,7 @@ export default async function babelLoader(
     const result = await transform(
       source,
       {
-        caller: { name: '@callstack/repack/babel-loader' },
+        caller: { name: '@callstack/repack' },
         filename: this.resourcePath,
         sourceMaps: withSourceMaps,
         sourceFileName: this.resourcePath,

--- a/packages/repack/src/loaders/babelSwcLoader/babelSwcLoader.ts
+++ b/packages/repack/src/loaders/babelSwcLoader/babelSwcLoader.ts
@@ -62,7 +62,6 @@ export default async function babelSwcLoader(
 ) {
   this.cacheable();
   const callback = this.async();
-  const loaderName = '@callstack/repack/babel-swc-loader';
   const logger = this.getLogger('BabelSwcLoader');
   const options = this.getOptions();
 
@@ -81,7 +80,7 @@ export default async function babelSwcLoader(
     : this.sourceMap;
 
   const baseBabelConfig: TransformOptions = {
-    caller: { name: loaderName },
+    caller: { name: '@callstack/repack' },
     root: projectRoot,
     filename: this.resourcePath,
     sourceMaps: withSourceMaps,
@@ -138,7 +137,7 @@ export default async function babelSwcLoader(
 
     const swcResult = swc.transformSync(babelResult?.code!, {
       ...finalSwcConfig,
-      caller: { name: loaderName },
+      caller: { name: '@callstack/repack' },
       filename: this.resourcePath,
       configFile: false,
       swcrc: false,

--- a/packages/repack/src/loaders/babelSwcLoader/utils.ts
+++ b/packages/repack/src/loaders/babelSwcLoader/utils.ts
@@ -17,7 +17,11 @@ export function isTSXSource(fileName: string) {
 }
 
 export function getProjectBabelConfig(filename: string, projectRoot?: string) {
-  const babelConfig = loadOptions({ filename, root: projectRoot });
+  const babelConfig = loadOptions({
+    caller: { name: '@callstack/repack' },
+    filename,
+    root: projectRoot,
+  });
   return babelConfig ?? {};
 }
 


### PR DESCRIPTION
### Summary

Always use `@callstack/repack` as caller.name passed to Babel / SWC

### Test plan

- [x] - testers work
