### PR TITLE
fix: update vulnerable transitive dependencies

### DIFF
--- a/.changeset/calm-tools-update.md
+++ b/.changeset/calm-tools-update.md
@@ -1,0 +1,6 @@
+---
+---
+
+Update vulnerable transitive dependencies in the workspace lockfile and pin
+Module Federation's exact Undici dependency to its patched release. No
+published package API or dependency range changes.

--- a/.changeset/calm-tools-update.md
+++ b/.changeset/calm-tools-update.md
@@ -1,6 +1,0 @@
----
----
-
-Update vulnerable transitive dependencies in the workspace lockfile and pin
-Module Federation's exact Undici dependency to its patched release. No
-published package API or dependency range changes.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -65,6 +65,7 @@ overrides:
   koa@3: ^3.1.2
   ws@8: ^8.21.1
   adm-zip: ^0.6.0
+  '@module-federation/dts-plugin@2.8.0>undici': 7.29.0
   esbuild@<0.25.0: ^0.25.0
   uuid@7: ^11.1.1
   vite: ^7.3.1
@@ -4491,11 +4492,11 @@ packages:
     resolution: {integrity: sha512-PyJxiNtA5T2PlLIeBot4lbp7rj4OadzjnMZD/G5zuBNt8ei/yCU7+wW0h2bag9vr8c+/WuRWmSxbqAl9hL1rBA==}
     engines: {node: '>= 5.10.0'}
 
-  brace-expansion@1.1.16:
-    resolution: {integrity: sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==}
+  brace-expansion@1.1.18:
+    resolution: {integrity: sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==}
 
-  brace-expansion@2.1.2:
-    resolution: {integrity: sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==}
+  brace-expansion@2.1.4:
+    resolution: {integrity: sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==}
 
   braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
@@ -5296,11 +5297,11 @@ packages:
   fast-querystring@1.1.2:
     resolution: {integrity: sha512-g6KuKWmFXc0fID8WWH0jit4g0AGBoJhCkJMb1RmbsSEUNvQ+ZC8D6CUZ+GtF8nMzSPXnhiePyyqqipzNNEnHjg==}
 
-  fast-uri@3.1.4:
-    resolution: {integrity: sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==}
+  fast-uri@3.1.5:
+    resolution: {integrity: sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==}
 
-  fast-uri@4.1.1:
-    resolution: {integrity: sha512-YPOs1zD5TG2+EZt+r88LwF6mclA7TPkpwMP7ZN3TO2HiHS8TXvq7QA/17iJsV9dubcLo/f8eEYqMBruyQV21hQ==}
+  fast-uri@4.1.2:
+    resolution: {integrity: sha512-TyGmBcbDTZXcb2cj5MV89DrF42DKvb3y5DDUNh95iO+IMeAzMkVSxK1PZRrRIpc9yg8U2GhGdbofNa0LS/a4Bw==}
 
   fast-xml-builder@1.3.0:
     resolution: {integrity: sha512-F74cZEdCvuw9P41GAC3rod4X04jjWGM1JPEv/GWSqFTWLsdyMSBMBMlm9Hk3GLBgLBbdBNY8yee0pQh2RBVESQ==}
@@ -8186,8 +8187,8 @@ packages:
   undici-types@8.3.0:
     resolution: {integrity: sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==}
 
-  undici@7.28.0:
-    resolution: {integrity: sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==}
+  undici@7.29.0:
+    resolution: {integrity: sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==}
     engines: {node: '>=20.18.1'}
 
   unhead@2.1.16:
@@ -9919,7 +9920,7 @@ snapshots:
     dependencies:
       ajv: 8.20.0
       ajv-formats: 3.0.1
-      fast-uri: 3.1.4
+      fast-uri: 3.1.5
 
   '@fastify/error@4.2.0': {}
 
@@ -10626,7 +10627,7 @@ snapshots:
       adm-zip: 0.6.0
       isomorphic-ws: 5.0.0(ws@8.21.1)
       typescript: 7.0.2
