### PR TITLE
chore: bump deps in Gemfile.lock and Podifle.lock files

### DIFF
--- a/apps/tester-app/Gemfile.lock
+++ b/apps/tester-app/Gemfile.lock
@@ -1,10 +1,7 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    CFPropertyList (3.0.7)
-      base64
-      nkf
-      rexml
+    CFPropertyList (3.0.8)
     activesupport (7.1.3.3)
       base64
       bigdecimal
@@ -21,7 +18,7 @@ GEM
       httpclient (~> 2.8, >= 2.8.3)
       json (>= 1.5.1)
     atomos (0.1.3)
-    base64 (0.2.0)
+    base64 (0.3.0)
     benchmark (0.4.0)
     bigdecimal (3.1.8)
     claide (1.1.0)
@@ -85,23 +82,20 @@ GEM
     nanaimo (0.3.0)
     nap (1.1.0)
     netrc (0.11.0)
-    nkf (0.2.0)
     public_suffix (4.0.7)
-    rexml (3.2.8)
-      strscan (>= 3.0.9)
+    rexml (3.4.4)
     ruby-macho (2.5.1)
-    strscan (3.1.0)
     typhoeus (1.4.1)
       ethon (>= 0.9.0)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
-    xcodeproj (1.24.0)
+    xcodeproj (1.25.1)
       CFPropertyList (>= 2.3.3, < 4.0)
       atomos (~> 0.1.3)
       claide (>= 1.0.2, < 2.0)
       colored2 (~> 3.1)
       nanaimo (~> 0.3.0)
-      rexml (~> 3.2.4)
+      rexml (>= 3.3.6, < 4.0)
 
 PLATFORMS
   arm64-darwin-21

--- a/apps/tester-app/ios/Podfile.lock
+++ b/apps/tester-app/ios/Podfile.lock
@@ -1,6 +1,6 @@
 PODS:
   - boost (1.84.0)
-  - callstack-repack (5.2.3):
+  - callstack-repack (5.2.4):
     - boost
     - DoubleConversion
     - fast_float
@@ -2749,7 +2749,7 @@ DEPENDENCIES:
   - ReactAppDependencyProvider (from `build/generated/ios`)
   - ReactCodegen (from `build/generated/ios`)
   - ReactCommon/turbomodule/core (from `../node_modules/react-native/ReactCommon`)
-  - "ReactNativeHost (from `../../../node_modules/.pnpm/react-native-test-app@4.4.7_react-native@0.81.0_@babel+core@7.25.2_@react-native-community+cl_rjr6int3jxckduwjexw7sqihnq/node_modules/@rnx-kit/react-native-host`)"
+  - "ReactNativeHost (from `../../../node_modules/.pnpm/react-native-test-app@4.4.7_react-native@0.81.0_@babel+core@7.25.2_@react-native-community+cl_ewtjfzw7qct7nbxbklxsged2ea/node_modules/@rnx-kit/react-native-host`)"
   - ReactTestApp-DevSupport (from `../node_modules/react-native-test-app`)
   - ReactTestApp-Resources (from `..`)
   - "RNCAsyncStorage (from `../node_modules/@react-native-async-storage/async-storage`)"
@@ -2912,7 +2912,7 @@ EXTERNAL SOURCES:
   ReactCommon:
     :path: "../node_modules/react-native/ReactCommon"
   ReactNativeHost:
-    :path: "../../../node_modules/.pnpm/react-native-test-app@4.4.7_react-native@0.81.0_@babel+core@7.25.2_@react-native-community+cl_rjr6int3jxckduwjexw7sqihnq/node_modules/@rnx-kit/react-native-host"
+    :path: "../../../node_modules/.pnpm/react-native-test-app@4.4.7_react-native@0.81.0_@babel+core@7.25.2_@react-native-community+cl_ewtjfzw7qct7nbxbklxsged2ea/node_modules/@rnx-kit/react-native-host"
   ReactTestApp-DevSupport:
     :path: "../node_modules/react-native-test-app"
   ReactTestApp-Resources:
@@ -2930,7 +2930,7 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   boost: 7e761d76ca2ce687f7cc98e698152abd03a18f90
-  callstack-repack: 15b29626cee2b659cd3f9afa4e8c33b1d42f5c59
+  callstack-repack: d2b994c81bca9047cfd550b1a760421c8868c1a3
   DoubleConversion: cb417026b2400c8f53ae97020b2be961b59470cb
   fast_float: b32c788ed9c6a8c584d114d0047beda9664e7cc6
   FBLazyVector: a867936a67af0d09c37935a1b900a1a3c795b6d1
