### PR TITLE
fix: pin emitting RN deep imports shared to RN shared

### DIFF
--- a/.changeset/smart-dryers-doubt.md
+++ b/.changeset/smart-dryers-doubt.md
@@ -1,0 +1,5 @@
+---
+"@callstack/repack": patch
+---
+
+Propagate `import:false` to RN deep imports

--- a/apps/tester-app/ios/Podfile.lock
+++ b/apps/tester-app/ios/Podfile.lock
@@ -1,6 +1,6 @@
 PODS:
   - boost (1.84.0)
-  - callstack-repack (5.1.3):
+  - callstack-repack (5.2.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -2371,7 +2371,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - ReactTestApp-DevSupport (4.4.6):
+  - ReactTestApp-DevSupport (4.4.7):
     - React-Core
     - React-jsi
   - ReactTestApp-Resources (1.0.0-dev)
@@ -2749,7 +2749,7 @@ DEPENDENCIES:
   - ReactAppDependencyProvider (from `build/generated/ios`)
   - ReactCodegen (from `build/generated/ios`)
   - ReactCommon/turbomodule/core (from `../node_modules/react-native/ReactCommon`)
-  - "ReactNativeHost (from `../../../node_modules/.pnpm/react-native-test-app@4.4.6_react-native@0.81.0_@babel+core@7.25.2_@react-native-community+cl_65gbnwg2irc35guz44pwmvvvyy/node_modules/@rnx-kit/react-native-host`)"
+  - "ReactNativeHost (from `../../../node_modules/.pnpm/react-native-test-app@4.4.7_react-native@0.81.0_@babel+core@7.25.2_@react-native-community+cl_rjr6int3jxckduwjexw7sqihnq/node_modules/@rnx-kit/react-native-host`)"
   - ReactTestApp-DevSupport (from `../node_modules/react-native-test-app`)
   - ReactTestApp-Resources (from `..`)
   - "RNCAsyncStorage (from `../node_modules/@react-native-async-storage/async-storage`)"
@@ -2912,7 +2912,7 @@ EXTERNAL SOURCES:
   ReactCommon:
     :path: "../node_modules/react-native/ReactCommon"
   ReactNativeHost:
-    :path: "../../../node_modules/.pnpm/react-native-test-app@4.4.6_react-native@0.81.0_@babel+core@7.25.2_@react-native-community+cl_65gbnwg2irc35guz44pwmvvvyy/node_modules/@rnx-kit/react-native-host"
+    :path: "../../../node_modules/.pnpm/react-native-test-app@4.4.7_react-native@0.81.0_@babel+core@7.25.2_@react-native-community+cl_rjr6int3jxckduwjexw7sqihnq/node_modules/@rnx-kit/react-native-host"
   ReactTestApp-DevSupport:
     :path: "../node_modules/react-native-test-app"
   ReactTestApp-Resources:
@@ -2930,7 +2930,7 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   boost: 7e761d76ca2ce687f7cc98e698152abd03a18f90
-  callstack-repack: 5adbb5908a4101ee58ecf9f67dc951bc203edc45
+  callstack-repack: 9c91d2c48b139e38919c656474f43ab0494b4c21
   DoubleConversion: cb417026b2400c8f53ae97020b2be961b59470cb
   fast_float: b32c788ed9c6a8c584d114d0047beda9664e7cc6
   FBLazyVector: a867936a67af0d09c37935a1b900a1a3c795b6d1
@@ -3003,7 +3003,7 @@ SPEC CHECKSUMS:
   ReactCodegen: 5ca1121763559a57a821b2d74a6bab524fa0a06c
   ReactCommon: c235ebd26d63fde9a2dfa72cee9f8294b910fee1
   ReactNativeHost: 6977837691a2084827c650fc23181eebc54ad9e1
-  ReactTestApp-DevSupport: 7f041d0226e551d19b818344272ffe901e1ac799
+  ReactTestApp-DevSupport: 6994b53b5b81139a8ce63e0776c726c95de079a1
   ReactTestApp-Resources: 8d72c3deef156833760694a288ff334af4d427d7
   RNCAsyncStorage: 302f2fac014fd450046c120567ca364632da682b
   RNReanimated: 6ee65830115a6fb2b175432212cc9f19aab162bb

--- a/apps/tester-federation-v2/ios/Podfile.lock
+++ b/apps/tester-federation-v2/ios/Podfile.lock
@@ -1,6 +1,6 @@
 PODS:
   - boost (1.84.0)
-  - callstack-repack (5.1.3):
+  - callstack-repack (5.2.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -1750,7 +1750,7 @@ PODS:
     - React-RCTFBReactNativeSpec
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - react-native-safe-area-context (5.5.0):
+  - react-native-safe-area-context (5.6.1):
     - boost
     - DoubleConversion
     - fast_float
@@ -1768,8 +1768,8 @@ PODS:
     - React-graphics
     - React-ImageManager
     - React-jsi
-    - react-native-safe-area-context/common (= 5.5.0)
-    - react-native-safe-area-context/fabric (= 5.5.0)
+    - react-native-safe-area-context/common (= 5.6.1)
+    - react-native-safe-area-context/fabric (= 5.6.1)
     - React-NativeModulesApple
     - React-RCTFabric
     - React-renderercss
@@ -1780,7 +1780,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - react-native-safe-area-context/common (5.5.0):
+  - react-native-safe-area-context/common (5.6.1):
     - boost
     - DoubleConversion
     - fast_float
@@ -1808,7 +1808,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - react-native-safe-area-context/fabric (5.5.0):
+  - react-native-safe-area-context/fabric (5.6.1):
     - boost
     - DoubleConversion
     - fast_float
@@ -2371,7 +2371,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - ReactTestApp-DevSupport (4.4.6):
+  - ReactTestApp-DevSupport (4.4.7):
     - React-Core
     - React-jsi
   - RNCAsyncStorage (2.2.0):
@@ -2402,7 +2402,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - RNScreens (4.13.1):
+  - RNScreens (4.15.4):
     - boost
     - DoubleConversion
     - fast_float
@@ -2429,10 +2429,10 @@ PODS:
     - ReactCodegen
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
-    - RNScreens/common (= 4.13.1)
+    - RNScreens/common (= 4.15.4)
     - SocketRocket
     - Yoga
-  - RNScreens/common (4.13.1):
+  - RNScreens/common (4.15.4):
     - boost
     - DoubleConversion
     - fast_float
@@ -2541,7 +2541,7 @@ DEPENDENCIES:
   - ReactAppDependencyProvider (from `build/generated/ios`)
   - ReactCodegen (from `build/generated/ios`)
   - ReactCommon/turbomodule/core (from `../node_modules/react-native/ReactCommon`)
-  - "ReactNativeHost (from `../../../node_modules/.pnpm/react-native-test-app@4.4.6_react-native@0.81.0_@babel+core@7.25.2_@react-native-community+cl_65gbnwg2irc35guz44pwmvvvyy/node_modules/@rnx-kit/react-native-host`)"
+  - "ReactNativeHost (from `../../../node_modules/.pnpm/react-native-test-app@4.4.7_react-native@0.81.0_@babel+core@7.25.2_@react-native-community+cl_rjr6int3jxckduwjexw7sqihnq/node_modules/@rnx-kit/react-native-host`)"
   - ReactTestApp-DevSupport (from `../node_modules/react-native-test-app`)
   - "RNCAsyncStorage (from `../node_modules/@react-native-async-storage/async-storage`)"
   - RNScreens (from `../node_modules/react-native-screens`)
@@ -2701,7 +2701,7 @@ EXTERNAL SOURCES:
   ReactCommon:
     :path: "../node_modules/react-native/ReactCommon"
   ReactNativeHost:
-    :path: "../../../node_modules/.pnpm/react-native-test-app@4.4.6_react-native@0.81.0_@babel+core@7.25.2_@react-native-community+cl_65gbnwg2irc35guz44pwmvvvyy/node_modules/@rnx-kit/react-native-host"
+    :path: "../../../node_modules/.pnpm/react-native-test-app@4.4.7_react-native@0.81.0_@babel+core@7.25.2_@react-native-community+cl_rjr6int3jxckduwjexw7sqihnq/node_modules/@rnx-kit/react-native-host"
   ReactTestApp-DevSupport:
     :path: "../node_modules/react-native-test-app"
   RNCAsyncStorage:
@@ -2713,7 +2713,7 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   boost: 7e761d76ca2ce687f7cc98e698152abd03a18f90
-  callstack-repack: 5adbb5908a4101ee58ecf9f67dc951bc203edc45
+  callstack-repack: 9c91d2c48b139e38919c656474f43ab0494b4c21
   DoubleConversion: cb417026b2400c8f53ae97020b2be961b59470cb
   fast_float: b32c788ed9c6a8c584d114d0047beda9664e7cc6
   FBLazyVector: a867936a67af0d09c37935a1b900a1a3c795b6d1
@@ -2754,7 +2754,7 @@ SPEC CHECKSUMS:
   React-logger: 839abfd18a3fbdf88132824de584b226d0c5cbce
   React-Mapbuffer: bd5b1120c9bbaac6203eb288735e239f04e03009
   React-microtasksnativemodule: 10892b00e612d79436022a11e5bc8bdf468a284f
-  react-native-safe-area-context: 0ba06165160a8ff54ff0f20eca9bc6717d4df79e
+  react-native-safe-area-context: 6d8a7b750e496e37bda47c938320bf2c734d441f
   React-NativeModulesApple: 3f9e97a4a90eeec1ceade511f973b277632650bb
   React-oscompat: 34f3d3c06cadcbc470bc4509c717fb9b919eaa8b
   React-perflogger: 95dff8cc9901777360716cbdcb2998849f133a4f
@@ -2786,12 +2786,12 @@ SPEC CHECKSUMS:
   ReactCodegen: 5ca1121763559a57a821b2d74a6bab524fa0a06c
   ReactCommon: c235ebd26d63fde9a2dfa72cee9f8294b910fee1
   ReactNativeHost: 6977837691a2084827c650fc23181eebc54ad9e1
-  ReactTestApp-DevSupport: 7f041d0226e551d19b818344272ffe901e1ac799
+  ReactTestApp-DevSupport: 6994b53b5b81139a8ce63e0776c726c95de079a1
   RNCAsyncStorage: 302f2fac014fd450046c120567ca364632da682b
-  RNScreens: 02516de412dd908659fdb5a3ed599719238a7502
+  RNScreens: 5c7f22b19ee2e900e5de2c578471aeb153d1e502
   SocketRocket: d4aabe649be1e368d1318fdf28a022d714d65748
   SwiftyRSA: 8c6dd1ea7db1b8dc4fb517a202f88bb1354bc2c6
-  Yoga: 00013dd9cde63a2d98e8002fcc4f5ddb66c10782
+  Yoga: b01392348aeea02064c21a2762a42893d82b60a7
 
 PODFILE CHECKSUM: 3d5c18eefbf70d38fbbfe81a262195cadac1f5dd
 

--- a/apps/tester-federation/ios/Podfile.lock
+++ b/apps/tester-federation/ios/Podfile.lock
@@ -1,6 +1,6 @@
 PODS:
   - boost (1.84.0)
-  - callstack-repack (5.1.3):
+  - callstack-repack (5.2.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -1750,7 +1750,7 @@ PODS:
     - React-RCTFBReactNativeSpec
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - react-native-safe-area-context (5.5.0):
+  - react-native-safe-area-context (5.6.1):
     - boost
     - DoubleConversion
     - fast_float
@@ -1768,8 +1768,8 @@ PODS:
     - React-graphics
     - React-ImageManager
     - React-jsi
-    - react-native-safe-area-context/common (= 5.5.0)
-    - react-native-safe-area-context/fabric (= 5.5.0)
+    - react-native-safe-area-context/common (= 5.6.1)
+    - react-native-safe-area-context/fabric (= 5.6.1)
     - React-NativeModulesApple
     - React-RCTFabric
     - React-renderercss
@@ -1780,7 +1780,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - react-native-safe-area-context/common (5.5.0):
+  - react-native-safe-area-context/common (5.6.1):
     - boost
     - DoubleConversion
     - fast_float
@@ -1808,7 +1808,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - react-native-safe-area-context/fabric (5.5.0):
+  - react-native-safe-area-context/fabric (5.6.1):
     - boost
     - DoubleConversion
     - fast_float
@@ -2371,7 +2371,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - ReactTestApp-DevSupport (4.4.6):
+  - ReactTestApp-DevSupport (4.4.7):
     - React-Core
     - React-jsi
   - RNCAsyncStorage (2.2.0):
@@ -2402,7 +2402,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - RNScreens (4.13.1):
+  - RNScreens (4.15.4):
     - boost
     - DoubleConversion
     - fast_float
@@ -2429,10 +2429,10 @@ PODS:
     - ReactCodegen
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
-    - RNScreens/common (= 4.13.1)
+    - RNScreens/common (= 4.15.4)
     - SocketRocket
     - Yoga
-  - RNScreens/common (4.13.1):
+  - RNScreens/common (4.15.4):
     - boost
     - DoubleConversion
     - fast_float
@@ -2541,7 +2541,7 @@ DEPENDENCIES:
   - ReactAppDependencyProvider (from `build/generated/ios`)
   - ReactCodegen (from `build/generated/ios`)
   - ReactCommon/turbomodule/core (from `../node_modules/react-native/ReactCommon`)
-  - "ReactNativeHost (from `../../../node_modules/.pnpm/react-native-test-app@4.4.6_react-native@0.81.0_@babel+core@7.25.2_@react-native-community+cl_65gbnwg2irc35guz44pwmvvvyy/node_modules/@rnx-kit/react-native-host`)"
+  - "ReactNativeHost (from `../../../node_modules/.pnpm/react-native-test-app@4.4.7_react-native@0.81.0_@babel+core@7.25.2_@react-native-community+cl_rjr6int3jxckduwjexw7sqihnq/node_modules/@rnx-kit/react-native-host`)"
   - ReactTestApp-DevSupport (from `../node_modules/react-native-test-app`)
   - "RNCAsyncStorage (from `../node_modules/@react-native-async-storage/async-storage`)"
   - RNScreens (from `../node_modules/react-native-screens`)
@@ -2701,7 +2701,7 @@ EXTERNAL SOURCES:
   ReactCommon:
     :path: "../node_modules/react-native/ReactCommon"
   ReactNativeHost:
-    :path: "../../../node_modules/.pnpm/react-native-test-app@4.4.6_react-native@0.81.0_@babel+core@7.25.2_@react-native-community+cl_65gbnwg2irc35guz44pwmvvvyy/node_modules/@rnx-kit/react-native-host"
+    :path: "../../../node_modules/.pnpm/react-native-test-app@4.4.7_react-native@0.81.0_@babel+core@7.25.2_@react-native-community+cl_rjr6int3jxckduwjexw7sqihnq/node_modules/@rnx-kit/react-native-host"
   ReactTestApp-DevSupport:
     :path: "../node_modules/react-native-test-app"
   RNCAsyncStorage:
@@ -2713,7 +2713,7 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   boost: 7e761d76ca2ce687f7cc98e698152abd03a18f90
-  callstack-repack: 5adbb5908a4101ee58ecf9f67dc951bc203edc45
+  callstack-repack: 9c91d2c48b139e38919c656474f43ab0494b4c21
   DoubleConversion: cb417026b2400c8f53ae97020b2be961b59470cb
   fast_float: b32c788ed9c6a8c584d114d0047beda9664e7cc6
   FBLazyVector: a867936a67af0d09c37935a1b900a1a3c795b6d1
@@ -2754,7 +2754,7 @@ SPEC CHECKSUMS:
   React-logger: 839abfd18a3fbdf88132824de584b226d0c5cbce
   React-Mapbuffer: bd5b1120c9bbaac6203eb288735e239f04e03009
   React-microtasksnativemodule: 10892b00e612d79436022a11e5bc8bdf468a284f
-  react-native-safe-area-context: 0ba06165160a8ff54ff0f20eca9bc6717d4df79e
+  react-native-safe-area-context: 6d8a7b750e496e37bda47c938320bf2c734d441f
   React-NativeModulesApple: 3f9e97a4a90eeec1ceade511f973b277632650bb
   React-oscompat: 34f3d3c06cadcbc470bc4509c717fb9b919eaa8b
   React-perflogger: 95dff8cc9901777360716cbdcb2998849f133a4f
@@ -2786,9 +2786,9 @@ SPEC CHECKSUMS:
   ReactCodegen: 5ca1121763559a57a821b2d74a6bab524fa0a06c
   ReactCommon: c235ebd26d63fde9a2dfa72cee9f8294b910fee1
   ReactNativeHost: 6977837691a2084827c650fc23181eebc54ad9e1
-  ReactTestApp-DevSupport: 7f041d0226e551d19b818344272ffe901e1ac799
+  ReactTestApp-DevSupport: 6994b53b5b81139a8ce63e0776c726c95de079a1
   RNCAsyncStorage: 302f2fac014fd450046c120567ca364632da682b
-  RNScreens: 02516de412dd908659fdb5a3ed599719238a7502
+  RNScreens: 5c7f22b19ee2e900e5de2c578471aeb153d1e502
   SocketRocket: d4aabe649be1e368d1318fdf28a022d714d65748
   SwiftyRSA: 8c6dd1ea7db1b8dc4fb517a202f88bb1354bc2c6
   Yoga: 00013dd9cde63a2d98e8002fcc4f5ddb66c10782

--- a/packages/repack/src/plugins/ModuleFederationPluginV2.ts
+++ b/packages/repack/src/plugins/ModuleFederationPluginV2.ts
@@ -199,11 +199,21 @@ export class ModuleFederationPluginV2 {
    * @internal
    */
   private adaptSharedDependencies(shared: MF.Shared): MF.Shared {
-    const sharedDependencyConfig = (eager?: boolean) => ({
-      singleton: true,
-      eager: eager ?? true,
-      requiredVersion: '*',
-    });
+    const sharedDependencyConfig = (
+      eager: boolean | undefined,
+      importValue: string | false | undefined
+    ): MF.SharedConfig => {
+      const config: MF.SharedConfig = {
+        singleton: true,
+        eager: eager ?? true,
+        requiredVersion: '*',
+      };
+      // set import to false if it's explicitly set to false
+      if (importValue === false) {
+        config.import = false;
+      }
+      return config;
+    };
 
     const findSharedDependency = (
       name: string,
@@ -222,6 +232,10 @@ export class ModuleFederationPluginV2 {
       typeof sharedReactNative === 'object'
         ? sharedReactNative.eager
         : undefined;
+    const reactNativeImport =
+      typeof sharedReactNative === 'object'
+        ? sharedReactNative.import
+        : undefined;
 
     if (!this.deepImports || !sharedReactNative) {
       return shared;
@@ -231,12 +245,18 @@ export class ModuleFederationPluginV2 {
       const adjustedSharedDependencies = [...shared];
       if (!findSharedDependency('react-native/', shared)) {
         adjustedSharedDependencies.push({
-          'react-native/': sharedDependencyConfig(reactNativeEager),
+          'react-native/': sharedDependencyConfig(
+            reactNativeEager,
+            reactNativeImport
+          ),
         });
       }
       if (!findSharedDependency('@react-native/', shared)) {
         adjustedSharedDependencies.push({
-          '@react-native/': sharedDependencyConfig(reactNativeEager),
+          '@react-native/': sharedDependencyConfig(
+            reactNativeEager,
+            reactNativeImport
+          ),
         });
       }
       return adjustedSharedDependencies;
@@ -244,12 +264,18 @@ export class ModuleFederationPluginV2 {
     const adjustedSharedDependencies = { ...shared };
     if (!findSharedDependency('react-native/', shared)) {
       Object.assign(adjustedSharedDependencies, {
-        'react-native/': sharedDependencyConfig(reactNativeEager),
+        'react-native/': sharedDependencyConfig(
+          reactNativeEager,
+          reactNativeImport
+        ),
       });
     }
     if (!findSharedDependency('@react-native/', shared)) {
       Object.assign(adjustedSharedDependencies, {
-        '@react-native/': sharedDependencyConfig(reactNativeEager),
+        '@react-native/': sharedDependencyConfig(
+          reactNativeEager,
+          reactNativeImport
+        ),
       });
     }
     return adjustedSharedDependencies;

--- a/packages/repack/src/plugins/__tests__/ModuleFederationPluginV1.test.ts
+++ b/packages/repack/src/plugins/__tests__/ModuleFederationPluginV1.test.ts
@@ -1,5 +1,4 @@
 import type { Compiler } from '@rspack/core';
-import { Federated } from '../../utils/federated.js';
 import { ModuleFederationPluginV1 } from '../ModuleFederationPluginV1.js';
 
 const mockPlugin = jest.fn().mockImplementation(() => ({
@@ -129,8 +128,8 @@ describe('ModuleFederationPlugin', () => {
     new ModuleFederationPluginV1({
       name: 'test',
       shared: {
-        react: Federated.SHARED_REACT,
-        'react-native': Federated.SHARED_REACT_NATIVE,
+        react: { singleton: true, eager: true },
+        'react-native': { singleton: true, eager: true },
       },
     }).apply(mockCompiler);
 
@@ -144,8 +143,8 @@ describe('ModuleFederationPlugin', () => {
       name: 'test',
       reactNativeDeepImports: false,
       shared: {
-        react: Federated.SHARED_REACT,
-        'react-native': Federated.SHARED_REACT_NATIVE,
+        react: { singleton: true, eager: true },
+        'react-native': { singleton: true, eager: true },
       },
     }).apply(mockCompiler);
 
@@ -158,7 +157,7 @@ describe('ModuleFederationPlugin', () => {
     new ModuleFederationPluginV1({
       name: 'test',
       shared: {
-        react: Federated.SHARED_REACT,
+        react: { singleton: true, eager: true },
       },
     }).apply(mockCompiler);
 
@@ -182,8 +181,8 @@ describe('ModuleFederationPlugin', () => {
     new ModuleFederationPluginV1({
       name: 'test',
       shared: {
-        react: Federated.SHARED_REACT,
-        'react-native': Federated.SHARED_REACT_NATIVE,
+        react: { singleton: true, eager: true },
+        'react-native': { singleton: true, eager: true },
         'react-native/': { singleton: true, eager: true },
       },
     }).apply(mockCompiler);
@@ -211,6 +210,21 @@ describe('ModuleFederationPlugin', () => {
     expect(config.shared).toHaveProperty('@react-native/');
     expect(config.shared['react-native/'].eager).toBe(false);
     expect(config.shared['@react-native/'].eager).toBe(false);
+  });
+
+  it('should propagate import=false to deep react-native imports', () => {
+    new ModuleFederationPluginV1({
+      name: 'test',
+      shared: {
+        'react-native': { singleton: true, eager: false, import: false },
+      },
+    }).apply(mockCompiler);
+
+    const config = mockPlugin.mock.calls[0][0];
+    expect(config.shared).toHaveProperty('react-native/');
+    expect(config.shared).toHaveProperty('@react-native/');
+    expect(config.shared['react-native/'].import).toBe(false);
+    expect(config.shared['@react-native/'].import).toBe(false);
   });
 
   it('should set default federated entry filename', () => {

--- a/packages/repack/src/plugins/__tests__/ModuleFederationPluginV2.test.ts
+++ b/packages/repack/src/plugins/__tests__/ModuleFederationPluginV2.test.ts
@@ -150,6 +150,22 @@ describe('ModuleFederationPlugin', () => {
     expect(config.shared['@react-native/'].eager).toBe(false);
   });
 
+  it('should propagate import=false to deep react-native imports', () => {
+    new ModuleFederationPluginV2({
+      name: 'test',
+      shared: {
+        react: { singleton: true, eager: true },
+        'react-native': { singleton: true, eager: false, import: false },
+      },
+    }).apply(mockCompiler);
+
+    const config = mockPlugin.mock.calls[0][0];
+    expect(config.shared).toHaveProperty('react-native/');
+    expect(config.shared).toHaveProperty('@react-native/');
+    expect(config.shared['react-native/'].import).toBe(false);
+    expect(config.shared['@react-native/'].import).toBe(false);
+  });
+
   it('should add CorePlugin & ResolverPlugin to runtime plugins by default', () => {
     new ModuleFederationPluginV2({ name: 'test' }).apply(mockCompiler);
 


### PR DESCRIPTION
### Summary

Closes #1282 

When `import: false` is set for shared `react-native`, the same is now applied to its deep imports (`react-native/`, `@react-native/`).

### Before
```ts
shared: {
  react: { singleton: true, eager: false },
  'react-native': { singleton: true, eager: false, import: false },
  // deep imports set automatically by the Re.Pack MF plugin
  'react-native/': { singleton: true, eager: false },
  '@react-native/': { singleton: true, eager: false },
}
```

### After
```ts
shared: {
  react: { singleton: true, eager: false, import: false },
  'react-native': { singleton: true, eager: false, import: false },
  // deep imports set automatically by the Re.Pack MF plugin
  'react-native/': { singleton: true, eager: false, import: false },
  '@react-native/': { singleton: true, eager: false, import: false },
}
```

### Test plan

- [x] - unit tests pass
- [x] - federation testers work 