-      undici: 7.28.0
+      undici: 7.29.0
       ws: 8.21.1
     transitivePeerDependencies:
       - bufferutil
@@ -12845,7 +12846,7 @@ snapshots:
   ajv@8.20.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.4
+      fast-uri: 3.1.5
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -13112,12 +13113,12 @@ snapshots:
     dependencies:
       big-integer: 1.6.52
 
-  brace-expansion@1.1.16:
+  brace-expansion@1.1.18:
     dependencies:
       balanced-match: 1.0.2
       concat-map: 0.0.1
 
-  brace-expansion@2.1.2:
+  brace-expansion@2.1.4:
     dependencies:
       balanced-match: 1.0.2
 
@@ -13917,7 +13918,7 @@ snapshots:
       '@fastify/merge-json-schemas': 0.2.1
       ajv: 8.20.0
       ajv-formats: 3.0.1
-      fast-uri: 4.1.1
+      fast-uri: 4.1.2
       json-schema-ref-resolver: 3.0.0
       rfdc: 1.4.1
 
@@ -13925,9 +13926,9 @@ snapshots:
     dependencies:
       fast-decode-uri-component: 1.0.1
 
-  fast-uri@3.1.4: {}
+  fast-uri@3.1.5: {}
 
-  fast-uri@4.1.1: {}
+  fast-uri@4.1.2: {}
 
   fast-xml-builder@1.3.0:
     dependencies:
@@ -16095,11 +16096,11 @@ snapshots:
 
   minimatch@3.1.5:
     dependencies:
-      brace-expansion: 1.1.16
+      brace-expansion: 1.1.18
 
   minimatch@8.0.7:
     dependencies:
-      brace-expansion: 2.1.2
+      brace-expansion: 2.1.4
 
   minimist@1.2.8: {}
 
@@ -17592,7 +17593,7 @@ snapshots:
 
   undici-types@8.3.0: {}
 
-  undici@7.28.0: {}
+  undici@7.29.0: {}
 
   unhead@2.1.16:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -18,6 +18,7 @@ overrides:
   "koa@3": ^3.1.2
   "ws@8": ^8.21.1
   "adm-zip": ^0.6.0
+  "@module-federation/dts-plugin@2.8.0>undici": 7.29.0
   # Security fix for GHSA-67mh-4wv8-2f99, reached only through
   # @modern-js/node-bundle-require inside @module-federation/cli.
   "esbuild@<0.25.0": ^0.25.0


### PR DESCRIPTION
## Summary

- update `fast-uri` to patched 3.1.5 and 4.1.2 releases
- update `brace-expansion` to patched 1.1.18 and 2.1.4 releases
- narrowly override `@module-federation/dts-plugin@2.8.0` from its exact `undici@7.28.0` pin to patched `7.29.0`

## Why

These updates address the actionable open Dependabot alerts for `fast-uri`, `brace-expansion`, and `undici`.

The `fast-uri` and `brace-expansion` parents already allow the patched versions, so they only require a transitive lockfile refresh. Module Federation pins `undici@7.28.0` exactly, including in its current 2.8.1 release, so a parent-scoped override is currently the only update path. The override affects only the private Module Federation v2 tester.

React Router alert #629 is intentionally not changed here. It only affects unstable RSC APIs, which neither the website nor Rspress uses. Rspress does not yet publish a compatible React Router 8 migration, so that alert should be dismissed separately as vulnerable code not used.

## Impact

No public Re.Pack API, published dependency range, or runtime behavior changes. Fresh consumers already resolve the patched `fast-uri` versions through the existing semver ranges.

## Validation

- `pnpm install --frozen-lockfile`
- `pnpm lint:ci`
- `pnpm typecheck`
- `pnpm --filter @callstack/repack-dev-server test` — 5 passed
- `pnpm --filter @callstack/repack test` — 283 passed
- `pnpm --filter metro-compat-test test` — 47 passed, 16 skipped
- installed dependency paths verified as:
  - `fast-uri@3.1.5` and `4.1.2`
  - `brace-expansion@1.1.18` and `2.1.4`
  - `undici@7.29.0`
