### PR TITLE
fix: dont use lazy imports by default with `babel-swc-loader`

### DIFF
--- a/.changeset/fresh-trams-judge.md
+++ b/.changeset/fresh-trams-judge.md
@@ -1,0 +1,5 @@
+---
+"@callstack/repack": patch
+---
+
+Dont use lazy imports by default when using babel-swc-loader

--- a/packages/repack/src/loaders/babelSwcLoader/babelSwcLoader.ts
+++ b/packages/repack/src/loaders/babelSwcLoader/babelSwcLoader.ts
@@ -72,7 +72,7 @@ export default async function babelSwcLoader(
   const inputSourceMap: InputSourceMap = sourceMap
     ? JSON.parse(sourceMap)
     : undefined;
-  const lazyImports = options.lazyImports ?? true;
+  const lazyImports = options.lazyImports ?? false;
   const projectRoot = getProjectRootPath(this);
 
   const withSourceMaps = this.resourcePath.match(/node_modules/)


### PR DESCRIPTION
### Summary

- [x] - disable using lazy imports by default with `babel-swc-loader`

### Test plan

n/a