@@ -3000,15 +3000,15 @@ SPEC CHECKSUMS:
   React-timing: 25e8229ad1cf6874e9f0711515213cb2bc322215
   React-utils: 7ea6e4d300c43a763e4e08091413aec962588f93
   ReactAppDependencyProvider: 562d731311d0524a577cf8a01faa97874bacbdfe
-  ReactCodegen: 5ca1121763559a57a821b2d74a6bab524fa0a06c
+  ReactCodegen: ee1afddd0b9416db28c0d7f442890f38116ef6d2
   ReactCommon: c235ebd26d63fde9a2dfa72cee9f8294b910fee1
   ReactNativeHost: 6977837691a2084827c650fc23181eebc54ad9e1
   ReactTestApp-DevSupport: 6994b53b5b81139a8ce63e0776c726c95de079a1
   ReactTestApp-Resources: 8d72c3deef156833760694a288ff334af4d427d7
   RNCAsyncStorage: 302f2fac014fd450046c120567ca364632da682b
-  RNReanimated: 6ee65830115a6fb2b175432212cc9f19aab162bb
+  RNReanimated: 2c2241d839b38b3ee258bc6c938adef91bc0d04f
   RNSVG: 99882257fbebbfd40adb30890002babf82077f3c
-  RNWorklets: 20451b83d42e7509f43599b405993e57e3a038af
+  RNWorklets: 98d1d1ebc96a15c4df64dd180153f3de0a53c4a3
   SocketRocket: d4aabe649be1e368d1318fdf28a022d714d65748
   SwiftyRSA: 8c6dd1ea7db1b8dc4fb517a202f88bb1354bc2c6
   Yoga: 00013dd9cde63a2d98e8002fcc4f5ddb66c10782

--- a/apps/tester-federation-v2/Gemfile.lock
+++ b/apps/tester-federation-v2/Gemfile.lock
@@ -1,10 +1,7 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    CFPropertyList (3.0.7)
-      base64
-      nkf
-      rexml
+    CFPropertyList (3.0.8)
     activesupport (7.1.3.3)
       base64
       bigdecimal
@@ -21,7 +18,7 @@ GEM
       httpclient (~> 2.8, >= 2.8.3)
       json (>= 1.5.1)
     atomos (0.1.3)
-    base64 (0.2.0)
+    base64 (0.3.0)
     benchmark (0.4.0)
     bigdecimal (3.1.8)
     claide (1.1.0)
@@ -85,23 +82,20 @@ GEM
     nanaimo (0.3.0)
     nap (1.1.0)
     netrc (0.11.0)
-    nkf (0.2.0)
     public_suffix (4.0.7)
-    rexml (3.2.8)
-      strscan (>= 3.0.9)
+    rexml (3.4.4)
     ruby-macho (2.5.1)
-    strscan (3.1.0)
     typhoeus (1.4.1)
       ethon (>= 0.9.0)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
-    xcodeproj (1.24.0)
+    xcodeproj (1.25.1)
       CFPropertyList (>= 2.3.3, < 4.0)
       atomos (~> 0.1.3)
       claide (>= 1.0.2, < 2.0)
       colored2 (~> 3.1)
       nanaimo (~> 0.3.0)
-      rexml (~> 3.2.4)
+      rexml (>= 3.3.6, < 4.0)
 
 PLATFORMS
   arm64-darwin-21

--- a/apps/tester-federation-v2/ios/Podfile.lock
+++ b/apps/tester-federation-v2/ios/Podfile.lock
@@ -1,6 +1,6 @@
 PODS:
   - boost (1.84.0)
-  - callstack-repack (5.2.3):
+  - callstack-repack (5.2.4):
     - boost
     - DoubleConversion
     - fast_float
@@ -2541,7 +2541,7 @@ DEPENDENCIES:
   - ReactAppDependencyProvider (from `build/generated/ios`)
   - ReactCodegen (from `build/generated/ios`)
   - ReactCommon/turbomodule/core (from `../node_modules/react-native/ReactCommon`)
