### PR TITLE
fix: inherit source type from babel

### DIFF
--- a/packages/repack/src/loaders/babelLoader/babelLoader.ts
+++ b/packages/repack/src/loaders/babelLoader/babelLoader.ts
@@ -1,4 +1,5 @@
 import {
+  type BabelFileResult,
   type TransformOptions,
   loadOptions,
   parseSync,
@@ -63,11 +64,15 @@ function buildBabelConfig(
   return babelConfig;
 }
 
+export type BabelTransformResult = BabelFileResult & {
+  sourceType: 'script' | 'module';
+};
+
 export const transform = async (
   src: string,
   transformOptions: TransformOptions,
   customOptions?: CustomTransformOptions
-) => {
+): Promise<BabelTransformResult> => {
   const babelConfig = buildBabelConfig(transformOptions, {
     includePlugins: customOptions?.includePlugins,
     excludePlugins: customOptions?.excludePlugins,
@@ -100,7 +105,12 @@ export const transform = async (
     throw new Error(`Failed to transform source file: ${babelConfig.filename}`);
   }
 
-  return result;
+  const sourceType = sourceAst.program.sourceType;
+
+  return {
+    ...result,
+    sourceType,
+  };
 };
 
 export default async function babelLoader(

--- a/packages/repack/src/loaders/babelSwcLoader/babelSwcLoader.ts
+++ b/packages/repack/src/loaders/babelSwcLoader/babelSwcLoader.ts
@@ -133,6 +133,7 @@ export default async function babelSwcLoader(
         lazy: lazyImports,
         type: swcConfig.module!.type,
       },
+      isModule: babelResult.sourceType === 'module',
     };
 
     const swcResult = swc.transformSync(babelResult?.code!, {


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->
Babel can detect whether a file being transformed is an ESM or CJS and return this information. However, SWC assumes by default that it will transform only ESM files. This can lead to issues with default export interop in certain cases.
See: https://github.com/callstackincubator/rozenite/issues/96

### Test plan

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
Use the reproduction repository provided in the linked issue. Link this branch with the app and try running it. If there are no errors reported, everything works as expected.
