### PR TITLE
fix: bump nimbus-jose-jwt to 10.8

### DIFF
--- a/.changeset/nimbus-jose-jwt-security.md
+++ b/.changeset/nimbus-jose-jwt-security.md
@@ -1,0 +1,5 @@
+---
+"@callstack/repack": patch
+---
+
+Bump the Android `nimbus-jose-jwt` dependency from `9.48` to `10.8` for upstream security fixes.

--- a/packages/repack/android/build.gradle
+++ b/packages/repack/android/build.gradle
@@ -196,5 +196,5 @@ dependencies {
     implementation 'com.facebook.react:react-android:+'
     implementation "com.squareup.okhttp3:okhttp:4.9.2"
     implementation "com.squareup.okhttp3:okhttp-urlconnection:4.9.2"
-    implementation 'com.nimbusds:nimbus-jose-jwt:9.48'
+    implementation 'com.nimbusds:nimbus-jose-jwt:10.8'
 }


### PR DESCRIPTION
## Summary

Fix for [CVE-2025-53864](https://www.cve.org/CVERecord?id=CVE-2025-53864)

- bump Android dependency `com.nimbusds:nimbus-jose-jwt` from `9.48` to `10.8`

## Verification
- ./gradlew :app:dependencies --configuration debugRuntimeClasspath (apps/tester-app/android)