### PR TITLE
chore: update package READMEs with new banner and footer

### DIFF
--- a/packages/dev-server/README.md
+++ b/packages/dev-server/README.md
@@ -1,7 +1,7 @@
-<div align="center">
-  <img src="https://raw.githubusercontent.com/callstack/repack/HEAD/logo.png" width="650" alt="Re.Pack logo" />
-  <h3>A toolkit to build your React Native application with Rspack or Webpack.</h3>
-</div>
+<a href="https://www.callstack.com/open-source?utm_campaign=generic&utm_source=github&utm_medium=referral&utm_content=repack" align="center">
+  <img src="https://github.com/user-attachments/assets/de25944e-d91e-4a2c-bec9-8b0595bd1bbb" alt="Re.Pack" />
+</a>
+<h3 align="center">A toolkit to build your React Native application with Rspack or Webpack.</h3>
 <div align="center">
 
 [![mit licence][license-badge]][license]
@@ -13,10 +13,17 @@
 
 `@callstack/repack-dev-server` is a bundler-agnostic development server for React Native applications as part of [`@callstack/repack`](https://github.com/callstack/repack).
 
-Check out our website at https://re-pack.dev for more info and documentation or out GitHub: https://github.com/callstack/repack.
+Check out our website at https://re-pack.dev for more info and documentation or our GitHub: https://github.com/callstack/repack.
+
+## Made with ❤️ at Callstack
+
+`@callstack/repack` is an open source project and will always remain free to use. If you think it's cool, please star it 🌟. [Callstack][callstack-readme-with-love] is a group of React and React Native geeks, contact us at [hello@callstack.com](mailto:hello@callstack.com) if you need any help with these or just want to say hi!
+
+Like the project? ⚛️ [Join the team](https://callstack.com/careers/?utm_campaign=Senior_RN&utm_source=github&utm_medium=readme) who does amazing stuff for clients and drives React Native Open Source! 🔥
 
 <!-- badges -->
 
+[callstack-readme-with-love]: https://callstack.com/?utm_source=github.com&utm_medium=referral&utm_campaign=repack&utm_term=readme-with-love
 [license-badge]: https://img.shields.io/npm/l/@callstack/repack?style=for-the-badge
 [license]: https://github.com/callstack/repack/blob/main/LICENSE
 [npm-downloads-badge]: https://img.shields.io/npm/dm/@callstack/repack?style=for-the-badge

--- a/packages/init/README.md
+++ b/packages/init/README.md
@@ -1,7 +1,7 @@
-<div align="center">
-  <img src="https://raw.githubusercontent.com/callstack/repack/HEAD/logo.png" width="650" alt="Re.Pack logo" />
-  <h3>A toolkit to build your React Native application with Rspack or Webpack.</h3>
-</div>
+<a href="https://www.callstack.com/open-source?utm_campaign=generic&utm_source=github&utm_medium=referral&utm_content=repack" align="center">
+  <img src="https://github.com/user-attachments/assets/de25944e-d91e-4a2c-bec9-8b0595bd1bbb" alt="Re.Pack" />
+</a>
+<h3 align="center">A toolkit to build your React Native application with Rspack or Webpack.</h3>
 <div align="center">
 
 [![mit licence][license-badge]][license]
@@ -35,10 +35,17 @@ npx @callstack/repack-init [options]
 
 ---
 
-Check out our website at https://re-pack.dev for more info and documentation or out GitHub: https://github.com/callstack/repack.
+Check out our website at https://re-pack.dev for more info and documentation or our GitHub: https://github.com/callstack/repack.
+
+## Made with ❤️ at Callstack
+
+`@callstack/repack` is an open source project and will always remain free to use. If you think it's cool, please star it 🌟. [Callstack][callstack-readme-with-love] is a group of React and React Native geeks, contact us at [hello@callstack.com](mailto:hello@callstack.com) if you need any help with these or just want to say hi!
+
+Like the project? ⚛️ [Join the team](https://callstack.com/careers/?utm_campaign=Senior_RN&utm_source=github&utm_medium=readme) who does amazing stuff for clients and drives React Native Open Source! 🔥
 
 <!-- badges -->
 
+[callstack-readme-with-love]: https://callstack.com/?utm_source=github.com&utm_medium=referral&utm_campaign=repack&utm_term=readme-with-love
 [license-badge]: https://img.shields.io/npm/l/@callstack/repack?style=for-the-badge
 [license]: https://github.com/callstack/repack/blob/main/LICENSE
 [npm-downloads-badge]: https://img.shields.io/npm/dm/@callstack/repack?style=for-the-badge

--- a/packages/plugin-expo-modules/README.md
+++ b/packages/plugin-expo-modules/README.md
@@ -1,7 +1,7 @@
-<div align="center">
-  <img src="https://raw.githubusercontent.com/callstack/repack/HEAD/logo.png" width="650" alt="Re.Pack logo" />
-  <h3>A toolkit to build your React Native application with Rspack or Webpack.</h3>
-</div>
+<a href="https://www.callstack.com/open-source?utm_campaign=generic&utm_source=github&utm_medium=referral&utm_content=repack" align="center">
+  <img src="https://github.com/user-attachments/assets/de25944e-d91e-4a2c-bec9-8b0595bd1bbb" alt="Re.Pack" />
+</a>
+<h3 align="center">A toolkit to build your React Native application with Rspack or Webpack.</h3>
 <div align="center">
 
 [![mit licence][license-badge]][license]
@@ -48,8 +48,15 @@ export default (env) => {
 
 Check out our website at https://re-pack.dev for more info and documentation or our GitHub: https://github.com/callstack/repack.
 
+## Made with ❤️ at Callstack
+
+`@callstack/repack` is an open source project and will always remain free to use. If you think it's cool, please star it 🌟. [Callstack][callstack-readme-with-love] is a group of React and React Native geeks, contact us at [hello@callstack.com](mailto:hello@callstack.com) if you need any help with these or just want to say hi!
+
+Like the project? ⚛️ [Join the team](https://callstack.com/careers/?utm_campaign=Senior_RN&utm_source=github&utm_medium=readme) who does amazing stuff for clients and drives React Native Open Source! 🔥
+
 <!-- badges -->
 
+[callstack-readme-with-love]: https://callstack.com/?utm_source=github.com&utm_medium=referral&utm_campaign=repack&utm_term=readme-with-love
 [license-badge]: https://img.shields.io/npm/l/@callstack/repack?style=for-the-badge
 [license]: https://github.com/callstack/repack/blob/main/LICENSE
 [npm-downloads-badge]: https://img.shields.io/npm/dm/@callstack/repack?style=for-the-badge

--- a/packages/plugin-nativewind/README.md
+++ b/packages/plugin-nativewind/README.md
@@ -1,7 +1,7 @@
-<div align="center">
-  <img src="https://raw.githubusercontent.com/callstack/repack/HEAD/logo.png" width="650" alt="Re.Pack logo" />
-  <h3>A toolkit to build your React Native application with Rspack or Webpack.</h3>
-</div>
+<a href="https://www.callstack.com/open-source?utm_campaign=generic&utm_source=github&utm_medium=referral&utm_content=repack" align="center">
+  <img src="https://github.com/user-attachments/assets/de25944e-d91e-4a2c-bec9-8b0595bd1bbb" alt="Re.Pack" />
+</a>
+<h3 align="center">A toolkit to build your React Native application with Rspack or Webpack.</h3>
 <div align="center">
 
 [![mit licence][license-badge]][license]
@@ -77,8 +77,15 @@ export default (env) => {
 
 Check out our website at https://re-pack.dev for more info and documentation or our GitHub: https://github.com/callstack/repack.
 
+## Made with ❤️ at Callstack
+
+`@callstack/repack` is an open source project and will always remain free to use. If you think it's cool, please star it 🌟. [Callstack][callstack-readme-with-love] is a group of React and React Native geeks, contact us at [hello@callstack.com](mailto:hello@callstack.com) if you need any help with these or just want to say hi!
+
+Like the project? ⚛️ [Join the team](https://callstack.com/careers/?utm_campaign=Senior_RN&utm_source=github&utm_medium=readme) who does amazing stuff for clients and drives React Native Open Source! 🔥
+
 <!-- badges -->
 
+[callstack-readme-with-love]: https://callstack.com/?utm_source=github.com&utm_medium=referral&utm_campaign=repack&utm_term=readme-with-love
 [license-badge]: https://img.shields.io/npm/l/@callstack/repack?style=for-the-badge
 [license]: https://github.com/callstack/repack/blob/main/LICENSE
 [npm-downloads-badge]: https://img.shields.io/npm/dm/@callstack/repack?style=for-the-badge

--- a/packages/plugin-reanimated/README.md
+++ b/packages/plugin-reanimated/README.md
@@ -1,7 +1,7 @@
-<div align="center">
-  <img src="https://raw.githubusercontent.com/callstack/repack/HEAD/logo.png" width="650" alt="Re.Pack logo" />
-  <h3>A toolkit to build your React Native application with Rspack or Webpack.</h3>
-</div>
+<a href="https://www.callstack.com/open-source?utm_campaign=generic&utm_source=github&utm_medium=referral&utm_content=repack" align="center">
+  <img src="https://github.com/user-attachments/assets/de25944e-d91e-4a2c-bec9-8b0595bd1bbb" alt="Re.Pack" />
+</a>
+<h3 align="center">A toolkit to build your React Native application with Rspack or Webpack.</h3>
 <div align="center">
 
 [![mit licence][license-badge]][license]
@@ -79,8 +79,15 @@ export default (env) => {
 
 Check out our website at https://re-pack.dev for more info and documentation or our GitHub: https://github.com/callstack/repack.
 
+## Made with ❤️ at Callstack
+
+`@callstack/repack` is an open source project and will always remain free to use. If you think it's cool, please star it 🌟. [Callstack][callstack-readme-with-love] is a group of React and React Native geeks, contact us at [hello@callstack.com](mailto:hello@callstack.com) if you need any help with these or just want to say hi!
+
+Like the project? ⚛️ [Join the team](https://callstack.com/careers/?utm_campaign=Senior_RN&utm_source=github&utm_medium=readme) who does amazing stuff for clients and drives React Native Open Source! 🔥
+
 <!-- badges -->
 
+[callstack-readme-with-love]: https://callstack.com/?utm_source=github.com&utm_medium=referral&utm_campaign=repack&utm_term=readme-with-love
 [license-badge]: https://img.shields.io/npm/l/@callstack/repack?style=for-the-badge
 [license]: https://github.com/callstack/repack/blob/main/LICENSE
 [npm-downloads-badge]: https://img.shields.io/npm/dm/@callstack/repack?style=for-the-badge

--- a/packages/repack/README.md
+++ b/packages/repack/README.md
@@ -1,7 +1,7 @@
-<div align="center">
-  <img src="https://raw.githubusercontent.com/callstack/repack/HEAD/logo.png" width="650" alt="Re.Pack logo" />
-  <h3>A toolkit to build your React Native application with Rspack or Webpack.</h3>
-</div>
+<a href="https://www.callstack.com/open-source?utm_campaign=generic&utm_source=github&utm_medium=referral&utm_content=repack" align="center">
+  <img src="https://github.com/user-attachments/assets/de25944e-d91e-4a2c-bec9-8b0595bd1bbb" alt="Re.Pack" />
+</a>
+<h3 align="center">A toolkit to build your React Native application with Rspack or Webpack.</h3>
 <div align="center">
 
 [![mit licence][license-badge]][license]


### PR DESCRIPTION
## Summary
- Updated all package READMEs to use the new Re.Pack banner graphic (matching root README)
- Added the "Made with ❤️ at Callstack" footer section to packages that were missing it (`dev-server`, `init`, `plugin-expo-modules`, `plugin-nativewind`, `plugin-reanimated`)
- Fixed "or out GitHub" → "or our GitHub" typos in `dev-server` and `init` READMEs

## Test plan
- [ ] Verify banner graphic renders correctly on GitHub for each package README
- [ ] Verify badge links still work on npm package pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)