### PR TITLE
docs: sync the rspack 2 design doc with review-round changes

### DIFF
--- a/agent_context/rspackv2-jul2026/design.md
+++ b/agent_context/rspackv2-jul2026/design.md
@@ -56,11 +56,15 @@ identical to v1.
 Rspack 2 moved the persistent cache configuration from `experiments.cache`
 to top-level `cache` (same shape) and **silently ignores** the legacy key.
 
-- `getRspackCacheConfig` reads both locations, so `--reset-cache` works
-  against configs written for either major.
+- `getRspackCacheConfigs` collects the cache configuration from **both**
+  locations, so `--reset-cache` clears every candidate directory regardless
+  of which major the config was written for (with both keys set, the wrong
+  cache would otherwise survive a reset under v2).
 - Under Rspack 2 with `experiments.cache` set, `warnLegacyRspackCacheConfig`
-  emits a one-time warning pointing at the top-level option. The config is
-  left untouched — migration is the user's action.
+  emits a one-time warning pointing at the top-level option — unless the
+  same config already sets a top-level persistent cache (then the leftover
+  legacy key is inert and no warning fires). The config is left untouched —
+  migration is the user's action.
 
 ## React Refresh
 
@@ -76,8 +80,10 @@ to top-level `cache` (same shape) and **silently ignores** the legacy key.
   vendored at `packages/repack/vendor/react-refresh/` (adapted from
   upstream plugin v2.0.2, MIT, with a LICENSE/provenance file). The
   `vendor/` directory ships as-is via `package.json#files` and is excluded
-  from linting and the babel build. There is no dependency on
-  `@rspack/plugin-react-refresh@1`.
+  from linting and the babel build. The refresh loader rule excludes the
+  vendored runtime files themselves (mirroring the official plugin's
+  self-exclusion) so they are never re-processed in symlinked-workspace
+  layouts. There is no dependency on `@rspack/plugin-react-refresh@1`.
 
 ## Tracing / profiling
 

--- a/agent_context/rspackv2-jul2026/design.md
+++ b/agent_context/rspackv2-jul2026/design.md
@@ -87,9 +87,13 @@ Published Rspack 2 binaries do not include the perfetto trace layer, so
 
 ## Module Federation v1
 
-Under Rspack 2, `@module-federation/runtime-tools` is no longer installed
-automatically by `@rspack/core`. `ModuleFederationPluginV1.apply` verifies
-it is resolvable and raises an actionable error otherwise.
+No changes required. Rspack's delegated `ModuleFederationPluginV1` does not
+use `@module-federation/runtime-tools` under either major - only the
+enhanced MF 1.5 plugin (`container.ModuleFederationPlugin`) resolves it,
+and that plugin raises its own actionable install error. (An earlier
+revision of this design added a resolvability pre-check to
+`ModuleFederationPluginV1.apply`; it was dropped after verification -
+see the evidence on PR #1400.)
 
 ## Types
 


### PR DESCRIPTION
Syncs `agent_context/rspackv2-jul2026/design.md` with the changes that came out of the stack's review round:

- **Module Federation v1 — section corrected.** The doc stated `ModuleFederationPluginV1` needs a resolvability pre-check for `@module-federation/runtime-tools` under Rspack 2. Review of #1400 disproved the premise: the delegated V1 plugin never uses that package under either major — only the enhanced MF 1.5 plugin (`container.ModuleFederationPlugin`) resolves it, and that plugin raises its own actionable install error. Verified empirically (clean MFv1 build + container execution under `@rspack/core@2.1.2` with the package absent) and in the 1.7.12/2.1.2 sources; full evidence in the #1400 review thread. #1400 is closed unmerged.
- **Persistent cache** (#1398): `getRspackCacheConfig` → `getRspackCacheConfigs`, which collects both the legacy and top-level locations so `--reset-cache` clears every candidate directory; the legacy-config warning (#1399) stays silent when the same config already sets a top-level persistent cache.
- **React Refresh** (#1402): the manual wiring's loader rule now self-excludes the vendored runtime files, mirroring the official plugin's behavior in symlinked-workspace layouts.

Docs only, no code changes.