### PR TITLE
fix(android): stop rewriting localhost to 10.0.2.2

### DIFF
--- a/.changeset/twenty-bushes-act.md
+++ b/.changeset/twenty-bushes-act.md
@@ -1,5 +1,5 @@
 ---
-"@callstack/repack": major
+"@callstack/repack": patch
 ---
 
 Fix Android dev-server URLs on physical devices by preserving `localhost` instead of rewriting it to `10.0.2.2`.

--- a/.changeset/twenty-bushes-act.md
+++ b/.changeset/twenty-bushes-act.md
@@ -1,0 +1,5 @@
+---
+"@callstack/repack": major
+---
+
+Fix Android dev-server URLs on physical devices by preserving `localhost` instead of rewriting it to `10.0.2.2`.

--- a/packages/repack/src/modules/getDevServerLocation.ts
+++ b/packages/repack/src/modules/getDevServerLocation.ts
@@ -1,14 +1,8 @@
-let hostname = __PUBLIC_HOST__;
-
-if (__PLATFORM__ === 'android' && __PUBLIC_HOST__ === 'localhost') {
-  hostname = '10.0.2.2';
-}
-
 const location = {
-  host: `${hostname}:${__PUBLIC_PORT__}`,
-  hostname,
-  href: `${__PUBLIC_PROTOCOL__}://${hostname}:${__PUBLIC_PORT__}/`,
-  origin: `${__PUBLIC_PROTOCOL__}://${hostname}:${__PUBLIC_PORT__}`,
+  host: `${__PUBLIC_HOST__}:${__PUBLIC_PORT__}`,
+  hostname: __PUBLIC_HOST__,
+  href: `${__PUBLIC_PROTOCOL__}://${__PUBLIC_HOST__}:${__PUBLIC_PORT__}/`,
+  origin: `${__PUBLIC_PROTOCOL__}://${__PUBLIC_HOST__}:${__PUBLIC_PORT__}`,
   pathname: '/',
   port: __PUBLIC_PORT__,
   protocol: __PUBLIC_PROTOCOL__,


### PR DESCRIPTION
### Summary

Issue #1247

Fix Android physical-device dev server resolution by removing the unconditional runtime rewrite from `localhost` to `10.0.2.2`

Previously, re.pack treated every Android runtime like an emulator. That caused:
- HMR websocket URLs to resolve to `ws://10.0.2.2:8081/__hmr`
- async chunk URLs to resolve to `http://10.0.2.2:8081/...`

It works on emulators, but breaks on physical devices, where `10.0.2.2` is unreachable

This change makes re.pack use the configured dev-server host literally, which allows Android physical devices to work correctly with the standard `localhost` + `adb reverse` flow

### Test Plan

1. connect an Android physical device with USB debugging enabled
2. start the dev server from `apps/tester-app` with the default host by `pnpm react-native webpack-start`
3. run `adb reverse tcp:8081 tcp:8081`
4. launch "Tester App" on the Android physical device
5. confirm the app loads successfully
6. edit visible UI file such as `apps/tester-app/src/App.tsx` & save
7. confirm HMR works - the UI should updates without full app relaunch

### Recordiing

https://github.com/user-attachments/assets/773552e8-92c4-45bc-81a7-0db4d015b6f5