-  - "ReactNativeHost (from `../../../node_modules/.pnpm/react-native-test-app@4.4.7_react-native@0.81.0_@babel+core@7.25.2_@react-native-community+cl_rjr6int3jxckduwjexw7sqihnq/node_modules/@rnx-kit/react-native-host`)"
+  - "ReactNativeHost (from `../../../node_modules/.pnpm/react-native-test-app@4.4.7_react-native@0.81.0_@babel+core@7.25.2_@react-native-community+cl_ewtjfzw7qct7nbxbklxsged2ea/node_modules/@rnx-kit/react-native-host`)"
   - ReactTestApp-DevSupport (from `../node_modules/react-native-test-app`)
   - "RNCAsyncStorage (from `../node_modules/@react-native-async-storage/async-storage`)"
   - RNScreens (from `../node_modules/react-native-screens`)
@@ -2701,7 +2701,7 @@ EXTERNAL SOURCES:
   ReactCommon:
     :path: "../node_modules/react-native/ReactCommon"
   ReactNativeHost:
-    :path: "../../../node_modules/.pnpm/react-native-test-app@4.4.7_react-native@0.81.0_@babel+core@7.25.2_@react-native-community+cl_rjr6int3jxckduwjexw7sqihnq/node_modules/@rnx-kit/react-native-host"
+    :path: "../../../node_modules/.pnpm/react-native-test-app@4.4.7_react-native@0.81.0_@babel+core@7.25.2_@react-native-community+cl_ewtjfzw7qct7nbxbklxsged2ea/node_modules/@rnx-kit/react-native-host"
   ReactTestApp-DevSupport:
     :path: "../node_modules/react-native-test-app"
   RNCAsyncStorage:
@@ -2713,7 +2713,7 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   boost: 7e761d76ca2ce687f7cc98e698152abd03a18f90
-  callstack-repack: 15b29626cee2b659cd3f9afa4e8c33b1d42f5c59
+  callstack-repack: d2b994c81bca9047cfd550b1a760421c8868c1a3
   DoubleConversion: cb417026b2400c8f53ae97020b2be961b59470cb
   fast_float: b32c788ed9c6a8c584d114d0047beda9664e7cc6
   FBLazyVector: a867936a67af0d09c37935a1b900a1a3c795b6d1
@@ -2783,7 +2783,7 @@ SPEC CHECKSUMS:
   React-timing: 25e8229ad1cf6874e9f0711515213cb2bc322215
   React-utils: 7ea6e4d300c43a763e4e08091413aec962588f93
   ReactAppDependencyProvider: 562d731311d0524a577cf8a01faa97874bacbdfe
-  ReactCodegen: 5ca1121763559a57a821b2d74a6bab524fa0a06c
+  ReactCodegen: ee1afddd0b9416db28c0d7f442890f38116ef6d2
   ReactCommon: c235ebd26d63fde9a2dfa72cee9f8294b910fee1
   ReactNativeHost: 6977837691a2084827c650fc23181eebc54ad9e1
   ReactTestApp-DevSupport: 6994b53b5b81139a8ce63e0776c726c95de079a1

--- a/apps/tester-federation/Gemfile.lock
+++ b/apps/tester-federation/Gemfile.lock
@@ -1,10 +1,7 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    CFPropertyList (3.0.7)
-      base64
-      nkf
-      rexml
+    CFPropertyList (3.0.8)
     activesupport (7.1.3.3)
       base64
       bigdecimal
@@ -21,7 +18,7 @@ GEM
       httpclient (~> 2.8, >= 2.8.3)
       json (>= 1.5.1)
     atomos (0.1.3)
-    base64 (0.2.0)
+    base64 (0.3.0)
     benchmark (0.4.0)
     bigdecimal (3.1.8)
     claide (1.1.0)
@@ -85,23 +82,20 @@ GEM
     nanaimo (0.3.0)
     nap (1.1.0)
     netrc (0.11.0)
-    nkf (0.2.0)
     public_suffix (4.0.7)
-    rexml (3.2.8)
-      strscan (>= 3.0.9)
+    rexml (3.4.4)
     ruby-macho (2.5.1)
-    strscan (3.1.0)
     typhoeus (1.4.1)
       ethon (>= 0.9.0)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
-    xcodeproj (1.24.0)
+    xcodeproj (1.25.1)
       CFPropertyList (>= 2.3.3, < 4.0)
       atomos (~> 0.1.3)
       claide (>= 1.0.2, < 2.0)
       colored2 (~> 3.1)
       nanaimo (~> 0.3.0)
-      rexml (~> 3.2.4)
+      rexml (>= 3.3.6, < 4.0)
 
 PLATFORMS
   arm64-darwin-21

--- a/apps/tester-federation/ios/Podfile.lock
+++ b/apps/tester-federation/ios/Podfile.lock
@@ -1,6 +1,6 @@
 PODS:
   - boost (1.84.0)
