### PR TITLE
fix: use noop handler for filesystem prefetch calls on Android

### DIFF
--- a/.changeset/lemon-paths-allow.md
+++ b/.changeset/lemon-paths-allow.md
@@ -1,0 +1,5 @@
+---
+"@callstack/repack": patch
+---
+
+Use noop handler for local filesystem prefetch calls on Android

--- a/packages/repack/android/src/main/java/com/callstack/repack/FileSystemScriptLoader.kt
+++ b/packages/repack/android/src/main/java/com/callstack/repack/FileSystemScriptLoader.kt
@@ -40,4 +40,9 @@ class FileSystemScriptLoader(private val reactContext: ReactContext, private val
             )
         }
     }
+
+    fun prefetch(config: ScriptConfig, promise: Promise) {
+        // noop since there is no need to prefetch local scripts
+        promise.resolve(null)
+    }
 }


### PR DESCRIPTION
### Summary

https://github.com/callstack/repack/pull/1243 intoduced a bug on Android that caused compilation errors - to address it, I've added a noop handler for prefetch calls on Android - the function will resolve correctly instead of throwing an error because of unsupported protocol, which was the primary intent behind the PR mentioned

### Test plan

- [x] - tests pass
- [x] - testers work
