### PR TITLE
fix: prevent public key validation ReDoS

### DIFF
--- a/.changeset/calm-keys-verify.md
+++ b/.changeset/calm-keys-verify.md
@@ -1,0 +1,5 @@
+---
+"@callstack/repack": patch
+---
+
+Prevent excessive regular-expression backtracking when validating per-script public keys.

--- a/packages/repack/src/modules/ScriptManager/__tests__/ScriptManager.test.ts
+++ b/packages/repack/src/modules/ScriptManager/__tests__/ScriptManager.test.ts
@@ -1,3 +1,6 @@
+import { createPublicKey } from 'node:crypto';
+import fs from 'node:fs';
+import path from 'node:path';
 import NativeScriptManager, {
   type NormalizedScriptLocator,
 } from '../NativeScriptManager.js';
@@ -30,6 +33,21 @@ webpackRequire.repack = {
 };
 
 globalThis.__webpack_require__ = webpackRequire;
+
+const RSA_PUBLIC_KEY = fs
+  .readFileSync(
+    path.join(
+      __dirname,
+      '../../../plugins/__tests__/__fixtures__/testRS256.pem.pub'
+    ),
+    'utf8'
+  )
+  .trim();
+
+const PKCS1_RSA_PUBLIC_KEY = createPublicKey(RSA_PUBLIC_KEY)
+  .export({ format: 'pem', type: 'pkcs1' })
+  .toString()
+  .trim();
 
 class FakeCache {
   data: Record<string, string> = {};
@@ -362,8 +380,7 @@ describe('ScriptManagerAPI', () => {
       return {
         url: Script.getRemoteURL(`http://domain.ext/${scriptId}`),
         verifyScriptSignature: 'strict',
-        publicKey:
-          '-----BEGIN PUBLIC KEY-----\\ncustom\\n-----END PUBLIC KEY-----',
+        publicKey: RSA_PUBLIC_KEY,
       };
     });
 
@@ -379,8 +396,7 @@ describe('ScriptManagerAPI', () => {
       method: 'GET',
       timeout: Script.DEFAULT_TIMEOUT,
       verifyScriptSignature: 'strict',
-      publicKey:
-        '-----BEGIN PUBLIC KEY-----\\ncustom\\n-----END PUBLIC KEY-----',
+      publicKey: RSA_PUBLIC_KEY,
       uniqueId: 'main_src_App_js',
     });
   });
