### PR TITLE
fix: remove devServer config when using the `bundle` command

### DIFF
--- a/.changeset/rotten-drinks-join.md
+++ b/.changeset/rotten-drinks-join.md
@@ -1,0 +1,5 @@
+---
+"@callstack/repack": patch
+---
+
+Unset DevServer configuration when using the bundle command

--- a/biome.jsonc
+++ b/biome.jsonc
@@ -41,6 +41,9 @@
         "noUnusedImports": "error",
         "noUnusedVariables": "error"
       },
+      "performance": {
+        "noDelete": "off"
+      },
       "style": {
         "noNonNullAssertion": "off",
         "useTemplate": "off"

--- a/packages/repack/src/commands/rspack/bundle.ts
+++ b/packages/repack/src/commands/rspack/bundle.ts
@@ -34,6 +34,9 @@ export async function bundle(
     reactNativePath: cliConfig.reactNativePath,
   });
 
+  // remove devServer configuration to avoid schema validation errors
+  delete config.devServer;
+
   // expose selected args as environment variables
   setupEnvironment(args);
 

--- a/packages/repack/src/commands/webpack/bundle.ts
+++ b/packages/repack/src/commands/webpack/bundle.ts
@@ -30,6 +30,9 @@ export async function bundle(
     reactNativePath: cliConfig.reactNativePath,
   });
 
+  // remove devServer configuration to avoid schema validation errors
+  delete config.devServer;
+
   // expose selected args as environment variables
   setupEnvironment(args);
 


### PR DESCRIPTION
### Summary

Unset `config.devServer` when running the bundle command to prevent passing it down to Rspack and ending up with schema validation error. 

### Test plan

n/a
