### PR TITLE
feat: support Rspack 2 alongside Rspack 1

### DIFF
--- a/packages/repack/src/commands/types.ts
+++ b/packages/repack/src/commands/types.ts
@@ -63,7 +63,9 @@ export type RemoveRecord<T> = T extends infer U & Record<string, any>
 
 type ConfigKeys =
   | 'name'
+  | 'cache'
   | 'context'
+  | 'experiments'
   | 'mode'
   | 'devServer'
   | 'entry'

--- a/packages/repack/src/helpers/__tests__/rspackVersion.test.ts
+++ b/packages/repack/src/helpers/__tests__/rspackVersion.test.ts
@@ -1,0 +1,134 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import type { Compiler as RspackCompiler } from '@rspack/core';
+import type { Compiler as WebpackCompiler } from 'webpack';
+import {
+  getRspackMajorVersion,
+  getRspackMajorVersionFromCompiler,
+  getRspackVersion,
+  isRspack2,
+} from '../rspackVersion.js';
+
+/**
+ * Creates a fake project directory containing `node_modules/@rspack/core`
+ * with the given version. The fake package's entrypoint throws, so any
+ * codepath that imports `@rspack/core` (instead of only resolving its
+ * `package.json`) fails loudly.
+ */
+function createFixtureProject(root: string, version: string): string {
+  const projectDir = fs.mkdtempSync(path.join(root, 'project-'));
+  const packageDir = path.join(projectDir, 'node_modules', '@rspack', 'core');
+  fs.mkdirSync(packageDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(packageDir, 'package.json'),
+    JSON.stringify({ name: '@rspack/core', version, main: 'index.js' })
+  );
+  fs.writeFileSync(
+    path.join(packageDir, 'index.js'),
+    'throw new Error("@rspack/core must not be imported by version detection");'
+  );
+  return projectDir;
+}
+
+describe('rspackVersion helpers', () => {
+  let tmpRoot: string;
+  let rspack1Project: string;
+  let rspack2Project: string;
+  let brokenProject: string;
+
+  beforeAll(() => {
+    tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'repack-rspack-version-'));
+    rspack1Project = createFixtureProject(tmpRoot, '1.7.0');
+    rspack2Project = createFixtureProject(tmpRoot, '2.3.4');
+    // simulates an unusable @rspack/core install: package.json resolves but
+    // cannot be loaded, which exercises the same `catch -> null` branch as a
+    // missing install (jest's `require.resolve` treats `paths` as additional
+    // lookup paths and falls back to the workspace install, so a truly absent
+    // package cannot be simulated in-process here)
+    brokenProject = createFixtureProject(tmpRoot, '0.0.0');
+    fs.writeFileSync(
+      path.join(
+        brokenProject,
+        'node_modules',
+        '@rspack',
+        'core',
+        'package.json'
+      ),
+      'not-json'
+    );
+  });
+
+  afterAll(() => {
+    fs.rmSync(tmpRoot, { recursive: true, force: true });
+  });
+
+  describe('getRspackVersion', () => {
+    it('resolves the installed @rspack/core version by default', () => {
+      const {
+        version: installedVersion,
+      } = require('@rspack/core/package.json');
+      expect(getRspackVersion()).toBe(installedVersion);
+    });
+
+    it('resolves @rspack/core from the given project context', () => {
+      expect(getRspackVersion(rspack2Project)).toBe('2.3.4');
+      expect(getRspackVersion(rspack1Project)).toBe('1.7.0');
+    });
+
+    it('does not import @rspack/core while detecting the version', () => {
+      // the fixture package's entrypoint throws on import, so a non-null
+      // result proves only package.json was read
+      expect(getRspackVersion(rspack2Project)).toBe('2.3.4');
+    });
+
+    it('returns null when the version cannot be read', () => {
+      expect(getRspackVersion(brokenProject)).toBeNull();
+    });
+  });
+
+  describe('getRspackMajorVersion', () => {
+    it('parses the major version', () => {
+      expect(getRspackMajorVersion(rspack1Project)).toBe(1);
+      expect(getRspackMajorVersion(rspack2Project)).toBe(2);
+    });
+
+    it('returns null when the version cannot be read', () => {
+      expect(getRspackMajorVersion(brokenProject)).toBeNull();
+    });
+  });
+
+  describe('isRspack2', () => {
+    it('detects Rspack 2 from the given project context', () => {
+      expect(isRspack2(rspack2Project)).toBe(true);
+      expect(isRspack2(rspack1Project)).toBe(false);
+    });
+
+    it('returns false when the version cannot be read', () => {
+      expect(isRspack2(brokenProject)).toBe(false);
+    });
+  });
+
+  describe('getRspackMajorVersionFromCompiler', () => {
+    it('reads the major version from an rspack compiler', () => {
+      // minimal mock: only `webpack.rspackVersion` is accessed
+      const compiler = {
+        webpack: { rspackVersion: '2.1.2' },
+      } as unknown as RspackCompiler;
+      expect(getRspackMajorVersionFromCompiler(compiler)).toBe(2);
+
+      const rspack1Compiler = {
+        webpack: { rspackVersion: '1.7.12' },
+      } as unknown as RspackCompiler;
+      expect(getRspackMajorVersionFromCompiler(rspack1Compiler)).toBe(1);
+    });
+
+    it('returns null for a webpack compiler', () => {
+      // minimal mock: webpack compilers expose `version`, not `rspackVersion`
+      const compiler = {
+        webpack: { version: '5.99.0' },
+      } as unknown as WebpackCompiler;
+      expect(getRspackMajorVersionFromCompiler(compiler)).toBeNull();
+    });
+  });
+});

