### PR TITLE
fix(ios): keep the original error message for script download failures

### DIFF
--- a/.changeset/ios-script-download-error-message.md
+++ b/.changeset/ios-script-download-error-message.md
@@ -1,0 +1,5 @@
+---
+"@callstack/repack": patch
+---
+
+Keep the original error message for iOS script download failures instead of surfacing "Unknown error from a native module".

--- a/packages/repack/ios/ScriptManager.mm
+++ b/packages/repack/ios/ScriptManager.mm
@@ -26,6 +26,20 @@
 static NSURLSession * (^_urlSessionFactory)(void) = nil;
 static NSURLSession *_cachedURLSession = nil;
 
+// NSURLError instances fill in localizedDescription but leave localizedFailureReason nil.
+// Passing a nil message to the reject block makes React Native substitute
+// "Unknown error from a native module", which hides whether the download timed out,
+// lost the connection or failed TLS. Fall back to the description and append the
+// domain/code so the cause survives the bridge.
+static NSString *DescribeScriptDownloadError(NSError *error)
+{
+  NSString *reason = error.localizedFailureReason ?: error.localizedDescription;
+  if (reason.length == 0) {
+    reason = @"Script download failed";
+  }
+  return [NSString stringWithFormat:@"%@ (%@ %ld)", reason, error.domain, (long)error.code];
+}
+
 @implementation ScriptManager
 
 RCT_EXPORT_MODULE()
@@ -88,7 +102,7 @@ RCT_EXPORT_METHOD(loadScript
         [self downloadAndCache:config
              completionHandler:^(NSError *error) {
                if (error) {
-                 reject(ScriptDownloadFailure, error.localizedFailureReason, nil);
+                 reject(ScriptDownloadFailure, DescribeScriptDownloadError(error), error);
                } else {
                  [self execute:config resolve:resolve reject:reject];
                }
@@ -139,7 +153,7 @@ RCT_EXPORT_METHOD(prefetchScript
         [self downloadAndCache:config
              completionHandler:^(NSError *error) {
                if (error) {
-                 reject(ScriptDownloadFailure, error.localizedFailureReason, nil);
+                 reject(ScriptDownloadFailure, DescribeScriptDownloadError(error), error);
                } else {
                  resolve(nil);
                }


### PR DESCRIPTION
## Summary

Fixes #1448.

On iOS, every transport-level script download failure reached JavaScript as `Unknown error from a native module`, so a timeout, a dropped connection and a TLS failure were indistinguishable in production logs.

`downloadAndCache` hands its `NSError` to the reject block as `error.localizedFailureReason`. `NSURLError` leaves that property `nil`, and React Native substitutes its own fallback string whenever the message is `nil`. HTTP status failures were unaffected only because `downloadAndCache` builds those errors itself and sets `NSLocalizedFailureReasonErrorKey` explicitly — which is what made the gap easy to miss.

Android already falls back with `e.message ?: e.toString()` in `RemoteScriptLoader.kt`, so this brings iOS in line.

## Changes

- Add `DescribeScriptDownloadError`, which falls back to `localizedDescription` and appends the error domain and code.
- Use it at both `ScriptDownloadFailure` reject sites (`loadScript`, `prefetchScript`), and pass the `NSError` through as the third argument so `userInfo` survives the bridge.

Before: `Unknown error from a native module`
After: `The request timed out. (NSURLErrorDomain -1001)`

## Compatibility

The reject code stays `ScriptDownloadFailure`, so the retry gate in `loadScriptWithRetry` (`LOADING_ERROR_CODES`) behaves exactly as before. Only the message and the attached error change.

## Test plan

- Load a remote container or chunk on a connection slow enough to exceed the script `timeout` (Network Link Conditioner, 3G profile) and confirm the rejection now names the failure.
- Point a remote at an unreachable host and confirm the domain and code appear.
- Confirm an HTTP 403 still reports `Request should have returned with 200 HTTP status, but instead it received 403`.
