### PR TITLE
feat: support passing options to reanimated / worklets plugin

### DIFF
--- a/.changeset/mean-dodos-hear.md
+++ b/.changeset/mean-dodos-hear.md
@@ -1,0 +1,5 @@
+---
+"@callstack/repack-plugin-reanimated": minor
+---
+
+Allow passing babel plugin options to RepackPluginReanimated

--- a/.changeset/tangy-lines-cheer.md
+++ b/.changeset/tangy-lines-cheer.md
@@ -1,0 +1,5 @@
+---
+"@callstack/repack-plugin-reanimated": patch
+---
+
+Ensure react-native-worklets is installed when using Reanimated >=4

--- a/apps/tester-app/rspack.config.mjs
+++ b/apps/tester-app/rspack.config.mjs
@@ -120,7 +120,9 @@ export default Repack.defineRspackConfig((env) => {
           },
         ],
       }),
-      new ReanimatedPlugin(),
+      new ReanimatedPlugin({
+        babelPluginOptions: { relativeSourceLocation: true },
+      }),
       new NativeWindPlugin({ cssInteropOptions: { inlineRem: 16 } }),
       process.env.RSDOCTOR && new RsdoctorRspackPlugin(),
     ].filter(Boolean),

--- a/packages/plugin-reanimated/src/loader.ts
+++ b/packages/plugin-reanimated/src/loader.ts
@@ -94,7 +94,7 @@ export function pitch(
       if (!warningDisplayed) {
         warningDisplayed = true;
         logger.warn(
-          '`@callstack/repack-plugin-reanimated` should not be used with `@callstack/repack/babel-swc-loader`. ' +
+          '`@callstack/repack-plugin-reanimated` is not needed when using `@callstack/repack/babel-swc-loader`. ' +
             'Instead, add the `react-native-reanimated/plugin` (or `react-native-worklets/plugin`) directly to your list of babel plugins in the `babel.config.js` file in the project root.'
         );
       }

--- a/packages/plugin-reanimated/src/loader.ts
+++ b/packages/plugin-reanimated/src/loader.ts
@@ -94,7 +94,7 @@ export function pitch(
       if (!warningDisplayed) {
         warningDisplayed = true;
         logger.warn(
-          '`@callstack/repack-plugin-reanimated` is not needed when using `@callstack/repack/babel-swc-loader`. ' +
+          '`@callstack/repack-plugin-reanimated` should not be used with `@callstack/repack/babel-swc-loader`. ' +
             'Instead, add the `react-native-reanimated/plugin` (or `react-native-worklets/plugin`) directly to your list of babel plugins in the `babel.config.js` file in the project root.'
         );
       }

--- a/packages/plugin-reanimated/src/plugin.ts
+++ b/packages/plugin-reanimated/src/plugin.ts
@@ -5,6 +5,9 @@ import type { Compiler as WebpackCompiler } from 'webpack';
 import { createReanimatedModuleRules } from './rules.js';
 
 interface ReanimatedPluginOptions {
+  /**
+   * Custom options passed to 'react-native-reanimated/plugin' or 'react-native-worklets/plugin' babel plugins.
+   */
   babelPluginOptions?: Record<string, any>;
 }
 

--- a/packages/plugin-reanimated/src/rules.ts
+++ b/packages/plugin-reanimated/src/rules.ts
@@ -1,6 +1,9 @@
 import { getModulePaths } from '@callstack/repack';
 
-const createReanimatedModuleRules = (majorVersion: number) => {
+export const createReanimatedModuleRules = (
+  majorVersion: number,
+  pluginOptions: Record<string, any> = {}
+) => {
   const workletsBabelPlugin =
     majorVersion < 4
       ? 'react-native-reanimated/plugin'
@@ -27,7 +30,7 @@ const createReanimatedModuleRules = (majorVersion: number) => {
                 '@babel/plugin-syntax-typescript',
                 { isTSX: false, allowNamespaces: true },
               ],
-              workletsBabelPlugin,
+              [workletsBabelPlugin, pluginOptions],
             ],
           },
         },
@@ -42,7 +45,7 @@ const createReanimatedModuleRules = (majorVersion: number) => {
                 '@babel/plugin-syntax-typescript',
                 { isTSX: true, allowNamespaces: true },
               ],
-              workletsBabelPlugin,
+              [workletsBabelPlugin, pluginOptions],
             ],
           },
         },
@@ -54,7 +57,7 @@ const createReanimatedModuleRules = (majorVersion: number) => {
           options: {
             babelPlugins: [
               'babel-plugin-syntax-hermes-parser',
-              workletsBabelPlugin,
+              [workletsBabelPlugin, pluginOptions],
             ],
           },
         },


### PR DESCRIPTION
### Summary

This PR adds a way to pass custom options to Reanimated/Worklets plugin.
It also adds a check to ensure `react-native-worklets` is installed when using Reanimated >= 4

Example:

```js
new ReanimatedPlugin({
  babelPluginOptions: { 
	relativeSourceLocation: true 
  },
}),
```

### Test plan

- [x] - testers work and options are passed
