### PR TITLE
fix(plugin-reanimated): suppress non-actionable initializers warning

### DIFF
--- a/.changeset/odd-chefs-hang.md
+++ b/.changeset/odd-chefs-hang.md
@@ -1,0 +1,5 @@
+---
+"@callstack/repack-plugin-reanimated": patch
+---
+
+Suppress non-actionable critical dependency warnings from `react-native-worklets` and legacy `react-native-reanimated` `initializers` modules during dev server builds.

--- a/packages/plugin-reanimated/src/plugin.ts
+++ b/packages/plugin-reanimated/src/plugin.ts
@@ -4,6 +4,46 @@ import semver, { type SemVer } from 'semver';
 import type { Compiler as WebpackCompiler } from 'webpack';
 import { createReanimatedModuleRules } from './rules.js';
 
+const REANIMATED_SETUP_TESTS_WARNING =
+  /'`setUpTests` is available only in Jest environment\.'/;
+const WORKLETS_CRITICAL_DEPENDENCY_WARNING =
+  /Critical dependency: require function is used in a way in which dependencies cannot be statically extracted/;
+const WORKLETS_INITIALIZERS_MODULE =
+  /react-native-(?:worklets|reanimated)[\\/].*initializers(?:\.[cm]?[jt]sx?)?/;
+
+type WarningLike = {
+  message?: unknown;
+  details?: unknown;
+  moduleName?: unknown;
+  moduleIdentifier?: unknown;
+  module?: {
+    resource?: unknown;
+    userRequest?: unknown;
+  };
+};
+
+function warningToSearchableText(warning: unknown): string {
+  if (typeof warning === 'string') {
+    return warning;
+  }
+
+  if (!warning || typeof warning !== 'object') {
+    return '';
+  }
+
+  const warningObject = warning as WarningLike;
+  return [
+    warningObject.message,
+    warningObject.details,
+    warningObject.moduleName,
+    warningObject.moduleIdentifier,
+    warningObject.module?.resource,
+    warningObject.module?.userRequest,
+  ]
+    .filter((value): value is string => typeof value === 'string')
+    .join('\n');
+}
+
 interface ReanimatedPluginOptions {
   /**
    * Custom options passed to 'react-native-reanimated/plugin' or 'react-native-worklets/plugin' babel plugins.
@@ -51,11 +91,14 @@ export class ReanimatedPlugin {
 
     // ignore the 'setUpTests' warning from reanimated which is not relevant
     compiler.options.ignoreWarnings = compiler.options.ignoreWarnings ?? [];
-    compiler.options.ignoreWarnings.push((warning) =>
-      /'`setUpTests` is available only in Jest environment\.'/.test(
-        warning.message
-      )
-    );
+    compiler.options.ignoreWarnings.push((warning) => {
+      const warningText = warningToSearchableText(warning);
+      return (
+        REANIMATED_SETUP_TESTS_WARNING.test(warningText) ||
+        (WORKLETS_CRITICAL_DEPENDENCY_WARNING.test(warningText) &&
+          WORKLETS_INITIALIZERS_MODULE.test(warningText))
+      );
+    });
   }
 
   private ensureDependencyInstalled(context: string, dependency: string) {


### PR DESCRIPTION
## Summary
- suppress non-actionable critical dependency warnings emitted from initializers modules in reanimated integration
- keep matching strict by requiring both the critical dependency message and an initializers module path
- support both modern `react-native-worklets` and legacy `react-native-reanimated` module paths

## Verification
- pnpm --filter @callstack/repack-plugin-reanimated build
- manual sanity check of matcher behavior (target warnings ignored, unrelated critical dependency warnings not ignored)
