### PR TITLE
Restrict GitHub Actions workflow permissions

### DIFF
--- a/.github/workflows/stale-bot.yml
+++ b/.github/workflows/stale-bot.yml
@@ -2,6 +2,12 @@ name: Stale bot
 on:
   schedule:
     - cron: '0 0 * * *'  # Run every day at midnight
+
+permissions:
+  contents: write
+  issues: write
+  pull-requests: write
+
 jobs:
   stale:
     runs-on: ubuntu-latest
@@ -22,4 +28,3 @@ jobs:
           remove-stale-when-updated: true
           exempt-issue-labels: pinned
           exempt-pr-labels: pinned
-

--- a/.github/workflows/test-main-matrix.yml
+++ b/.github/workflows/test-main-matrix.yml
@@ -7,6 +7,9 @@ on:
       - 'website/**'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   test_main_matrix:
     name: Tests [Node ${{ matrix.node_version }}]

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,6 +10,9 @@ on:
       - 'website/**'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     name: Lint


### PR DESCRIPTION
## Summary

- restrict the CI and main-matrix workflows to read-only repository contents
- grant the stale workflow only the write permissions required to manage repository contents, issues, and pull requests
- address the five open `actions/missing-workflow-permissions` CodeQL alerts: [#5](https://github.com/callstack/repack/security/code-scanning/5), [#6](https://github.com/callstack/repack/security/code-scanning/6), [#8](https://github.com/callstack/repack/security/code-scanning/8), [#9](https://github.com/callstack/repack/security/code-scanning/9), and [#18](https://github.com/callstack/repack/security/code-scanning/18)

## Root cause

These workflows did not declare explicit `GITHUB_TOKEN` permissions, so their effective access depended on repository or organization defaults.

## Impact

The test workflows now operate with read-only access. The stale bot retains the minimum write access needed to label, update, and close stale issues and pull requests. No application or package behavior changes.

## Validation

- `actionlint .github/workflows/test-main-matrix.yml .github/workflows/test.yml .github/workflows/stale-bot.yml`
- parsed all three files as YAML
- `git diff --check`