@@ -391,6 +407,38 @@ describe('ScriptManagerAPI', () => {
         url: Script.getRemoteURL(`http://domain.ext/${scriptId}`),
         verifyScriptSignature: 'strict',
         publicKey: 'not-a-valid-pem-public-key',
+      };
+    });
+
+    await expect(
+      ScriptManager.shared.resolveScript('src_App_js', 'main')
+    ).rejects.toThrow(
+      'Property publicKey must be a PEM-formatted public key enclosed in BEGIN/END PUBLIC KEY markers.'
+    );
+  });
+
+  it('should reject a truncated PEM public key', async () => {
+    ScriptManager.shared.addResolver(async (scriptId) => {
+      return {
+        url: Script.getRemoteURL(`http://domain.ext/${scriptId}`),
+        verifyScriptSignature: 'strict',
+        publicKey: RSA_PUBLIC_KEY.replace('-----END PUBLIC KEY-----', ''),
+      };
+    });
+
+    await expect(
+      ScriptManager.shared.resolveScript('src_App_js', 'main')
+    ).rejects.toThrow(
+      'Property publicKey must be a PEM-formatted public key enclosed in BEGIN/END PUBLIC KEY markers.'
+    );
+  });
+
+  it('should reject a PKCS#1 public key with RSA PUBLIC KEY markers', async () => {
+    ScriptManager.shared.addResolver(async (scriptId) => {
+      return {
+        url: Script.getRemoteURL(`http://domain.ext/${scriptId}`),
+        verifyScriptSignature: 'strict',
+        publicKey: PKCS1_RSA_PUBLIC_KEY,
       };
     });
 
@@ -418,12 +466,16 @@ describe('ScriptManagerAPI', () => {
   });
 
   it('should allow public key override with surrounding whitespace', async () => {
+    const publicKeyWithWindowsLineEndings = RSA_PUBLIC_KEY.replaceAll(
+      '\n',
+      '\r\n'
+    );
+
     ScriptManager.shared.addResolver(async (scriptId) => {
       return {
         url: Script.getRemoteURL(`http://domain.ext/${scriptId}`),
         verifyScriptSignature: 'strict',
-        publicKey:
-          '\n  -----BEGIN PUBLIC KEY-----\\ncustom\\n-----END PUBLIC KEY-----  \n',
+        publicKey: `\r\n  ${publicKeyWithWindowsLineEndings}  \r\n`,
       };
     });
 
@@ -432,9 +484,7 @@ describe('ScriptManagerAPI', () => {
       'main'
     );
 
-    expect(script.locator.publicKey).toBe(
-      '-----BEGIN PUBLIC KEY-----\\ncustom\\n-----END PUBLIC KEY-----'
-    );
+    expect(script.locator.publicKey).toBe(publicKeyWithWindowsLineEndings);
   });
 
   it('should resolve with body', async () => {

--- a/packages/repack/src/modules/ScriptManager/__tests__/ScriptManager.test.ts
+++ b/packages/repack/src/modules/ScriptManager/__tests__/ScriptManager.test.ts
@@ -401,6 +401,22 @@ describe('ScriptManagerAPI', () => {
     );
   });
 
+  it('should reject a large malformed public key without excessive backtracking', async () => {
+    ScriptManager.shared.addResolver(async (scriptId) => {
+      return {
+        url: Script.getRemoteURL(`http://domain.ext/${scriptId}`),
+        verifyScriptSignature: 'strict',
+        publicKey: `-----BEGIN PUBLIC KEY-----${' '.repeat(4096)}x`,
+      };
+    });
+
+    await expect(
+      ScriptManager.shared.resolveScript('src_App_js', 'main')
+    ).rejects.toThrow(
+      'Property publicKey must be a PEM-formatted public key enclosed in BEGIN/END PUBLIC KEY markers.'
+    );
+  });
+
   it('should allow public key override with surrounding whitespace', async () => {
     ScriptManager.shared.addResolver(async (scriptId) => {
       return {

--- a/packages/repack/src/modules/ScriptManager/normalizePublicKey.ts
+++ b/packages/repack/src/modules/ScriptManager/normalizePublicKey.ts
@@ -1,7 +1,7 @@
 import { NormalizedScriptLocatorSignatureVerificationMode } from './NativeScriptManager.js';
 
 const PUBLIC_KEY_PEM_PATTERN =
-  /^-----BEGIN PUBLIC KEY-----\s*[\s\S]+?\s*-----END PUBLIC KEY-----$/;
+  /^-----BEGIN PUBLIC KEY-----[\s\S]+-----END PUBLIC KEY-----$/;
 
 export const INVALID_PUBLIC_KEY_ERROR =
   'Property publicKey must be a PEM-formatted public key enclosed in BEGIN/END PUBLIC KEY markers.';


### PR DESCRIPTION
## Summary

- simplify public-key delimiter validation to remove ambiguous overlapping regex quantifiers
- add a regression test covering a large malformed near-match
- exercise resolver validation with an existing real 4096-bit RSA fixture, CRLF PEM formatting, a truncated key, and a genuine PKCS#1 variant
- add a patch changeset for `@callstack/repack`

## Root cause

The existing `\s*[\s\S]+?\s*` expression allowed the JavaScript regex engine to partition an internal whitespace run in many ways before failing to find the PEM footer. Because `ScriptLocator.publicKey` can come from resolver-provided runtime metadata and had no length bound, malformed input could block the JavaScript thread with polynomial backtracking.

This addresses [code-scanning alert #10](https://github.com/callstack/repack/security/code-scanning/10) (`js/polynomial-redos`).

## Compatibility and impact

The replacement is language-equivalent to the previous validator: both accept any non-empty content between the existing `BEGIN PUBLIC KEY` and `END PUBLIC KEY` markers after trimming. The public API, normalization, errors, native verification, and accepted input set are unchanged. Matching malformed near-misses is now linear.

No migration or user action is required.

## Test plan

- `pnpm --filter @callstack/repack test -- --watchman=false ScriptManager.test.ts`
- `pnpm --filter @callstack/repack typecheck`
- `pnpm biome check packages/repack/src/modules/ScriptManager/normalizePublicKey.ts packages/repack/src/modules/ScriptManager/__tests__/ScriptManager.test.ts`
- commit hook: repository-wide Biome check (457 files)
