### PR TITLE
feat(init): support React Native 0.84.1 bootstrap

### DIFF
--- a/.changeset/bootstrap-rn-84-projects.md
+++ b/.changeset/bootstrap-rn-84-projects.md
@@ -1,0 +1,5 @@
+---
+"@callstack/repack-init": patch
+---
+
+Add support for bootstrapping new Re.Pack projects with React Native 0.84.1 and refresh the default bundler dependency versions used during initialization.

--- a/packages/init/versions.json
+++ b/packages/init/versions.json
@@ -1,11 +1,11 @@
 {
-  "react-native": "0.81",
+  "react-native": "0.84.1",
   "rspack": {
-    "@rspack/core": "^1.3.4",
-    "@swc/helpers": "^0.5.17"
+    "@rspack/core": "^1.7.8",
+    "@swc/helpers": "^0.5.19"
   },
   "webpack": {
-    "terser-webpack-plugin": "^5.3.14",
-    "webpack": "^5.99.5"
+    "terser-webpack-plugin": "^5.4.0",
+    "webpack": "^5.105.4"
   }
 }


### PR DESCRIPTION
## Summary
- update `@callstack/repack-init` to bootstrap React Native 0.84.1 projects
- bump the default init dependency versions for Rspack, SWC helpers, webpack, and terser-webpack-plugin
- add a patch changeset for `@callstack/repack-init` describing the new bootstrap target

## Test Plan
- pnpm --filter @callstack/repack-init typecheck
- pnpm --filter @callstack/repack-init build
- pnpm test