-  - callstack-repack (5.2.3):
+  - callstack-repack (5.2.4):
     - boost
     - DoubleConversion
     - fast_float
@@ -2541,7 +2541,7 @@ DEPENDENCIES:
   - ReactAppDependencyProvider (from `build/generated/ios`)
   - ReactCodegen (from `build/generated/ios`)
   - ReactCommon/turbomodule/core (from `../node_modules/react-native/ReactCommon`)
-  - "ReactNativeHost (from `../../../node_modules/.pnpm/react-native-test-app@4.4.7_react-native@0.81.0_@babel+core@7.25.2_@react-native-community+cl_rjr6int3jxckduwjexw7sqihnq/node_modules/@rnx-kit/react-native-host`)"
+  - "ReactNativeHost (from `../../../node_modules/.pnpm/react-native-test-app@4.4.7_react-native@0.81.0_@babel+core@7.25.2_@react-native-community+cl_ewtjfzw7qct7nbxbklxsged2ea/node_modules/@rnx-kit/react-native-host`)"
   - ReactTestApp-DevSupport (from `../node_modules/react-native-test-app`)
   - "RNCAsyncStorage (from `../node_modules/@react-native-async-storage/async-storage`)"
   - RNScreens (from `../node_modules/react-native-screens`)
@@ -2701,7 +2701,7 @@ EXTERNAL SOURCES:
   ReactCommon:
     :path: "../node_modules/react-native/ReactCommon"
   ReactNativeHost:
-    :path: "../../../node_modules/.pnpm/react-native-test-app@4.4.7_react-native@0.81.0_@babel+core@7.25.2_@react-native-community+cl_rjr6int3jxckduwjexw7sqihnq/node_modules/@rnx-kit/react-native-host"
+    :path: "../../../node_modules/.pnpm/react-native-test-app@4.4.7_react-native@0.81.0_@babel+core@7.25.2_@react-native-community+cl_ewtjfzw7qct7nbxbklxsged2ea/node_modules/@rnx-kit/react-native-host"
   ReactTestApp-DevSupport:
     :path: "../node_modules/react-native-test-app"
   RNCAsyncStorage:
@@ -2713,7 +2713,7 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   boost: 7e761d76ca2ce687f7cc98e698152abd03a18f90
-  callstack-repack: 15b29626cee2b659cd3f9afa4e8c33b1d42f5c59
+  callstack-repack: d2b994c81bca9047cfd550b1a760421c8868c1a3
   DoubleConversion: cb417026b2400c8f53ae97020b2be961b59470cb
   fast_float: b32c788ed9c6a8c584d114d0047beda9664e7cc6
   FBLazyVector: a867936a67af0d09c37935a1b900a1a3c795b6d1
@@ -2783,7 +2783,7 @@ SPEC CHECKSUMS:
   React-timing: 25e8229ad1cf6874e9f0711515213cb2bc322215
   React-utils: 7ea6e4d300c43a763e4e08091413aec962588f93
   ReactAppDependencyProvider: 562d731311d0524a577cf8a01faa97874bacbdfe
-  ReactCodegen: 5ca1121763559a57a821b2d74a6bab524fa0a06c
+  ReactCodegen: ee1afddd0b9416db28c0d7f442890f38116ef6d2
   ReactCommon: c235ebd26d63fde9a2dfa72cee9f8294b910fee1
   ReactNativeHost: 6977837691a2084827c650fc23181eebc54ad9e1
   ReactTestApp-DevSupport: 6994b53b5b81139a8ce63e0776c726c95de079a1


### PR DESCRIPTION
## Summary
- update `rexml` in tester app Gemfile.lock files to `3.4.4` to satisfy Dependabot security patch requirements
- update `xcodeproj` to `1.25.1` so patched `rexml` versions are resolvable
- include regenerated iOS Podfile.lock files for tester apps

## Files changed
- apps/tester-app/Gemfile.lock
- apps/tester-federation/Gemfile.lock
- apps/tester-federation-v2/Gemfile.lock
- apps/tester-app/ios/Podfile.lock
- apps/tester-federation/ios/Podfile.lock
- apps/tester-federation-v2/ios/Podfile.lock

## Verification
- confirmed all three Gemfile.lock files now resolve `rexml (3.4.4)`
- re-queried Dependabot alerts for Gemfile.lock manifests (alerts remain open until this PR is merged into default branch)
