### PR TITLE
fix: point root website scripts at existing website package scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,8 +19,8 @@
     "release:canary": "pnpm changeset publish --tag canary --no-git-tag",
     "pods": "turbo run pods",
     "pods:update": "turbo run pods:update",
-    "website:start": "pnpm --filter website run start",
-    "website:build": "pnpm --filter website run export"
+    "website:start": "pnpm --filter website run dev",
+    "website:build": "pnpm --filter website run build"
   },
   "devDependencies": {
     "@babel/cli": "^7.29.7",


### PR DESCRIPTION
## Summary

The root `website:start` and `website:build` scripts referenced scripts that don't exist in `website/package.json` (which only defines `dev`, `build`, and `preview`), so both failed with `ERR_PNPM_RECURSIVE_RUN_NO_SCRIPT`:

- `website:start` ran `pnpm --filter website run start` → now runs `run dev`
- `website:build` ran `pnpm --filter website run export` → now runs `run build`

## Test plan

- `pnpm website:build` now completes successfully (rspress builds 54 pages and generates the sitemap).