### PR TITLE
release: 5.2.2

### DIFF
--- a/.changeset/brown-pillows-write.md
+++ b/.changeset/brown-pillows-write.md
@@ -1,5 +1,0 @@
----
-"@callstack/repack": patch
----
-
-Fix `ERR_UNSUPPORTED_ESM_URL_SCHEME` errors when bundling on Windows

--- a/packages/dev-server/CHANGELOG.md
+++ b/packages/dev-server/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @callstack/repack-dev-server
 
+## 5.2.2
+
 ## 5.2.1
 
 ## 5.2.0

--- a/packages/dev-server/package.json
+++ b/packages/dev-server/package.json
@@ -2,7 +2,7 @@
   "name": "@callstack/repack-dev-server",
   "description": "A bundler-agnostic development server for React Native applications as part of @callstack/repack.",
   "license": "MIT",
-  "version": "5.2.1",
+  "version": "5.2.2",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/init/CHANGELOG.md
+++ b/packages/init/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @callstack/repack-init
 
+## 5.2.2
+
 ## 5.2.1
 
 ## 5.2.0

--- a/packages/init/package.json
+++ b/packages/init/package.json
@@ -3,7 +3,7 @@
   "description": "Automates the integration of the @callstack/repack into React-Native projects",
   "author": "Jakub Romańczyk <jakub.romanczyk@callstack.com>",
   "license": "MIT",
-  "version": "5.2.1",
+  "version": "5.2.2",
   "homepage": "https://github.com/callstack/repack",
   "repository": "github:callstack/repack",
   "keywords": ["repack", "re.pack", "init", "repack-init"],

--- a/packages/plugin-expo-modules/CHANGELOG.md
+++ b/packages/plugin-expo-modules/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @callstack/repack-plugin-expo-modules
 
+## 5.2.2
+
+### Patch Changes
+
+- Updated dependencies [[`bc3ac46bfc6f025345caf194082249fa572655ad`](https://github.com/callstack/repack/commit/bc3ac46bfc6f025345caf194082249fa572655ad)]:
+  - @callstack/repack@5.2.2
+
 ## 5.2.1
 
 ### Patch Changes

--- a/packages/plugin-expo-modules/package.json
+++ b/packages/plugin-expo-modules/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@callstack/repack-plugin-expo-modules",
-  "version": "5.2.1",
+  "version": "5.2.2",
   "description": "A plugin for @callstack/repack that integrates Expo Modules",
   "author": "Jakub Romańczyk <jakub.romanczyk@callstack.com>",
   "license": "MIT",

--- a/packages/plugin-nativewind/CHANGELOG.md
+++ b/packages/plugin-nativewind/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @callstack/repack-plugin-nativewind
 
+## 5.2.2
+
+### Patch Changes
+
+- Updated dependencies [[`bc3ac46bfc6f025345caf194082249fa572655ad`](https://github.com/callstack/repack/commit/bc3ac46bfc6f025345caf194082249fa572655ad)]:
+  - @callstack/repack@5.2.2
+
 ## 5.2.1
 
 ### Patch Changes

--- a/packages/plugin-nativewind/package.json
+++ b/packages/plugin-nativewind/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@callstack/repack-plugin-nativewind",
-  "version": "5.2.1",
+  "version": "5.2.2",
   "description": "A plugin for @callstack/repack that integrates NativeWind",
   "author": "Boris Yankov <boris.yankov@callstack.com>",
   "contributors": ["Jakub Romańczyk <jakub.romanczyk@callstack.com>"],

--- a/packages/plugin-reanimated/CHANGELOG.md
+++ b/packages/plugin-reanimated/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @callstack/repack-plugin-reanimated
 
+## 5.2.2
+
+### Patch Changes
+
+- Updated dependencies [[`bc3ac46bfc6f025345caf194082249fa572655ad`](https://github.com/callstack/repack/commit/bc3ac46bfc6f025345caf194082249fa572655ad)]:
+  - @callstack/repack@5.2.2
+
 ## 5.2.1
 
 ### Patch Changes

--- a/packages/plugin-reanimated/package.json
+++ b/packages/plugin-reanimated/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@callstack/repack-plugin-reanimated",
-  "version": "5.2.1",
+  "version": "5.2.2",
   "description": "A plugin for @callstack/repack that integrates react-native-reanimated",
   "author": "Jakub Romańczyk <jakub.romanczyk@callstack.com>",
   "license": "MIT",

--- a/packages/repack/CHANGELOG.md
+++ b/packages/repack/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @callstack/repack
 
+## 5.2.2
+
+### Patch Changes
+
+- [#1302](https://github.com/callstack/repack/pull/1302) [`bc3ac46bfc6f025345caf194082249fa572655ad`](https://github.com/callstack/repack/commit/bc3ac46bfc6f025345caf194082249fa572655ad) Thanks [@jbroma](https://github.com/jbroma)! - Fix `ERR_UNSUPPORTED_ESM_URL_SCHEME` errors when bundling on Windows
+
+- Updated dependencies []:
+  - @callstack/repack-dev-server@5.2.2
+
 ## 5.2.1
 
 ### Patch Changes

--- a/packages/repack/package.json
+++ b/packages/repack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@callstack/repack",
-  "version": "5.2.1",
+  "version": "5.2.2",
   "description": "A toolkit to build your React Native application with Rspack or Webpack.",
   "type": "commonjs",
   "main": "./dist/index.js",


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Publish 5.2.2 with a Windows bundling fix and version bumps across packages/plugins.
> 
> - **Release 5.2.2**
>   - **Core (`packages/repack`)**: Fix `ERR_UNSUPPORTED_ESM_URL_SCHEME` on Windows; update dependency to `@callstack/repack-dev-server@5.2.2`.
>   - **Dev Server (`packages/dev-server`)**: Version bump to `5.2.2`.
>   - **Plugins & Init**: Bump `@callstack/repack-plugin-{expo-modules,nativewind,reanimated}` and `@callstack/repack-init` to `5.2.2`; update changelogs to reference `@callstack/repack@5.2.2`.
>   - **Housekeeping**: Remove consumed changeset `/.changeset/brown-pillows-write.md`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1c23c750162fe80936175d9c4f8e11beac7be351. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->