### PR TITLE
fix(dev-server): validate open-url targets

### DIFF
--- a/.changeset/safe-tools-open.md
+++ b/.changeset/safe-tools-open.md
@@ -1,0 +1,5 @@
+---
+"@callstack/repack-dev-server": patch
+---
+
+Validate `/open-url` requests before passing their targets to the operating system.

--- a/packages/dev-server/src/plugins/devtools/__tests__/devtoolsPlugin.test.ts
+++ b/packages/dev-server/src/plugins/devtools/__tests__/devtoolsPlugin.test.ts
@@ -1,0 +1,147 @@
+import Fastify, { type FastifyInstance } from 'fastify';
+import fastifyPlugin from 'fastify-plugin';
+import open from 'open';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Server } from '../../../types.js';
+import devtoolsPlugin from '../devtoolsPlugin.js';
+
+vi.mock('open', () => ({
+  default: vi.fn(),
+}));
+
+const openMock = vi.mocked(open);
+
+async function createTestServer() {
+  const instance = Fastify();
+
+  await instance.register(
+    fastifyPlugin(
+      async (fastify) => {
+        fastify.decorate('wss', {
+          messageServer: {
+            broadcast: vi.fn(),
+          },
+        } as unknown as FastifyInstance['wss']);
+      },
+      { name: 'wss-plugin' }
+    )
+  );
+  await instance.register(devtoolsPlugin, {
+    delegate: {} as Server.Delegate,
+  });
+
+  return instance;
+}
+
+describe('devtoolsPlugin /open-url', () => {
+  let instance: FastifyInstance;
+
+  beforeEach(async () => {
+    openMock.mockResolvedValue({} as never);
+    instance = await createTestServer();
+  });
+
+  afterEach(async () => {
+    await instance.close();
+    vi.clearAllMocks();
+  });
+
+  it.each([
+    'https://reactnative.dev/docs/tutorial',
+    'http://localhost:8081/docs?platform=ios#debugging',
+    'https://[::1]:8081/path',
+    'https://example.com/a%20path?value=%24safe#fragment',
+  ])('should open the validated browser URL %s', async (url) => {
+    const response = await instance.inject({
+      method: 'POST',
+      url: '/open-url',
+      payload: { url },
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.body).toBe('OK');
+    expect(openMock).toHaveBeenCalledOnce();
+    expect(openMock).toHaveBeenCalledWith(new URL(url).href);
+  });
+
+  it('should accept a text/plain JSON request body', async () => {
+    const url = 'https://reactnative.dev/docs/debugging';
+    const response = await instance.inject({
+      method: 'POST',
+      url: '/open-url',
+      headers: {
+        'content-type': 'text/plain',
+      },
+      payload: JSON.stringify({ url }),
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(openMock).toHaveBeenCalledWith(url);
+  });
+
+  it.each([
+    ['bare executable', 'calc.exe'],
+    ['Windows executable path', 'C:\\Windows\\System32\\calc.exe'],
+    ['POSIX application path', '/Applications/Calculator.app'],
+    ['UNC path', '\\\\server\\share\\payload.exe'],
+    ['file URL', 'file:///etc/passwd'],
+    ['JavaScript URL', 'javascript:alert(1)'],
+    ['data URL', 'data:text/html,<script>alert(1)</script>'],
+    ['custom URL scheme', 'ms-msdt:/id'],
+    ['PowerShell subexpression', 'https://example.invalid/$(calc.exe)'],
+    ['PowerShell environment expansion', 'https://example.invalid/$env:PATH'],
+    ['PowerShell escape character', 'https://example.invalid/?value=`whoami'],
+  ])('should reject a %s', async (_name, url) => {
+    const response = await instance.inject({
+      method: 'POST',
+      url: '/open-url',
+      payload: { url },
+    });
+
+    expect(response.statusCode).toBe(400);
+    expect(response.body).toBe('Invalid URL');
+    expect(openMock).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ['missing URL', {}],
+    ['non-string URL', { url: 123 }],
+    ['array body', [{ url: 'https://example.com' }]],
+  ])('should reject a request with a %s', async (_name, payload) => {
+    const response = await instance.inject({
+      method: 'POST',
+      url: '/open-url',
+      payload,
+    });
+
+    expect(response.statusCode).toBe(400);
+    expect(response.body).toBe('Invalid URL');
+    expect(openMock).not.toHaveBeenCalled();
+  });
+
+  it('should reject a request with no body', async () => {
+    const response = await instance.inject({
+      method: 'POST',
+      url: '/open-url',
+    });
+
+    expect(response.statusCode).toBe(400);
+    expect(response.body).toBe('Invalid URL');
+    expect(openMock).not.toHaveBeenCalled();
+  });
+
+  it('should reject malformed text/plain JSON', async () => {
+    const response = await instance.inject({
+      method: 'POST',
+      url: '/open-url',
+      headers: {
+        'content-type': 'text/plain',
+      },
+      payload: 'not JSON',
+    });
+
+    expect(response.statusCode).toBe(400);
+    expect(response.body).toBe('Invalid URL');
+    expect(openMock).not.toHaveBeenCalled();
+  });
+});

--- a/packages/dev-server/src/plugins/devtools/devtoolsPlugin.ts
+++ b/packages/dev-server/src/plugins/devtools/devtoolsPlugin.ts
@@ -4,19 +4,49 @@ import launchEditor from 'launch-editor';
 import open from 'open';
 import type { Server } from '../../types.js';
 
-interface OpenURLRequestBody {
-  url: string;
-}
-
 interface OpenStackFrameRequestBody {
   file: string;
   lineNumber: number;
 }
 
+const INVALID_URL = 'Invalid URL';
+const POWERSHELL_INTERPOLATION_CHARACTERS = /[$`]/;
+
 function parseRequestBody<T>(body: unknown): T {
   if (typeof body === 'object') return body as T;
   if (typeof body === 'string') return JSON.parse(body) as T;
   throw new Error(`Unsupported body type: ${typeof body}`);
+}
+
+function validateURLForOpen(body: unknown): string {
+  const parsedBody = parseRequestBody<unknown>(body);
+  if (
+    typeof parsedBody !== 'object' ||
+    parsedBody === null ||
+    Array.isArray(parsedBody)
+  ) {
+    throw new Error(INVALID_URL);
+  }
+
+  const { url } = parsedBody as { url?: unknown };
+  if (typeof url !== 'string') {
+    throw new Error(INVALID_URL);
+  }
+
+  const parsedURL = new URL(url);
+  if (parsedURL.protocol !== 'http:' && parsedURL.protocol !== 'https:') {
+    throw new Error(INVALID_URL);
+  }
+
+  const normalizedURL = parsedURL.href;
+
+  // open@10 interpolates its target into a double-quoted PowerShell command on
+  // Windows. Reject characters that PowerShell expands inside those strings.
+  if (POWERSHELL_INTERPOLATION_CHARACTERS.test(normalizedURL)) {
+    throw new Error(INVALID_URL);
+  }
+
+  return normalizedURL;
 }
 
 async function devtoolsPlugin(
@@ -29,7 +59,14 @@ async function devtoolsPlugin(
     method: ['POST'],
     url: '/open-url',
     handler: async (request, reply) => {
-      const { url } = parseRequestBody<OpenURLRequestBody>(request.body);
+      let url: string;
+      try {
+        url = validateURLForOpen(request.body);
+      } catch {
+        reply.code(400).send(INVALID_URL);
+        return;
+      }
+
       await open(url);
       reply.send('OK');
     },


### PR DESCRIPTION
## Summary

- validate `/open-url` request bodies before invoking the operating-system opener
- allow only canonical `http:` and `https:` URLs
- reject PowerShell interpolation characters that are unsafe with the pinned `open@10`
- add Fastify injection coverage for valid browser links, text bodies, local paths, executable targets, custom schemes, and PowerShell payloads
- add a patch changeset for `@callstack/repack-dev-server`

## Why

The endpoint passed the request-provided `url` directly to `open()`. That package accepts files and executables in addition to URLs, and its Windows implementation interpolates the target into PowerShell. This left the unauthenticated development-server route vulnerable to uncontrolled path/process targets and addresses [code-scanning alert #3](https://github.com/callstack/repack/security/code-scanning/3).

## Impact

Normal React Native `http:` and `https:` browser links continue to work without configuration or API changes. Invalid bodies, paths, executable targets, and non-browser schemes now receive HTTP 400 and never reach `open()`.

## Test plan

- [x] dev-server Vitest suite (`2` files, `26` tests)
- [x] dev-server TypeScript typecheck
- [x] Biome check for changed source and tests
- [x] repository-wide Biome pre-commit hook

### What user-facing behavior uses `/open-url`?

React Native's dev-only `openURLInBrowser()` helper posts a URL to this endpoint. The React Native **New App Screen** uses that helper for its **Learn & Explore** cards: tapping a card such as **DevTools** opens the documentation in the default browser on the computer running the development server, rather than inside the simulator or device.

The Re.Pack tester app renders its own test dashboard and does not currently include `@react-native/new-app-screen` or another caller of `openURLInBrowser()`. Therefore it has no existing on-screen control that reaches `/open-url`. Pressing `j` exercises the separate `/open-debugger` route and is useful only as a general developer-workflow regression check.

### Manual tester-app validation

1. To expose the real user interaction temporarily, add the React Native helper and the tester app's existing button to `apps/tester-app/src/App.tsx`:

   ```tsx
   // @ts-expect-error React Native's dev-only helper does not publish TypeScript types.
   import openURLInBrowser from 'react-native/Libraries/Core/Devtools/openURLInBrowser';
   import { Button } from './ui/Button';
   ```

   Then add this section inside `SectionContainer`:

   ```tsx
   <Section
     title="Open URL on development host"
     description="Opens React Native documentation in the host computer's browser"
   >
     <Button
       title="Open React Native docs"
       onPress={() => openURLInBrowser('https://reactnative.dev/')}
     />
   </Section>
   ```

   These are local test-only edits and should not be committed.

2. From the repository root, start the tester-app development server:

   ```sh
   pnpm --filter tester-app start
   ```

3. In a second terminal, launch either platform:

   ```sh
   pnpm --filter tester-app ios
   # or
   pnpm --filter tester-app android
   ```

4. Tap **Open React Native docs** in the tester app.

   Expected: `https://reactnative.dev/` opens in the default browser on the computer running the development server, and the tester app remains running. This exercises the same React Native helper and `/open-url` request used by New App Screen links.

5. In the development-server terminal, press `r` and verify the app reloads, then press `j` and verify React Native DevTools opens and connects.

6. Verify a non-browser target is rejected at the endpoint boundary:

   ```sh
   curl -i http://localhost:8081/open-url \
     -H 'Content-Type: application/json' \
     --data '{"url":"file:///tmp/repack-open-url-check"}'
   ```

   Expected: HTTP 400 with `Invalid URL`, with no browser, file, or application opened.

7. Remove the temporary tester-app edits.

The positive check is intentionally user-facing. The rejected-target check remains direct because no legitimate React Native UI should generate a file, executable, or non-browser URL for this endpoint.
