### PR TITLE
fix: use Terser for Rspack 1.5.0 and above

### DIFF
--- a/.changeset/rare-squids-worry.md
+++ b/.changeset/rare-squids-worry.md
@@ -1,0 +1,5 @@
+---
+"@callstack/repack": patch
+---
+
+Use Terser for Rspack 1.5.0 and above

--- a/packages/repack/src/commands/common/config/getMinimizerConfig.ts
+++ b/packages/repack/src/commands/common/config/getMinimizerConfig.ts
@@ -25,10 +25,11 @@ async function getTerserConfig(rootDir: string) {
   });
 }
 
-// use SwcJsMinimizerRspackPlugin for Rspack 1.5.0 and above
+// use SwcJsMinimizerRspackPlugin for Rspack 1.4.11
+// Rspack 1.5.0 broke the minimizer again, pending a fix
 function shouldUseTerserForRspack(rspackVersion: string): boolean {
   const version = semver.coerce(rspackVersion) ?? '0.0.0';
-  return semver.lt(version, '1.5.0');
+  return semver.eq(version, '1.4.11');
 }
 
 async function getWebpackMinimizer(rootDir: string) {


### PR DESCRIPTION
### Summary

Despite a fix in https://github.com/web-infra-dev/rspack/issues/11183, Rspack 1.5.0 shipped with a regression so to counter this we disable the SWC minifier for now

### Test plan

n/a