--- a/packages/repack/src/helpers/index.ts
+++ b/packages/repack/src/helpers/index.ts
@@ -1,2 +1,3 @@
 export * from './errors.js';
 export * from './helpers.js';
+export * from './rspackVersion.js';

--- a/packages/repack/src/helpers/rspackVersion.ts
+++ b/packages/repack/src/helpers/rspackVersion.ts
@@ -1,0 +1,61 @@
+import type { Compiler as RspackCompiler } from '@rspack/core';
+import type { Compiler as WebpackCompiler } from 'webpack';
+
+/**
+ * Reads the version of the installed `@rspack/core` package without loading it.
+ *
+ * Resolving `@rspack/core/package.json` instead of importing the package keeps
+ * this helper safe to call in any context:
+ * - `@rspack/core` v2 is ESM-only, so a CJS `require('@rspack/core')` throws
+ *   `ERR_REQUIRE_ESM` on Node < 20.19,
+ * - `@rspack/core` is an optional peer dependency and may not be installed
+ *   at all (webpack-only projects).
+ *
+ * @param context Optional directory to resolve `@rspack/core` from. Defaults
+ * to Re.Pack's own resolution paths.
+ * @returns Version string or `null` when `@rspack/core` is not resolvable.
+ */
+export function getRspackVersion(context?: string): string | null {
+  try {
+    const options = context ? { paths: [context] } : undefined;
+    const packageJsonPath = require.resolve(
+      '@rspack/core/package.json',
+      options
+    );
+    const { version }: { version: string } = require(packageJsonPath);
+    return version;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Major version of the installed `@rspack/core` package,
+ * or `null` when it's not resolvable.
+ */
+export function getRspackMajorVersion(context?: string): number | null {
+  const version = getRspackVersion(context);
+  if (!version) return null;
+  return Number(version.split('.')[0]);
+}
+
+/**
+ * Whether the installed `@rspack/core` package is version 2 or newer.
+ * Returns `false` when `@rspack/core` is not resolvable.
+ */
+export function isRspack2(context?: string): boolean {
+  return (getRspackMajorVersion(context) ?? 0) >= 2;
+}
+
+/**
+ * Major version of Rspack derived from an already-created compiler instance.
+ * Returns `null` for webpack compilers.
+ */
+export function getRspackMajorVersionFromCompiler(
+  compiler: RspackCompiler | WebpackCompiler
+): number | null {
+  if ('rspackVersion' in compiler.webpack && compiler.webpack.rspackVersion) {
+    return Number(compiler.webpack.rspackVersion.split('.')[0]);
+  }
+  return null;
+}


### PR DESCRIPTION
## Summary

Tracks Rspack 2 support on a dedicated feature branch while keeping Rspack 1 and webpack working from the same Re.Pack release.

Incremental implementation PRs merge into `dannyhw/rspack-2-support` after their own review. When one change depends on another, it targets that prerequisite PR first; once the prerequisite lands, the dependent PR is retargeted toward the feature branch. The complete feature is verified here before this draft PR merges to `main`.

Technical design: [`agent_context/rspackv2-jul2026/design.md`](https://github.com/callstack/repack/blob/main/agent_context/rspackv2-jul2026/design.md).

## Current feature-branch state

Only the first implementation step has landed so far:

- #1394 — Rspack version-detection helpers and the related configuration keys.

The remaining work has been reduced to four implementation PRs without folding it wholesale into this branch:

- #1397 — runtime foundations, Rspack 2 types, and dual-major test infrastructure (absorbs #1398).
- #1401 — version-aware config and cache compatibility (absorbs #1399).
- #1402 — React Refresh compatibility.
- #1404 — built-dist smoke coverage and per-major tester apps (absorbs #1403).

#1401 and #1402 currently target prerequisite #1397. #1404 remains on the temporary integration base until its implementation prerequisites have landed, then it will retarget to this feature branch.

## Delivery flow

1. Review and merge a bounded implementation PR into this feature branch, or into a prerequisite PR when ordering requires it.
2. Retarget dependent PRs as their prerequisites land.
3. Verify the combined feature branch after each merge.
4. Merge this draft feature PR to `main` only after the full Rspack 1, Rspack 2, and webpack validation matrix passes.

## Validation

The current foundations-only feature branch passes:

- `pnpm install --frozen-lockfile`
- `pnpm turbo run typecheck test --force` — **17/17 tasks**
  - Re.Pack: **30 suites / 290 tests**
  - Integration: **58 tests**
  - Tester app: **12 tests**

#1394 also passed its GitHub Lint, TypeScript, Tests, CodeQL, and Vercel checks before merging.

Broader dual-major validation will be recorded here as later steps land.
