### PR TITLE
feat: check module federation runtime-tools availability under rspack 2

### DIFF
--- a/.changeset/rspack-2-mfv1-precheck.md
+++ b/.changeset/rspack-2-mfv1-precheck.md
@@ -1,0 +1,5 @@
+---
+"@callstack/repack": patch
+---
+
+Fail with a clear, actionable error when using `ModuleFederationPluginV1` under Rspack 2 without `@module-federation/runtime-tools` installed. In Rspack 2 the package became an optional peer dependency of `@rspack/core` and is no longer installed automatically, which previously surfaced as a cryptic module resolution failure at build time.

--- a/packages/repack/src/plugins/ModuleFederationPluginV1.ts
+++ b/packages/repack/src/plugins/ModuleFederationPluginV1.ts
@@ -1,6 +1,9 @@
 import type { Compiler as RspackCompiler, container } from '@rspack/core';
 import type { Compiler as WebpackCompiler } from 'webpack';
-import { isRspackCompiler } from '../helpers/index.js';
+import {
+  getRspackMajorVersionFromCompiler,
+  isRspackCompiler,
+} from '../helpers/index.js';
 import { Federated } from '../utils/federated.js';
 
 type MFPluginV1 = typeof container.ModuleFederationPluginV1;
@@ -123,6 +126,31 @@ export class ModuleFederationPluginV1 {
     }
     // @ts-expect-error webpack has MF1 under ModuleFederationPlugin
     return compiler.webpack.container.ModuleFederationPlugin;
+  }
+
+  /**
+   * In Rspack 2, `@module-federation/runtime-tools` became an optional
+   * peer dependency of `@rspack/core` and is no longer installed
+   * automatically. The built-in ModuleFederationPluginV1 still needs it,
+   * so verify it's installed to fail with an actionable error instead of
+   * a raw module resolution error at build time.
+   */
+  private ensureModuleFederationRuntimeToolsInstalled(context: string) {
+    try {
+      require.resolve('@module-federation/runtime-tools', {
+        paths: [context],
+      });
+    } catch {
+      const error = new Error(
+        '[RepackModuleFederationPluginV1] ' +
+          "Dependency named '@module-federation/runtime-tools' is required when using Module Federation with Rspack 2 " +
+          '(it became an optional peer dependency of @rspack/core) but is not found in your project. ' +
+          'Did you forget to install it?'
+      );
+      // remove the stack trace to make the error more readable
+      error.stack = undefined;
+      throw error;
+    }
   }
 
   private replaceRemotes<T extends string | string[] | RemotesObject>(
@@ -279,6 +307,11 @@ export class ModuleFederationPluginV1 {
 
   apply(__compiler: unknown) {
     const compiler = __compiler as RspackCompiler;
+
+    const rspackMajor = getRspackMajorVersionFromCompiler(compiler);
+    if (rspackMajor !== null && rspackMajor >= 2) {
+      this.ensureModuleFederationRuntimeToolsInstalled(compiler.context);
+    }
 
     const ModuleFederationPlugin = this.getModuleFederationPlugin(compiler);
 


### PR DESCRIPTION
## Summary

Adds a pre-check to `ModuleFederationPluginV1.apply`: when running under Rspack >= 2, verify that `@module-federation/runtime-tools` is resolvable from the compiler context and fail with an actionable error if it is not.

## Why

In Rspack 2, `@module-federation/runtime-tools` became an optional peer dependency of `@rspack/core` and is no longer installed automatically. The built-in `ModuleFederationPluginV1` still needs it, so MFv1 users on Rspack 2 must install it explicitly. Without this check, the missing package surfaces as a cryptic module resolution failure at build time; with it, the user gets a clear message telling them exactly what to install.

Under Rspack 1 (and webpack) nothing changes — the check only runs when the compiler reports major version >= 2.

This change was maintainer-approved on the reference PR #1393 (feedback item 8: "MFv1 changes look good").

## Stack position

Part of the Rspack 2 support PR stack (reference implementation: #1393, design doc: `agent_context/rspackv2-jul2026/design.md`).

- Sequential prefix: #1394 (version utilities) <- #1397 (Node guard + lazy command loading) <- #1398 (Rspack 2 types + dual-major test infrastructure)
- **This PR** is part of the parallel set based on the prefix (targets #1398's branch; merges after the prefix lands). It shares no files with the other parallel-set PRs — it touches only `packages/repack/src/plugins/ModuleFederationPluginV1.ts` plus its own uniquely-named changeset.

## Files changed

- `packages/repack/src/plugins/ModuleFederationPluginV1.ts` — the pre-check (uses `getRspackMajorVersionFromCompiler` from #1394)
- `.changeset/rspack-2-mfv1-precheck.md` — patch changeset

## Validation

- `pnpm turbo run typecheck test --force` — 17/17 tasks green
- `packages/repack`: `pnpm test` (Rspack 2 lane) — 282/282 green
- `packages/repack`: `pnpm test:rspack1` (Rspack 1 lane) — 282/282 green
- `pnpm lint:ci` — clean
